### PR TITLE
Nest host folders in the sidebar

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -64,9 +64,13 @@ const initialKeys = collectStaticGraph(entry[0]);
 // shortcut has to work before any lazy chunk could load. It costs ~9 KiB raw
 // and ~0.3 KiB gzip, which this budget accounts for — everything else that
 // only the dialogs need stays lazy.
+//
+// The sidebar's folder tree adds ~12 KiB raw on top of that. Its model,
+// keyboard navigation and drag-and-drop are the host list itself and cannot be
+// deferred; the menus and dialogs it opens are lazy (see SidebarMenus).
 check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 768_000,
-  gzip: 244_000,
+  raw: 782_000,
+  gzip: 249_000,
 });
 
 for (const feature of [

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import { ToastHost } from './components/ToastHost.js';
 import { BackendStatusBanner } from './components/BackendStatusBanner.js';
 import {
   loadHostEditorDialog,
+  loadFolderDialog,
   loadHostOrganizationDialog,
   loadCommandButtonsDialog,
   loadSettingsDialog,
@@ -28,6 +29,9 @@ const HostEditorDialog = lazy(() =>
 );
 const HostOrganizationDialog = lazy(() =>
   loadHostOrganizationDialog().then((module) => ({ default: module.HostOrganizationDialog })),
+);
+const FolderDialog = lazy(() =>
+  loadFolderDialog().then((module) => ({ default: module.FolderDialog })),
 );
 const SettingsDialog = lazy(() =>
   loadSettingsDialog().then((module) => ({ default: module.SettingsDialog })),
@@ -56,6 +60,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const interfaceZoom = usePrefsStore((s) => s.interfaceZoom);
   const hostEditorOpen = useUiStore((s) => !!s.hostEditor);
   const hostOrganizerOpen = useUiStore((s) => !!s.hostOrganizer);
+  const folderDialogOpen = useUiStore((s) => !!s.folderDialog);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const commandButtonsOpen = useUiStore((s) => s.commandButtonsOpen);
   const shortcutsOpen = useUiStore((s) => s.shortcutsOpen);
@@ -95,6 +100,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
       <Suspense fallback={null}>
         {hostEditorOpen ? <HostEditorDialog /> : null}
         {hostOrganizerOpen ? <HostOrganizationDialog /> : null}
+        {folderDialogOpen ? <FolderDialog /> : null}
         {settingsOpen ? <SettingsDialog /> : null}
         {commandButtonsOpen ? <CommandButtonsDialog /> : null}
         {shortcutsOpen ? <ShortcutsDialog /> : null}

--- a/client/src/api/host-groups.ts
+++ b/client/src/api/host-groups.ts
@@ -1,0 +1,121 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  OpenSshMetadataPatch,
+  SavedHostProfile,
+  SavedHostProfilesResponse,
+  SshConfigResponse,
+} from '@muxus/shared';
+import type { FolderMove } from '../components/sidebar/folder-mutations.js';
+import { managedHostKey } from '../managed-hosts.js';
+import { showToast } from '../state/toast.js';
+import { apiFetch } from './http.js';
+
+/** Enough in flight to feel instant, few enough not to stampede the server. */
+const CHUNK_SIZE = 8;
+
+export interface FolderMutationResult {
+  attempted: number;
+  failed: number;
+}
+
+/**
+ * Apply one folder operation across every host it touches.
+ *
+ * Looping the per-host metadata hooks would work, but each of those raises its
+ * own error toast and invalidation — renaming a 40-host folder over a flaky
+ * connection would produce 40 of each. This batches the same PATCH endpoints
+ * into a single optimistic update, a single toast, and a single refetch.
+ */
+export function useApplyFolderMoves() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ moves }: { moves: FolderMove[]; label: string }) => {
+      let failed = 0;
+      for (let index = 0; index < moves.length; index += CHUNK_SIZE) {
+        const chunk = moves.slice(index, index + CHUNK_SIZE);
+        const results = await Promise.allSettled(chunk.map(patchGroup));
+        failed += results.filter((result) => result.status === 'rejected').length;
+      }
+      return { attempted: moves.length, failed } satisfies FolderMutationResult;
+    },
+    onMutate: async ({ moves }) => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: ['ssh-config'] }),
+        queryClient.cancelQueries({ queryKey: ['saved-host-profiles'] }),
+      ]);
+      const previousConfig = queryClient.getQueryData<SshConfigResponse>(['ssh-config']);
+      const previousProfiles = queryClient.getQueryData<SavedHostProfilesResponse>([
+        'saved-host-profiles',
+      ]);
+      const groupByKey = new Map(
+        moves.map((move) => [managedHostKey(move.host), move.group ?? undefined]),
+      );
+
+      queryClient.setQueryData<SshConfigResponse>(['ssh-config'], (current) => {
+        if (!current) return current;
+        return {
+          ...current,
+          hosts: current.hosts.map((host) => {
+            const key = `ssh:${host.alias}`;
+            if (!groupByKey.has(key)) return host;
+            return {
+              ...host,
+              metadata: {
+                profileId: host.metadata?.profileId ?? host.alias,
+                favorite: host.metadata?.favorite ?? false,
+                connectCount: host.metadata?.connectCount ?? 0,
+                ...host.metadata,
+                group: groupByKey.get(key),
+              },
+            };
+          }),
+        };
+      });
+      queryClient.setQueryData<SavedHostProfilesResponse>(['saved-host-profiles'], (current) => {
+        if (!current) return current;
+        return {
+          profiles: current.profiles.map((profile) => {
+            const key = `profile:${profile.id}`;
+            if (!groupByKey.has(key)) return profile;
+            return { ...profile, metadata: { ...profile.metadata, group: groupByKey.get(key) } };
+          }),
+        };
+      });
+      return { previousConfig, previousProfiles };
+    },
+    onSuccess: ({ attempted, failed }, { label }) => {
+      if (failed === 0) return;
+      showToast(
+        'error',
+        `Moved ${attempted - failed} of ${attempted} hosts — “${label}” is only partly moved.`,
+      );
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousConfig) queryClient.setQueryData(['ssh-config'], context.previousConfig);
+      if (context?.previousProfiles) {
+        queryClient.setQueryData(['saved-host-profiles'], context.previousProfiles);
+      }
+      showToast('error', 'Could not move that folder.');
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ssh-config'] });
+      void queryClient.invalidateQueries({ queryKey: ['saved-host-profiles'] });
+    },
+  });
+}
+
+function patchGroup({ host, group }: FolderMove): Promise<unknown> {
+  const patch: OpenSshMetadataPatch = { group };
+  const body = JSON.stringify(patch);
+  const init = { method: 'PATCH', headers: { 'content-type': 'application/json' }, body } as const;
+  return host.kind === 'ssh'
+    ? apiFetch<unknown>(
+        `/api/ssh/config/hosts/${encodeURIComponent(host.entry.alias)}/metadata`,
+        init,
+      )
+    : apiFetch<SavedHostProfile>(
+        `/api/profiles/${encodeURIComponent(host.entry.id)}/metadata`,
+        init,
+      );
+}

--- a/client/src/api/profiles.ts
+++ b/client/src/api/profiles.ts
@@ -3,6 +3,7 @@ import type {
   OpenSshMetadataPatch,
   SavedHostProfile,
   SavedHostProfileInput,
+  SavedHostProfilesResponse,
 } from '@muxus/shared';
 import { apiFetch } from './http.js';
 import { showErrorToast } from '../state/toast.js';
@@ -35,12 +36,44 @@ export function useUpdateHostProfileMetadata(
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(patch),
       }),
+    // Telnet and serial rows sit in the same sidebar folders as SSH hosts,
+    // whose metadata hook is optimistic — without this they visibly lag behind
+    // when a favorite or a folder change moves both at once.
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey: ['saved-host-profiles'] });
+      const previous = queryClient.getQueryData<SavedHostProfilesResponse>([
+        'saved-host-profiles',
+      ]);
+      queryClient.setQueryData<SavedHostProfilesResponse>(['saved-host-profiles'], (current) => {
+        if (!current) return current;
+        return {
+          profiles: current.profiles.map((profile) =>
+            profile.id === id
+              ? { ...profile, metadata: { ...profile.metadata, ...nullsToUndefined(patch) } }
+              : profile,
+          ),
+        };
+      });
+      return { previous };
+    },
     onSuccess: (profile) => {
-      void queryClient.invalidateQueries({ queryKey: ['saved-host-profiles'] });
       onSuccess?.(profile);
     },
-    onError: showErrorToast,
+    onError: (error, _variables, context) => {
+      if (context?.previous) queryClient.setQueryData(['saved-host-profiles'], context.previous);
+      showErrorToast(error);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['saved-host-profiles'] });
+    },
   });
+}
+
+/** The patch clears fields with null; the stored metadata omits them instead. */
+function nullsToUndefined(patch: OpenSshMetadataPatch): Partial<SavedHostProfile['metadata']> {
+  return Object.fromEntries(
+    Object.entries(patch).map(([key, value]) => [key, value ?? undefined]),
+  );
 }
 
 export function useDeleteHostProfile(onSuccess?: () => void) {

--- a/client/src/components/FolderPathField.tsx
+++ b/client/src/components/FolderPathField.tsx
@@ -1,0 +1,74 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import { useMemo } from 'react';
+import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
+import { folderLabel, folderParentPath, knownFolderPaths } from '../host-tree.js';
+import { usePrefsStore } from '../state/prefs.js';
+
+/**
+ * The one control for choosing a sidebar folder. Offers every existing path
+ * including ancestors, and accepts a new one typed with `/` between levels.
+ */
+export function FolderPathField({
+  value,
+  onChange,
+  label = 'Folder',
+  helperText,
+  error,
+  /** Paths to hide — a folder can never be moved inside itself. */
+  exclude,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  helperText?: string;
+  error?: boolean;
+  exclude?: (path: string) => boolean;
+}) {
+  const { data: config } = useSshConfig();
+  const { data: savedData } = useSavedHostProfiles();
+  const emptyFolders = usePrefsStore((state) => state.sidebarEmptyFolders);
+
+  const options = useMemo(() => {
+    const paths = knownFolderPaths(
+      config?.hosts ?? [],
+      savedData?.profiles ?? [],
+      emptyFolders,
+    );
+    return exclude ? paths.filter((path) => !exclude(path)) : paths;
+  }, [config?.hosts, savedData?.profiles, emptyFolders, exclude]);
+
+  return (
+    <Autocomplete
+      freeSolo
+      options={options}
+      value={value}
+      onInputChange={(_event, next) => onChange(next)}
+      onChange={(_event, next) => onChange(next ?? '')}
+      renderOption={(props, option) => {
+        const { key, ...rest } = props;
+        const parent = folderParentPath(option);
+        return (
+          <Box component="li" key={key} {...rest}>
+            {parent && (
+              <Box component="span" sx={{ color: 'text.disabled', mr: 0.5 }}>
+                {parent.split('/').join(' / ')} /
+              </Box>
+            )}
+            <Box component="span">{folderLabel(option)}</Box>
+          </Box>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          error={error}
+          placeholder="e.g. Production/EU"
+          helperText={helperText ?? 'Use / to nest, e.g. Production/EU. Leave empty for no folder.'}
+        />
+      )}
+    />
+  );
+}

--- a/client/src/components/HostOrganizationDialog.tsx
+++ b/client/src/components/HostOrganizationDialog.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
-import Autocomplete from '@mui/material/Autocomplete';
+import { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -11,12 +10,12 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
 import { useUpdateHostProfileMetadata } from '../api/profiles.js';
-import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import { useUpdateSshMetadata } from '../api/ssh-config.js';
+import { folderSegments } from '../host-tree.js';
 import { hostAddress, hostDisplayName } from '../host-organization.js';
-import { knownHostGroups } from '../managed-hosts.js';
 import { savedHostAddress, savedHostDisplayName } from '../saved-hosts.js';
 import { useUiStore } from '../state/ui.js';
+import { FolderPathField } from './FolderPathField.js';
 import { HostColorPicker } from './HostColorPicker.js';
 import { hostKindIcon } from './host-kind-icon.js';
 
@@ -24,8 +23,6 @@ import { hostKindIcon } from './host-kind-icon.js';
 export function HostOrganizationDialog() {
   const entry = useUiStore((state) => state.hostOrganizer);
   const setEntry = useUiStore((state) => state.setHostOrganizer);
-  const { data: config } = useSshConfig();
-  const { data: savedData } = useSavedHostProfiles();
   const [displayName, setDisplayName] = useState('');
   const [group, setGroup] = useState('');
   const [color, setColor] = useState<string | undefined>();
@@ -38,11 +35,6 @@ export function HostOrganizationDialog() {
     setGroup(entry.metadata?.group ?? '');
     setColor(entry.metadata?.color);
   }, [entry]);
-
-  const groups = useMemo(
-    () => knownHostGroups(config?.hosts ?? [], savedData?.profiles ?? []),
-    [config?.hosts, savedData?.profiles],
-  );
 
   if (!entry) return null;
 
@@ -76,7 +68,7 @@ export function HostOrganizationDialog() {
         <DialogTitle sx={{ pb: 0.75 }}>Organize {managedHostName(entry)}</DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2.5 }}>
-            Display name, group, and color are local to Muxus. Connection settings
+            Display name, folder, and color are local to Muxus. Connection settings
             stay unchanged.
           </Typography>
 
@@ -89,20 +81,10 @@ export function HostOrganizationDialog() {
               helperText="Optional — only changes how this host appears in Muxus."
               fullWidth
             />
-            <Autocomplete
-              freeSolo
-              options={groups}
+            <FolderPathField
               value={group}
-              onInputChange={(_event, value) => setGroup(value)}
-              onChange={(_event, value) => setGroup(value ?? '')}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Group"
-                  placeholder="e.g. Production"
-                  helperText="Choose an existing group or type a new one."
-                />
-              )}
+              onChange={setGroup}
+              helperText="Choose a folder or type a new one — use / to nest."
             />
             <HostColorPicker value={color} onChange={setColor} />
 
@@ -126,7 +108,9 @@ export function HostOrganizationDialog() {
                   {name}
                 </Typography>
                 <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
-                  {group.trim() ? `${group.trim()} · ` : ''}
+                  {folderSegments(group).length > 0
+                    ? `${folderSegments(group).join(' / ')} · `
+                    : ''}
                   {managedHostAddress(entry)}
                 </Typography>
               </Box>

--- a/client/src/components/HostPickerPopover.tsx
+++ b/client/src/components/HostPickerPopover.tsx
@@ -143,7 +143,9 @@ export function HostPickerPopover({
                   color: 'text.secondary',
                 }}
               >
-                {group.label}
+                {/* Stays a flat picker rather than a tree — it is a compact
+                    popover — but a nested group still reads as a path. */}
+                {group.label.split('/').join(' / ')}
               </ListSubheader>
             }
           >

--- a/client/src/components/NativeHostEditorContent.tsx
+++ b/client/src/components/NativeHostEditorContent.tsx
@@ -17,14 +17,9 @@ import UsbOutlinedIcon from '@mui/icons-material/UsbOutlined';
 import type { SavedHostProfile, SerialPortInfo, SerialProfile } from '@muxus/shared';
 import { useDeleteHostProfile, useSaveHostProfile, useUpdateHostProfileMetadata } from '../api/profiles.js';
 import { useSaveSessionLoggingPolicy } from '../api/session-history.js';
-import {
-  useSavedHostProfiles,
-  useSerialPorts,
-  useSessionLoggingPolicy,
-  useSshConfig,
-} from '../api/queries.js';
+import { useSerialPorts, useSessionLoggingPolicy } from '../api/queries.js';
 import { confirmDeleteHost } from '../host-actions.js';
-import { knownHostGroups } from '../managed-hosts.js';
+import { FolderPathField } from './FolderPathField.js';
 import { connectSavedHost } from '../session-actions.js';
 import {
   hostSessionLoggingDraft,
@@ -224,10 +219,6 @@ function GeneralSection({
   draft: NativeHostDraft;
   set: (patch: Partial<NativeHostDraft>) => void;
 }) {
-  const { data: config } = useSshConfig();
-  const { data: savedData } = useSavedHostProfiles();
-  const groups = knownHostGroups(config?.hosts ?? [], savedData?.profiles ?? []);
-
   return (
     <Stack spacing={2}>
       <TextField
@@ -259,19 +250,10 @@ function GeneralSection({
       ) : (
         <SerialPortField draft={draft} set={set} />
       )}
-      <Autocomplete
-        freeSolo
-        options={groups}
-        inputValue={draft.group}
-        onInputChange={(_event, value) => set({ group: value })}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            label="Group"
-            placeholder="Lab"
-            helperText="Optional — groups this host in the sidebar."
-          />
-        )}
+      <FolderPathField
+        value={draft.group}
+        onChange={(group: string) => set({ group })}
+        helperText="Optional — use / to nest, e.g. Lab/Bench 3."
       />
       <HostColorPicker value={draft.color} onChange={(color) => set({ color })} />
       {kind === 'telnet' && (

--- a/client/src/components/QuickLauncherDialog.tsx
+++ b/client/src/components/QuickLauncherDialog.tsx
@@ -49,6 +49,7 @@ import { useForwards, useSavedHostProfiles, useSessionHistory, useSshConfig, use
 import { startTunnel, stopForward } from '../api/tunnels.js';
 import { commandButtonInput } from '../command-buttons.js';
 import { confirmDiscardRemoteEditors } from '../editor/remote-editor-registry.js';
+import { folderSegments } from '../host-tree.js';
 import {
   managedHostAddress,
   managedHostDisplayName,
@@ -773,10 +774,13 @@ function buildCatalogResults({
       host,
       protocol: 'ssh',
       label: managedHostDisplayName(host),
-      detail: `${metadata?.group ? `${metadata.group} · ` : ''}${managedHostAddress(host)}`,
+      detail: `${folderDetail(metadata?.group)}${managedHostAddress(host)}`,
       keywords: [
         'ssh',
         ...entry.aliases,
+        // Each folder level is its own keyword, so typing "EU" finds the hosts
+        // in Production/EU without having to type the whole path.
+        ...folderSegments(metadata?.group),
         entry.description ?? '',
         entry.file,
         entry.resolved.hostname,
@@ -799,8 +803,13 @@ function buildCatalogResults({
       host,
       protocol: entry.kind,
       label: managedHostDisplayName(host),
-      detail: `${entry.metadata.group ? `${entry.metadata.group} · ` : ''}${managedHostAddress(host)}`,
-      keywords: [entry.kind, entry.name, managedHostAddress(host)],
+      detail: `${folderDetail(entry.metadata.group)}${managedHostAddress(host)}`,
+      keywords: [
+        entry.kind,
+        entry.name,
+        ...folderSegments(entry.metadata.group),
+        managedHostAddress(host),
+      ],
       priority:
         (entry.metadata.favorite ? 260 : 0) +
         Math.min(entry.metadata.connectCount, 80) +
@@ -1158,4 +1167,10 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
     return () => window.clearTimeout(timer);
   }, [delayMs, value]);
   return debounced;
+}
+
+/** `Production / EU · ` — spaced so a folder path does not read like a URL. */
+function folderDetail(group: string | undefined): string {
+  const segments = folderSegments(group);
+  return segments.length > 0 ? `${segments.join(' / ')} · ` : '';
 }

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -1,81 +1,67 @@
-import { useDeferredValue, useMemo, useRef, useState, type DragEvent, type MouseEvent } from 'react';
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import ButtonBase from '@mui/material/ButtonBase';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import ListSubheader from '@mui/material/ListSubheader';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import BoltIcon from '@mui/icons-material/Bolt';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import CreateNewFolderOutlinedIcon from '@mui/icons-material/CreateNewFolderOutlined';
 import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
-import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
-import LibraryAddOutlinedIcon from '@mui/icons-material/LibraryAddOutlined';
-import GridViewOutlinedIcon from '@mui/icons-material/GridViewOutlined';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
-import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
-import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
-import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import SearchIcon from '@mui/icons-material/Search';
-import StarIcon from '@mui/icons-material/Star';
-import StarBorderIcon from '@mui/icons-material/StarBorder';
-import TabOutlinedIcon from '@mui/icons-material/TabOutlined';
-import TableRowsOutlinedIcon from '@mui/icons-material/TableRowsOutlined';
 import TerminalIcon from '@mui/icons-material/Terminal';
-import ViewColumnOutlinedIcon from '@mui/icons-material/ViewColumnOutlined';
-import type { SshHostEntry } from '@muxus/shared';
+import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
+import { useApplyFolderMoves } from '../api/host-groups.js';
 import { useReorderManagedHosts } from '../api/host-order.js';
 import { useDeleteHostProfile, useUpdateHostProfileMetadata } from '../api/profiles.js';
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import { useDeleteHost, useUpdateSshMetadata } from '../api/ssh-config.js';
-import { copyToClipboard } from '../clipboard.js';
 import { confirmDeleteHost } from '../host-actions.js';
 import { hostOrderAfterDrop } from '../host-organization.js';
 import {
+  buildHostTree,
+  folderParentPath,
+  folderSiblings,
+  siblingHostKeys,
+  type ContainerNode,
+  type FolderNode,
+  type VisibleNode,
+} from '../host-tree.js';
+import {
   anyManagedHostMatches,
   groupManagedHosts,
-  managedHostAddress,
-  managedHostCopyCommand,
   managedHostDisplayName,
   managedHostKey,
   managedHostRef,
   type ManagedHost,
-  type ManagedHostGroup,
 } from '../managed-hosts.js';
 import {
   connectManagedHost,
   connectTarget,
   isQuickConnectTarget,
-  launchManagedHostGroup,
   openLocalTerminal,
-  openManagedHostInNewWindow,
 } from '../session-actions.js';
 import {
+  loadFolderDialog,
   loadHostEditorDialog,
-  loadHostOrganizationDialog,
+  loadSidebarMenus,
   loadTerminalViewImpl,
 } from '../lazy-features.js';
 import {
@@ -84,225 +70,201 @@ import {
   maxSidebarWidth,
   MIN_SIDEBAR_WIDTH,
 } from '../sidebar-width.js';
+import { confirmAction } from '../state/dialogs.js';
 import { usePrefsStore } from '../state/prefs.js';
-import { showToast } from '../state/toast.js';
-import { useTabsStore } from '../state/tabs.js';
-import type { SessionSetLayout } from '../state/tabs.js';
 import { useUiStore } from '../state/ui.js';
-import { hostKindIcon } from './host-kind-icon.js';
 import { PanelResizeHandle } from './PanelResizeHandle.js';
+import { deleteFolderPlan, folderRewritePlan } from './sidebar/folder-mutations.js';
+import type { FolderMenuState } from './sidebar/FolderContextMenu.js';
+import type { HostMenuState } from './sidebar/HostContextMenu.js';
+import { HostTree } from './sidebar/HostTree.js';
+import type { LaunchTarget } from './sidebar/LaunchGroupDialog.js';
+import { useAllManagedHosts } from './sidebar/useAllManagedHosts.js';
+import { useFolderPrefs } from './sidebar/useFolderPrefs.js';
+import { useLiveHostCounts } from './sidebar/useLiveHostCounts.js';
+import { useTreeDnd, type FolderPlacement } from './sidebar/useTreeDnd.js';
+
+const SidebarMenus = lazy(() =>
+  loadSidebarMenus().then((module) => ({ default: module.SidebarMenus })),
+);
 
 const EMPTY_HOSTS: SshHostEntry[] = [];
-type LiveCounts = { connected: number; connecting: number };
-type DropTarget =
-  | { kind: 'row'; groupKey: string; hostKey: string; edge: 'before' | 'after' }
-  | { kind: 'group'; groupKey: string };
+const EMPTY_PROFILES: SavedHostProfile[] = [];
+const EMPTY_KEYS: ReadonlySet<string> = new Set();
 
 /** Saved Telnet/serial profiles and live OpenSSH hosts in one host manager. */
 export function SessionSidebar() {
   const { data: config } = useSshConfig();
   const { data: savedData } = useSavedHostProfiles();
   const setHostEditor = useUiStore((s) => s.setHostEditor);
-  const setHostOrganizer = useUiStore((s) => s.setHostOrganizer);
-  const tabs = useTabsStore((s) => s.tabs);
+  const setFolderDialog = useUiStore((s) => s.setFolderDialog);
   const sidebarWidth = usePrefsStore((state) => state.sidebarWidth);
   const setPrefs = usePrefsStore((state) => state.set);
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState('');
-  const [menu, setMenu] = useState<{ anchor: HTMLElement; position?: { top: number; left: number }; host: ManagedHost } | null>(null);
-  const [launchGroup, setLaunchGroup] = useState<ManagedHostGroup | null>(null);
-  const [launchLayout, setLaunchLayout] = useState<SessionSetLayout>('tabs');
-  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
-  const [dragged, setDragged] = useState<{ groupKey: string; hostKey: string } | null>(null);
-  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+  const [menu, setMenu] = useState<HostMenuState | null>(null);
+  const [folderMenu, setFolderMenu] = useState<FolderMenuState | null>(null);
+  const [launchTarget, setLaunchTarget] = useState<LaunchTarget | null>(null);
+  /** Folders collapsed during a search; discarded when the query changes. */
+  const [searchCollapsed, setSearchCollapsed] = useState<ReadonlySet<string>>(EMPTY_KEYS);
   const deleteHost = useDeleteHost();
   const deleteProfile = useDeleteHostProfile();
   const updateMetadata = useUpdateSshMetadata();
   const updateProfileMetadata = useUpdateHostProfileMetadata();
   const reorder = useReorderManagedHosts();
+  const applyFolderMoves = useApplyFolderMoves();
+  const liveByKey = useLiveHostCounts();
+  const folders = useFolderPrefs();
+  const allHosts = useAllManagedHosts();
 
   const normalizedFilter = filter.trim().toLowerCase();
   const needle = useDeferredValue(normalizedFilter);
   const hosts = config?.hosts ?? EMPTY_HOSTS;
+  const profiles = savedData?.profiles ?? EMPTY_PROFILES;
+
   const groups = useMemo(
+    () => groupManagedHosts(hosts, profiles, config?.files ?? [], config?.path, needle),
+    [hosts, profiles, config?.files, config?.path, needle],
+  );
+  const tree = useMemo(
     () =>
-      groupManagedHosts(
-        hosts,
-        savedData?.profiles ?? [],
-        config?.files ?? [],
-        config?.path,
-        needle,
-      ),
-    [hosts, savedData?.profiles, config?.files, config?.path, needle],
+      buildHostTree(groups, {
+        knownFolders: folders.emptyFolders,
+        folderOrder: folders.folderOrder,
+      }),
+    [groups, folders.emptyFolders, folders.folderOrder],
   );
   // The list itself lags behind typing, but quick-connect must answer for the
   // text as typed — and that only needs to know whether anything matched.
   const hasImmediateMatch = useMemo(
-    () => anyManagedHostMatches(hosts, savedData?.profiles ?? [], normalizedFilter),
-    [hosts, savedData?.profiles, normalizedFilter],
+    () => anyManagedHostMatches(hosts, profiles, normalizedFilter),
+    [hosts, profiles, normalizedFilter],
   );
-  const visible = useMemo(() => groups.flatMap((group) => group.hosts), [groups]);
   const hostByKey = useMemo(
-    () => new Map(visible.map((host) => [managedHostKey(host), host])),
-    [visible],
+    () => new Map(tree.hosts.map((host) => [managedHostKey(host), host])),
+    [tree],
   );
-  const menuGroup = menu
-    ? groups.find((group) =>
-        group.hosts.some((host) => managedHostKey(host) === managedHostKey(menu.host)),
-      )
-    : undefined;
-  const menuIndex =
-    menu && menuGroup
-      ? menuGroup.hosts.findIndex(
-          (host) => managedHostKey(host) === managedHostKey(menu.host),
-        )
-      : -1;
 
   const mutating =
-    reorder.isPending || updateMetadata.isPending || updateProfileMetadata.isPending;
+    reorder.isPending ||
+    updateMetadata.isPending ||
+    updateProfileMetadata.isPending ||
+    applyFolderMoves.isPending;
+  const filtering = !!needle;
+  const reorderEnabled = !filtering && !mutating;
+  useEffect(() => {
+    setSearchCollapsed(EMPTY_KEYS);
+  }, [needle]);
+  // Folder edits rewrite paths across hosts the filter may be hiding, so they
+  // are only offered against the full list.
+  const folderEditsEnabled = !filtering && !mutating;
 
-  const commitOrder = (keys: readonly string[]) =>
-    reorder.mutate(
-      keys.flatMap((key) => {
-        const host = hostByKey.get(key);
-        return host ? [managedHostRef(host)] : [];
-      }),
-    );
+  const commitOrder = useCallback(
+    (keys: readonly string[]) =>
+      reorder.mutate(
+        keys.flatMap((key) => {
+          const host = hostByKey.get(key);
+          return host ? [managedHostRef(host)] : [];
+        }),
+      ),
+    [reorder, hostByKey],
+  );
 
-  const reorderWithin = (groupKey: string, sourceKey: string, targetKey: string, edge: 'before' | 'after') => {
-    const group = groups.find((candidate) => candidate.key === groupKey);
-    if (!group || sourceKey === targetKey) return;
-    const keys = group.hosts.map(managedHostKey);
-    const next = hostOrderAfterDrop(keys, sourceKey, targetKey, edge);
-    if (next.every((key, index) => key === keys[index])) return;
-    commitOrder(next);
-  };
+  /** Reorder a host among its siblings — folders are always alphabetical. */
+  const moveHostByKey = useCallback(
+    (key: string, delta: -1 | 1) => {
+      if (!reorderEnabled) return;
+      for (const container of allContainers(tree.roots)) {
+        const keys = siblingHostKeys(container);
+        const from = keys.indexOf(key);
+        if (from < 0) continue;
+        const to = from + delta;
+        if (to < 0 || to >= keys.length) return;
+        [keys[from], keys[to]] = [keys[to]!, keys[from]!];
+        commitOrder(keys);
+        return;
+      }
+    },
+    [tree, commitOrder, reorderEnabled],
+  );
+  const moveHost = useCallback(
+    (row: VisibleNode, delta: -1 | 1) => moveHostByKey(row.key, delta),
+    [moveHostByKey],
+  );
 
-  const moveToGroup = (
-    targetGroupKey: string,
-    sourceKey: string,
-    targetKey?: string,
-    edge: 'before' | 'after' = 'after',
-  ) => {
-    const targetGroup = groups.find((candidate) => candidate.key === targetGroupKey);
-    const source = hostByKey.get(sourceKey);
-    if (!targetGroup || targetGroup.kind !== 'custom' || !source) return;
-    const keys = targetGroup.hosts.map(managedHostKey);
-    const next = hostOrderAfterDrop(keys, sourceKey, targetKey, edge);
-    if (targetGroup.hosts.some((host) => managedHostKey(host) === sourceKey)) {
-      if (!next.every((key, index) => key === keys[index])) commitOrder(next);
-      return;
-    }
-    const patch = { group: targetGroup.label };
-    const moved =
-      source.kind === 'ssh'
-        ? updateMetadata.mutateAsync({ alias: source.entry.alias, patch })
-        : updateProfileMetadata.mutateAsync({ id: source.entry.id, patch });
-    void moved.then(() => commitOrder(next)).catch(() => undefined);
-  };
+  /** Commit a drag: change the host's folder if it moved, then its order. */
+  const dropHost = useCallback(
+    (hostKey: string, path: string | undefined, order: string[]) => {
+      const host = hostByKey.get(hostKey);
+      if (!host) return;
+      if (path === undefined) {
+        commitOrder(order);
+        return;
+      }
+      const patch = { group: path || null };
+      const moved =
+        host.kind === 'ssh'
+          ? updateMetadata.mutateAsync({ alias: host.entry.alias, patch })
+          : updateProfileMetadata.mutateAsync({ id: host.entry.id, patch });
+      // Order is only meaningful once the host actually belongs to the folder.
+      void moved.then(() => commitOrder(order)).catch(() => undefined);
+    },
+    [hostByKey, commitOrder, updateMetadata, updateProfileMetadata],
+  );
 
-  const moveBy = (groupKey: string, hostKey: string, delta: -1 | 1) => {
-    const group = groups.find((candidate) => candidate.key === groupKey);
-    if (!group) return;
-    const keys = group.hosts.map(managedHostKey);
-    const from = keys.indexOf(hostKey);
-    const to = from + delta;
-    if (from < 0 || to < 0 || to >= keys.length) return;
-    [keys[from], keys[to]] = [keys[to]!, keys[from]!];
-    commitOrder(keys);
-  };
+  const dropFolder = useCallback(
+    (fromPath: string, toPath: string, placement?: FolderPlacement) => {
+      // The key changes with the path, so carry colour, collapse state and the
+      // sibling order across before anything is written.
+      if (fromPath !== toPath) {
+        folders.renameFolderPrefs(fromPath, toPath);
+        const moves = folderRewritePlan(allHosts, fromPath, toPath);
+        if (moves.length > 0) applyFolderMoves.mutate({ moves, label: toPath });
+        else folders.addEmptyFolder(toPath);
+        folders.removeEmptyFolder(fromPath);
+      }
+      if (placement) folders.setFolderOrder(placement.parentKey, placement.keys);
+    },
+    [allHosts, folders, applyFolderMoves],
+  );
 
-  const beginDrag = (event: DragEvent<HTMLElement>, groupKey: string, hostKey: string) => {
-    event.dataTransfer.effectAllowed = 'move';
-    event.dataTransfer.setData('text/plain', hostKey);
-    setDragged({ groupKey, hostKey });
-    setDropTarget(null);
-  };
+  /** Alt+Arrow on a folder: swap it with the sibling folder next to it. */
+  const moveFolderByKey = useCallback(
+    (key: string, delta: -1 | 1) => {
+      if (!reorderEnabled) return;
+      const siblings = folderSiblings(tree, key);
+      if (!siblings) return;
+      const keys = [...siblings.keys];
+      const from = keys.indexOf(key);
+      const to = from + delta;
+      if (from < 0 || to < 0 || to >= keys.length) return;
+      [keys[from], keys[to]] = [keys[to]!, keys[from]!];
+      folders.setFolderOrder(siblings.parentKey, keys);
+    },
+    [tree, folders, reorderEnabled],
+  );
+  const moveFolder = useCallback(
+    (row: VisibleNode, delta: -1 | 1) => moveFolderByKey(row.key, delta),
+    [moveFolderByKey],
+  );
 
-  const dragOver = (event: DragEvent<HTMLElement>, groupKey: string, hostKey: string) => {
-    if (!dragged) return;
-    const targetGroup = groups.find((candidate) => candidate.key === groupKey);
-    if (
-      dragged.hostKey === hostKey ||
-      !targetGroup ||
-      (dragged.groupKey !== groupKey && targetGroup.kind !== 'custom')
-    ) {
-      setDropTarget((current) => (current ? null : current));
-      return;
-    }
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-    const rect = event.currentTarget.getBoundingClientRect();
-    const edge = event.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
-    setDropTarget((current) =>
-      current?.kind === 'row' &&
-      current.groupKey === groupKey &&
-      current.hostKey === hostKey &&
-      current.edge === edge
-        ? current
-        : { kind: 'row', groupKey, hostKey, edge },
-    );
-  };
+  const dnd = useTreeDnd({
+    tree,
+    enabled: reorderEnabled,
+    onDropHost: dropHost,
+    onDropFolder: dropFolder,
+    hostOrderAfterDrop,
+  });
 
-  const drop = (event: DragEvent<HTMLElement>, groupKey: string, hostKey: string) => {
-    event.preventDefault();
-    if (
-      dragged &&
-      dropTarget?.kind === 'row' &&
-      dropTarget.groupKey === groupKey &&
-      dropTarget.hostKey === hostKey
-    ) {
-      if (dragged.groupKey === groupKey) reorderWithin(groupKey, dragged.hostKey, hostKey, dropTarget.edge);
-      else moveToGroup(groupKey, dragged.hostKey, hostKey, dropTarget.edge);
-    }
-    setDragged(null);
-    setDropTarget(null);
-  };
-
-  const dragOverGroup = (event: DragEvent<HTMLElement>, groupKey: string) => {
-    const group = groups.find((candidate) => candidate.key === groupKey);
-    if (!dragged) return;
-    if (!group || group.kind !== 'custom') {
-      setDropTarget((current) => (current ? null : current));
-      return;
-    }
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-    setDropTarget((current) =>
-      current?.kind === 'group' && current.groupKey === groupKey
-        ? current
-        : { kind: 'group', groupKey },
-    );
-  };
-
-  const dropOnGroup = (event: DragEvent<HTMLElement>, groupKey: string) => {
-    event.preventDefault();
-    if (dragged && dropTarget?.kind === 'group' && dropTarget.groupKey === groupKey) {
-      moveToGroup(groupKey, dragged.hostKey);
-    }
-    setDragged(null);
-    setDropTarget(null);
-  };
-
-  /** Live session dots keyed like managedHostKey: connected/connecting tab counts. */
-  const liveByKey = useMemo(() => {
-    const map = new Map<string, LiveCounts>();
-    for (const tab of tabs) {
-      if (!tab.profile) continue;
-      const key =
-        tab.profile.kind === 'ssh'
-          ? `ssh:${tab.profile.target}`
-          : tab.profile.kind === 'telnet' || tab.profile.kind === 'serial'
-            ? tab.profile.profileId && `profile:${tab.profile.profileId}`
-            : undefined;
-      if (!key) continue;
-      const entry = map.get(key) ?? { connected: 0, connecting: 0 };
-      if (tab.status === 'connected') entry.connected++;
-      if (tab.status === 'connecting') entry.connecting++;
-      map.set(key, entry);
-    }
-    return map;
-  }, [tabs]);
+  const folderColor = useCallback(
+    (key: string) => folders.folderStyle(key)?.color,
+    [folders],
+  );
+  const folderIconId = useCallback(
+    (key: string) => folders.folderStyle(key)?.icon,
+    [folders],
+  );
 
   const quickConnectable =
     !!normalizedFilter &&
@@ -315,7 +277,7 @@ export function SessionSidebar() {
     const currentMatch = hasImmediateMatch
       ? groupManagedHosts(
           hosts,
-          savedData?.profiles ?? [],
+          profiles,
           config?.files ?? [],
           config?.path,
           normalizedFilter,
@@ -347,14 +309,134 @@ export function SessionSidebar() {
     });
   };
 
-  const openMenu = (host: ManagedHost, anchor: HTMLElement, position?: { top: number; left: number }) =>
-    setMenu({ anchor, position, host });
+  const openMenu = useCallback(
+    (host: ManagedHost, anchor: HTMLElement, position?: { top: number; left: number }) =>
+      setMenu({ anchor, position, host }),
+    [],
+  );
 
-  const copyAction = menu ? managedHostCopyCommand(menu.host) : undefined;
+  const launchNode = useCallback(
+    (node: ContainerNode) =>
+      setLaunchTarget({ label: node.label, hosts: collectHosts(node) }),
+    [],
+  );
+
+  const openFolderMenu = useCallback(
+    (node: ContainerNode, anchor: HTMLElement, position?: { top: number; left: number }) => {
+      // ssh_config file groups are defined by the config file, not by Muxus.
+      if (node.kind !== 'folder') return;
+      setFolderMenu({ anchor, position, node });
+    },
+    [],
+  );
+
+  /**
+   * Expansion has two layers. Normally it is the persisted one. While a filter
+   * is active every folder opens — `groupManagedHosts` has already dropped the
+   * non-matching hosts, so "expand what contains a hit" is just "expand all" —
+   * and collapses made during the search live in a scratch set. The persisted
+   * layer is never written to while filtering, so clearing the box restores
+   * exactly the shape the sidebar had before.
+   */
+  const isExpanded = useCallback(
+    (key: string) => (filtering ? !searchCollapsed.has(key) : folders.isExpanded(key)),
+    [filtering, searchCollapsed, folders],
+  );
+  const setCollapsedKeys = useCallback(
+    (keys: readonly string[], collapsed: boolean) => {
+      if (filtering) {
+        setSearchCollapsed((current) => {
+          const next = new Set(current);
+          for (const key of keys) {
+            if (collapsed) next.add(key);
+            else next.delete(key);
+          }
+          return next;
+        });
+        return;
+      }
+      const next = new Set(usePrefsStore.getState().sidebarCollapsedFolders);
+      for (const key of keys) {
+        if (collapsed) next.add(key);
+        else next.delete(key);
+      }
+      setPrefs({ sidebarCollapsedFolders: [...next] });
+    },
+    [filtering, setPrefs],
+  );
+  const setExpanded = useCallback(
+    (key: string, expanded: boolean) => setCollapsedKeys([key], !expanded),
+    [setCollapsedKeys],
+  );
+
+  /** Collapse a folder and everything nested inside it, in one write. */
+  const collapseSubtree = useCallback(
+    (node: FolderNode) => {
+      const keys = [node.key];
+      const walk = (folder: FolderNode) => {
+        for (const child of folder.children) {
+          if (child.kind !== 'folder') continue;
+          keys.push(child.key);
+          walk(child);
+        }
+      };
+      walk(node);
+      setCollapsedKeys(keys, true);
+    },
+    [setCollapsedKeys],
+  );
+
+  const deleteFolder = useCallback(
+    (node: FolderNode) => {
+      const moves = deleteFolderPlan(allHosts, node.path);
+      const parent = folderParentPath(node.path);
+      void confirmAction({
+        title: `Delete “${node.label}”?`,
+        description:
+          moves.length === 0
+            ? 'The folder is empty, so nothing else changes.'
+            : `${moves.length} host${moves.length === 1 ? '' : 's'} move${moves.length === 1 ? 's' : ''} ${parent ? `up into “${parent}”` : 'out of every folder'}. No connection settings change.`,
+        confirmLabel: 'Delete folder',
+        destructive: true,
+      }).then((confirmed) => {
+        if (!confirmed) return;
+        folders.removeEmptyFolder(node.path);
+        folders.setFolderStyle(node.key, undefined);
+        if (moves.length > 0) applyFolderMoves.mutate({ moves, label: node.label });
+      });
+    },
+    [allHosts, folders, applyFolderMoves],
+  );
+
+  // Where the menu's host sits among its siblings, for Move up / Move down.
+  const menuPosition = useMemo(() => {
+    if (!menu) return { index: -1, total: 0 };
+    const key = managedHostKey(menu.host);
+    for (const container of allContainers(tree.roots)) {
+      const keys = siblingHostKeys(container);
+      const index = keys.indexOf(key);
+      if (index >= 0) return { index, total: keys.length };
+    }
+    return { index: -1, total: 0 };
+  }, [menu, tree]);
+
+  /** Where the menu's folder sits among its siblings, for Move up / Move down. */
+  const folderMenuPosition = useMemo(() => {
+    const siblings = folderMenu ? folderSiblings(tree, folderMenu.node.key) : undefined;
+    return siblings
+      ? { index: siblings.keys.indexOf(folderMenu!.node.key), total: siblings.keys.length }
+      : { index: -1, total: 0 };
+  }, [folderMenu, tree]);
+
+  const empty = hosts.length === 0 && profiles.length === 0;
 
   return (
     <Box
       ref={sidebarRef}
+      // Every menu and the launch dialog live in one lazy chunk. Pointing at
+      // the sidebar at all is enough warning to have it ready by the time a
+      // right-click lands.
+      onMouseEnter={() => void loadSidebarMenus()}
       sx={{
         width: sidebarWidth,
         maxWidth: '45%',
@@ -382,6 +464,7 @@ export function SessionSidebar() {
       <Stack direction="row" spacing={1} sx={{ p: 1.25, pb: 0.75, alignItems: 'center' }}>
         <TextField
           fullWidth
+          inputRef={searchRef}
           placeholder="Search / user@host ⏎"
           value={filter}
           onChange={(e) => {
@@ -394,6 +477,11 @@ export function SessionSidebar() {
           onKeyDown={(e) => {
             if (e.key === 'Enter') onEnter();
             if (e.key === 'Escape') setFilter('');
+            if (e.key === 'ArrowDown') {
+              // Hand off to the tree rather than moving the text cursor.
+              e.preventDefault();
+              sidebarRef.current?.querySelector<HTMLElement>('[role="treeitem"]')?.focus();
+            }
           }}
           slotProps={{
             input: {
@@ -405,6 +493,20 @@ export function SessionSidebar() {
             },
           }}
         />
+        <Tooltip title="New folder">
+          <span>
+            <IconButton
+              size="small"
+              aria-label="New folder"
+              disabled={!folderEditsEnabled}
+              onMouseEnter={() => void loadFolderDialog()}
+              onFocus={() => void loadFolderDialog()}
+              onClick={() => setFolderDialog({ mode: 'new' })}
+            >
+              <CreateNewFolderOutlinedIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
         <Tooltip title="Add host">
           <IconButton
             size="small"
@@ -425,10 +527,10 @@ export function SessionSidebar() {
             onFocus={() => void loadTerminalViewImpl()}
             onClick={() => openLocalTerminal()}
           >
-            <ListItemIcon sx={{ minWidth: 32 }}>
-              <TerminalIcon fontSize="small" />
+            <ListItemIcon sx={{ minWidth: 28 }}>
+              <TerminalIcon sx={{ fontSize: 16 }} />
             </ListItemIcon>
-            <ListItemText primary="Local terminal" />
+            <ListItemText primary="Local terminal" slotProps={{ primary: { sx: { fontSize: 13 } } }} />
           </ListItemButton>
           {quickConnectable && (
             <ListItemButton
@@ -439,10 +541,13 @@ export function SessionSidebar() {
                 setFilter('');
               }}
             >
-              <ListItemIcon sx={{ minWidth: 32 }}>
-                <BoltIcon fontSize="small" color="primary" />
+              <ListItemIcon sx={{ minWidth: 28 }}>
+                <BoltIcon sx={{ fontSize: 16 }} color="primary" />
               </ListItemIcon>
-              <ListItemText primary={`Connect to ${filter.trim()}`} slotProps={{ primary: { sx: { color: 'primary.main' } } }} />
+              <ListItemText
+                primary={`Connect to ${filter.trim()}`}
+                slotProps={{ primary: { sx: { fontSize: 13, color: 'primary.main' } } }}
+              />
             </ListItemButton>
           )}
         </List>
@@ -453,147 +558,25 @@ export function SessionSidebar() {
           </Alert>
         )}
 
-        {groups.map((group) => (
-          <List
-            key={group.key}
-            dense
-            disablePadding
-            subheader={
-              <ListSubheader
-                disableSticky
-                onDragOver={(event) => dragOverGroup(event, group.key)}
-                onDragLeave={(event) => {
-                  const related = event.relatedTarget;
-                  if (related instanceof Node && event.currentTarget.contains(related)) return;
-                  setDropTarget((current) =>
-                    current?.kind === 'group' && current.groupKey === group.key ? null : current,
-                  );
-                }}
-                onDrop={(event) => dropOnGroup(event, group.key)}
-                sx={{
-                  bgcolor:
-                    dropTarget?.kind === 'group' && dropTarget.groupKey === group.key
-                      ? 'action.selected'
-                      : 'transparent',
-                  lineHeight: '26px',
-                  fontSize: 11,
-                  textTransform: 'uppercase',
-                  letterSpacing: 0.6,
-                  userSelect: 'none',
-                  display: 'flex',
-                  alignItems: 'center',
-                  px: 0.75,
-                  mt: 0.5,
-                  borderRadius: 1,
-                  transition: 'background-color 120ms ease, color 120ms ease, box-shadow 120ms ease',
-                  // Group actions stay out of sight until the header is hovered
-                  // or tabbed to; the slot is always laid out so nothing shifts.
-                  '&:hover .group-launch, & .group-launch:focus-visible': { opacity: 1 },
-                  ...(dropTarget?.kind === 'group' &&
-                    dropTarget.groupKey === group.key && {
-                      color: 'primary.main',
-                      boxShadow: (theme) => `inset 3px 0 ${theme.palette.primary.main}`,
-                    }),
-                }}
-              >
-                <Tooltip title={group.tooltip ?? ''} placement="right" disableInteractive>
-                  <ButtonBase
-                    aria-expanded={!collapsed[group.key]}
-                    onClick={() =>
-                      setCollapsed((current) => ({ ...current, [group.key]: !current[group.key] }))
-                    }
-                    sx={{
-                      flex: 1,
-                      minWidth: 0,
-                      justifyContent: 'flex-start',
-                      gap: 0.5,
-                      font: 'inherit',
-                      letterSpacing: 'inherit',
-                      // Form controls drop the inherited transform in some engines.
-                      textTransform: 'inherit',
-                      color: 'inherit',
-                      borderRadius: 1,
-                      px: 0.25,
-                    }}
-                  >
-                    <ExpandMoreIcon
-                      sx={{
-                        fontSize: 14,
-                        flexShrink: 0,
-                        color: 'text.disabled',
-                        transition: 'transform 150ms ease',
-                        transform: collapsed[group.key] ? 'rotate(-90deg)' : 'none',
-                      }}
-                    />
-                    <Box
-                      component="span"
-                      sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                    >
-                      {group.label}
-                    </Box>
-                  </ButtonBase>
-                </Tooltip>
-                <Tooltip title={group.hosts.length > 0 ? `Launch all ${group.hosts.length} hosts…` : ''}>
-                  <span>
-                    <IconButton
-                      className="group-launch"
-                      size="small"
-                      aria-label={`Launch ${group.label} group`}
-                      disabled={group.hosts.length === 0}
-                      onClick={() => {
-                        setLaunchGroup(group);
-                        setLaunchLayout('tabs');
-                      }}
-                      sx={{ p: 0.25, opacity: { xs: 1, md: 0 }, transition: 'opacity 120ms ease' }}
-                    >
-                      <PlayArrowOutlinedIcon sx={{ fontSize: 15 }} />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 11, color: 'text.disabled', minWidth: 14, textAlign: 'right' }}
-                >
-                  {group.hosts.length}
-                </Typography>
-              </ListSubheader>
-            }
-          >
-            {!collapsed[group.key] &&
-              group.hosts.map((host) => {
-                const hostKey = managedHostKey(host);
-                return (
-                  <HostRow
-                    key={hostKey}
-                    host={host}
-                    live={liveByKey.get(hostKey)}
-                    onConnect={() => connectManagedHost(host)}
-                    onMenu={openMenu}
-                    showDragGrip={!needle}
-                    dragEnabled={!needle && !mutating}
-                    dragging={dragged?.groupKey === group.key && dragged.hostKey === hostKey}
-                    dropEdge={
-                      dropTarget?.kind === 'row' &&
-                      dropTarget.groupKey === group.key &&
-                      dropTarget.hostKey === hostKey
-                        ? dropTarget.edge
-                        : undefined
-                    }
-                    onDragStart={(event) => beginDrag(event, group.key, hostKey)}
-                    onDragOver={(event) => dragOver(event, group.key, hostKey)}
-                    onDrop={(event) => drop(event, group.key, hostKey)}
-                    onDragEnd={() => {
-                      setDragged(null);
-                      setDropTarget(null);
-                    }}
-                    onMove={(delta) => moveBy(group.key, hostKey, delta)}
-                  />
-                );
-              })}
-          </List>
-        ))}
+        <HostTree
+          tree={tree}
+          isExpanded={isExpanded}
+          setExpanded={setExpanded}
+          folderColor={folderColor}
+          folderIconId={folderIconId}
+          liveByKey={liveByKey}
+          reorderEnabled={reorderEnabled}
+          onConnect={connectManagedHost}
+          onHostMenu={openMenu}
+          onFolderMenu={openFolderMenu}
+          onLaunch={launchNode}
+          onMoveHost={moveHost}
+          onMoveFolder={moveFolder}
+          onEscape={() => searchRef.current?.focus()}
+          dnd={dnd.binding}
+        />
 
-        {hosts.length === 0 && (savedData?.profiles.length ?? 0) === 0 && (
+        {empty && (
           <Stack spacing={1.5} sx={{ alignItems: 'center', p: 3, textAlign: 'center' }}>
             <DnsOutlinedIcon sx={{ fontSize: 36, color: 'text.disabled' }} />
             <Typography variant="body2" color="text.secondary">
@@ -611,477 +594,79 @@ export function SessionSidebar() {
             </Button>
           </Stack>
         )}
-        {(hosts.length > 0 || (savedData?.profiles.length ?? 0) > 0) &&
-          visible.length === 0 &&
-          !quickConnectable && (
+        {!empty && tree.hosts.length === 0 && !quickConnectable && (
           <Typography variant="body2" color="text.secondary" sx={{ p: 2, textAlign: 'center' }}>
             No hosts match.
           </Typography>
-          )}
+        )}
       </Box>
 
-      <Menu
-        open={!!menu}
-        anchorEl={menu?.position ? undefined : menu?.anchor}
-        anchorReference={menu?.position ? 'anchorPosition' : 'anchorEl'}
-        anchorPosition={menu?.position}
-        onClose={() => setMenu(null)}
-      >
-        <MenuItem
-          onMouseEnter={() => void loadTerminalViewImpl()}
-          onFocus={() => void loadTerminalViewImpl()}
-          onClick={() => {
-            if (menu) connectManagedHost(menu.host);
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <PlayArrowOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          Connect
-        </MenuItem>
-        <MenuItem
-          onMouseEnter={() => void loadTerminalViewImpl()}
-          onFocus={() => void loadTerminalViewImpl()}
-          onClick={() => {
-            if (menu) openManagedHostInNewWindow(menu.host);
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <OpenInNewOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          Open in new window
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            if (menu) toggleFavorite(menu.host);
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            {menu?.host.entry.metadata?.favorite ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
-          </ListItemIcon>
-          {menu?.host.entry.metadata?.favorite ? 'Remove from favorites' : 'Add to favorites'}
-        </MenuItem>
-        <MenuItem
-          disabled={!!needle || menuIndex <= 0 || mutating}
-          onClick={() => {
-            if (menu && menuGroup) moveBy(menuGroup.key, managedHostKey(menu.host), -1);
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <KeyboardArrowUpIcon fontSize="small" />
-          </ListItemIcon>
-          Move up
-        </MenuItem>
-        <MenuItem
-          disabled={
-            !!needle ||
-            !menuGroup ||
-            menuIndex < 0 ||
-            menuIndex >= menuGroup.hosts.length - 1 ||
-            mutating
-          }
-          onClick={() => {
-            if (menu && menuGroup) moveBy(menuGroup.key, managedHostKey(menu.host), 1);
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <KeyboardArrowDownIcon fontSize="small" />
-          </ListItemIcon>
-          Move down
-        </MenuItem>
-        <Divider />
-        <MenuItem
-          onMouseEnter={() => void loadHostOrganizationDialog()}
-          onFocus={() => void loadHostOrganizationDialog()}
-          onClick={() => {
-            if (menu) setHostOrganizer(menu.host.entry);
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <PaletteOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          Organize & color…
-        </MenuItem>
-        <MenuItem
-          onMouseEnter={() => void loadHostEditorDialog()}
-          onFocus={() => void loadHostEditorDialog()}
-          onClick={() => {
-            if (menu) {
-              setHostEditor(
-                menu.host.kind === 'ssh'
-                  ? { mode: 'edit', entry: menu.host.entry }
-                  : { mode: 'edit-profile', entry: menu.host.entry },
-              );
-            }
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <EditOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          Edit host
-        </MenuItem>
-        <MenuItem
-          onMouseEnter={() => void loadHostEditorDialog()}
-          onFocus={() => void loadHostEditorDialog()}
-          onClick={() => {
-            if (menu) {
-              setHostEditor(
-                menu.host.kind === 'ssh'
-                  ? { mode: 'duplicate', entry: menu.host.entry }
-                  : { mode: 'duplicate-profile', entry: menu.host.entry },
-              );
-            }
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <LibraryAddOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          Duplicate
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            if (copyAction) {
-              void copyToClipboard(copyAction.text).then((ok) => {
-                if (ok) showToast('success', `Copied "${copyAction.text}"`);
-              });
-            }
-            setMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <ContentCopyIcon fontSize="small" />
-          </ListItemIcon>
-          {copyAction?.label ?? 'Copy'}
-        </MenuItem>
-        <Divider />
-        <MenuItem
-          onClick={() => {
-            if (menu) requestDelete(menu.host);
-            setMenu(null);
-          }}
-          sx={{ color: 'error.main' }}
-        >
-          <ListItemIcon sx={{ color: 'error.main' }}>
-            <DeleteOutlineIcon fontSize="small" />
-          </ListItemIcon>
-          Delete host
-        </MenuItem>
-      </Menu>
-
-      <Dialog open={!!launchGroup} onClose={() => setLaunchGroup(null)} maxWidth="xs" fullWidth>
-        <DialogTitle>Launch “{launchGroup?.label}”</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Start all {launchGroup?.hosts.length ?? 0} hosts and replace the current pane layout.
-          </Typography>
-          <ToggleButtonGroup
-            exclusive
-            fullWidth
-            size="small"
-            value={launchLayout}
-            onChange={(_event, value: SessionSetLayout | null) => {
-              if (value) setLaunchLayout(value);
+      {(menu || folderMenu || launchTarget) && (
+        <Suspense fallback={null}>
+          <SidebarMenus
+            host={{
+              menu,
+              onClose: () => setMenu(null),
+              canMoveUp: reorderEnabled && menuPosition.index > 0,
+              canMoveDown:
+                reorderEnabled &&
+                menuPosition.index >= 0 &&
+                menuPosition.index < menuPosition.total - 1,
+              onMove: (delta) => {
+                if (menu) moveHostByKey(managedHostKey(menu.host), delta);
+              },
+              onToggleFavorite: toggleFavorite,
+              onDelete: requestDelete,
+              onMoveToFolder: (host) =>
+                setFolderDialog({
+                  mode: 'move-host',
+                  hostKey: managedHostKey(host),
+                  hostName: managedHostDisplayName(host),
+                  currentPath: host.entry.metadata?.group ?? '',
+                }),
             }}
-            aria-label="Host group layout"
-          >
-            <ToggleButton value="tabs" aria-label="Tabs">
-              <Stack spacing={0.25} sx={{ alignItems: 'center' }}>
-                <TabOutlinedIcon fontSize="small" />
-                <Typography variant="caption">Tabs</Typography>
-              </Stack>
-            </ToggleButton>
-            <ToggleButton value="columns" aria-label="Columns">
-              <Stack spacing={0.25} sx={{ alignItems: 'center' }}>
-                <ViewColumnOutlinedIcon fontSize="small" />
-                <Typography variant="caption">Columns</Typography>
-              </Stack>
-            </ToggleButton>
-            <ToggleButton value="rows" aria-label="Rows">
-              <Stack spacing={0.25} sx={{ alignItems: 'center' }}>
-                <TableRowsOutlinedIcon fontSize="small" />
-                <Typography variant="caption">Rows</Typography>
-              </Stack>
-            </ToggleButton>
-            <ToggleButton value="grid" aria-label="Grid">
-              <Stack spacing={0.25} sx={{ alignItems: 'center' }}>
-                <GridViewOutlinedIcon fontSize="small" />
-                <Typography variant="caption">Grid</Typography>
-              </Stack>
-            </ToggleButton>
-          </ToggleButtonGroup>
-          {tabs.some((tab) => tab.profile && tab.status !== 'closed') ? (
-            <Alert severity="warning" sx={{ mt: 2 }}>
-              Existing live sessions will be closed when this group replaces the current layout.
-            </Alert>
-          ) : null}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setLaunchGroup(null)}>Cancel</Button>
-          <Button
-            variant="contained"
-            startIcon={<PlayArrowOutlinedIcon />}
-            disabled={!launchGroup?.hosts.length}
-            onClick={() => {
-              if (!launchGroup) return;
-              const { hosts: groupHosts, label } = launchGroup;
-              void launchManagedHostGroup(groupHosts, launchLayout).then((ids) => {
-                if (ids.length === 0) return;
-                showToast(
-                  'success',
-                  `Launching ${ids.length} session${ids.length === 1 ? '' : 's'} from “${label}” in ${launchLayout}.`,
-                );
-                setLaunchGroup(null);
-              });
+            folder={{
+              menu: folderMenu,
+              onClose: () => setFolderMenu(null),
+              onNewChild: (node) => setFolderDialog({ mode: 'new', parentPath: node.path }),
+              onEdit: (node) => setFolderDialog({ mode: 'edit', path: node.path }),
+              onLaunch: launchNode,
+              onCollapseAll: collapseSubtree,
+              onDelete: deleteFolder,
+              onMove: (node, delta) => moveFolderByKey(node.key, delta),
+              canMoveUp: reorderEnabled && folderMenuPosition.index > 0,
+              canMoveDown:
+                reorderEnabled &&
+                folderMenuPosition.index >= 0 &&
+                folderMenuPosition.index < folderMenuPosition.total - 1,
             }}
-          >
-            Launch group
-          </Button>
-        </DialogActions>
-      </Dialog>
+            launch={{ target: launchTarget, onClose: () => setLaunchTarget(null) }}
+          />
+        </Suspense>
+      )}
     </Box>
   );
 }
 
-/**
- * What a row deliberately does not draw. Jump chain, key, auth mode and
- * forwards are reference material, not things you act on from the list, so
- * they live in the row's hover card instead of as a row of grey glyphs.
- */
-function hostDetailLines(host: ManagedHost): string[] {
-  const lines: string[] = [];
-  if (host.kind !== 'ssh') return lines;
-  if (host.entry.description) lines.push(host.entry.description);
-  const resolved = host.entry.resolved;
-  if (!resolved) return lines;
-  if (resolved.proxyJump.length > 0) lines.push(`via ${resolved.proxyJump.join(' → ')}`);
-  if (resolved.identityFiles.length > 0) {
-    lines.push(`Key ${resolved.identityFiles.map((file) => file.split(/[\\/]/).pop()).join(', ')}`);
+/** Depth-first walk of every container, so sibling lookups can scan once. */
+function* allContainers(nodes: readonly ContainerNode[]): Generator<ContainerNode> {
+  for (const node of nodes) {
+    yield node;
+    if (node.kind === 'folder') {
+      yield* allContainers(node.children.filter((child) => child.kind === 'folder'));
+    }
   }
-  if (resolved.passwordOnly) lines.push('Password authentication');
-  if (resolved.forwards.length > 0) {
-    lines.push(
-      `${resolved.forwards.length} port forward${resolved.forwards.length > 1 ? 's' : ''} on connect`,
-    );
-  }
-  return lines;
 }
 
-/** One sidebar row for any host source; details ride along in the hover card. */
-function HostRow({
-  host,
-  live,
-  onConnect,
-  onMenu,
-  showDragGrip,
-  dragEnabled,
-  dragging,
-  dropEdge,
-  onDragStart,
-  onDragOver,
-  onDrop,
-  onDragEnd,
-  onMove,
-}: {
-  host: ManagedHost;
-  live?: LiveCounts;
-  onConnect: () => void;
-  onMenu: (host: ManagedHost, anchor: HTMLElement, position?: { top: number; left: number }) => void;
-  showDragGrip: boolean;
-  dragEnabled: boolean;
-  dragging: boolean;
-  dropEdge?: 'before' | 'after';
-  onDragStart: (event: DragEvent<HTMLElement>) => void;
-  onDragOver: (event: DragEvent<HTMLElement>) => void;
-  onDrop: (event: DragEvent<HTMLElement>) => void;
-  onDragEnd: () => void;
-  onMove: (delta: -1 | 1) => void;
-}) {
-  const title = managedHostDisplayName(host);
-  const address = managedHostAddress(host);
-  const secondary = host.kind === 'ssh' && address === host.entry.alias ? undefined : address;
-  const color = host.entry.metadata?.color;
-  const Icon = hostKindIcon(host.kind === 'ssh' ? 'ssh' : host.entry.kind);
-  const details = hostDetailLines(host);
-  const connected = live?.connected ?? 0;
-  const connecting = live?.connecting ?? 0;
-  const [clipped, setClipped] = useState(false);
-
-  /** The hover card is worth showing only for what the row can't fit. */
-  const measure = (event: MouseEvent<HTMLElement>) => {
-    const name = event.currentTarget.querySelector('[data-host-name]');
-    const line = event.currentTarget.querySelector('.MuiListItemText-secondary');
-    setClipped(
-      (!!name && name.scrollWidth > name.clientWidth) ||
-        (!!line && line.scrollWidth > line.clientWidth),
-    );
+function collectHosts(node: ContainerNode): ManagedHost[] {
+  const out: ManagedHost[] = [];
+  const walk = (container: ContainerNode) => {
+    for (const child of container.children) {
+      if (child.kind === 'host') out.push(child.host);
+      else if (child.kind === 'folder') walk(child);
+    }
   };
-
-  const row = (
-    <ListItemButton
-      draggable={dragEnabled}
-      onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
-      onMouseEnter={(event) => {
-        void loadTerminalViewImpl();
-        measure(event);
-      }}
-      onFocus={() => void loadTerminalViewImpl()}
-      onClick={onConnect}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      onKeyDown={(event) => {
-        if (!dragEnabled || !event.altKey) return;
-        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
-        event.preventDefault();
-        onMove(event.key === 'ArrowUp' ? -1 : 1);
-      }}
-      aria-keyshortcuts={dragEnabled ? 'Alt+ArrowUp Alt+ArrowDown' : undefined}
-      onContextMenu={(e) => {
-        e.preventDefault();
-        onMenu(host, e.currentTarget, { top: e.clientY, left: e.clientX });
-      }}
-      sx={{
-        '&:hover .host-row-menu, & .host-row-menu:focus-visible': { opacity: 1 },
-        // The grip takes over the kind-icon slot on hover: the reorder
-        // affordance costs no width and no row is decorated at rest.
-        ...(showDragGrip && {
-          '&:hover .host-drag-grip': { opacity: 0.55 },
-          '&:hover .host-kind-icon': { opacity: 0 },
-        }),
-        opacity: dragging ? 0.45 : 1,
-        pr: 0.5,
-        borderLeft: 3,
-        borderLeftColor: color ?? 'transparent',
-        position: 'relative',
-        contentVisibility: 'auto',
-        containIntrinsicSize: '0 48px',
-        ...(dropEdge && {
-          [`&::${dropEdge === 'before' ? 'before' : 'after'}`]: {
-            content: '""',
-            position: 'absolute',
-            left: 8,
-            right: 8,
-            [dropEdge === 'before' ? 'top' : 'bottom']: -1,
-            height: 2,
-            borderRadius: 2,
-            bgcolor: 'primary.main',
-            zIndex: 2,
-          },
-        }),
-      }}
-    >
-      <ListItemIcon sx={{ minWidth: 32 }}>
-        <Box sx={{ position: 'relative', display: 'flex', cursor: dragEnabled ? 'grab' : undefined }}>
-          <Icon
-            className="host-kind-icon"
-            fontSize="small"
-            sx={{ color: color ?? 'text.secondary', transition: 'opacity 120ms ease' }}
-          />
-          {showDragGrip && (
-            <DragIndicatorIcon
-              className="host-drag-grip"
-              sx={{
-                position: 'absolute',
-                inset: 0,
-                fontSize: 20,
-                opacity: 0,
-                pointerEvents: 'none',
-                transition: 'opacity 120ms ease',
-              }}
-            />
-          )}
-          {connected + connecting > 0 && (
-            <Box
-              sx={{
-                position: 'absolute',
-                right: -3,
-                bottom: -2,
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                bgcolor: connected > 0 ? 'success.main' : 'warning.main',
-                boxShadow: (theme) => `0 0 0 2px ${theme.palette.sidebar}`,
-                ...(connected === 0 && {
-                  animation: 'muxus-pulse 1.2s ease-in-out infinite',
-                  '@keyframes muxus-pulse': { '50%': { opacity: 0.3 } },
-                }),
-              }}
-            />
-          )}
-        </Box>
-      </ListItemIcon>
-      <ListItemText
-        primary={
-          <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 0 }}>
-            <Box
-              component="span"
-              data-host-name
-              sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-            >
-              {title}
-            </Box>
-            {host.entry.metadata?.favorite && (
-              <StarIcon sx={{ fontSize: 13, flexShrink: 0, color: 'warning.main' }} />
-            )}
-            {connected > 1 && (
-              <Typography component="span" sx={{ fontSize: 10, flexShrink: 0, color: 'success.main' }}>
-                ×{connected}
-              </Typography>
-            )}
-          </Stack>
-        }
-        secondary={secondary}
-        slotProps={{ secondary: { sx: { fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } } }}
-      />
-      <IconButton
-        className="host-row-menu"
-        size="small"
-        edge="end"
-        aria-label={`Options for ${title}`}
-        sx={{ flexShrink: 0, ml: 0.25, opacity: { xs: 1, md: 0 }, transition: 'opacity 120ms ease' }}
-        onClick={(e) => {
-          e.stopPropagation();
-          onMenu(host, e.currentTarget);
-        }}
-      >
-        <MoreVertIcon sx={{ fontSize: 16 }} />
-      </IconButton>
-    </ListItemButton>
-  );
-
-  return (
-    <Tooltip
-      placement="right"
-      enterDelay={500}
-      enterNextDelay={250}
-      disableInteractive
-      title={
-        details.length === 0 && !clipped ? (
-          ''
-        ) : (
-          <Stack spacing={0.25} sx={{ py: 0.25 }}>
-            <Box sx={{ fontWeight: 600 }}>{title}</Box>
-            {address !== title && <Box sx={{ opacity: 0.7 }}>{address}</Box>}
-            {details.length > 0 && (
-              <Stack spacing={0.25} sx={{ pt: 0.5, opacity: 0.7 }}>
-                {details.map((line) => (
-                  <Box key={line}>{line}</Box>
-                ))}
-              </Stack>
-            )}
-          </Stack>
-        )
-      }
-    >
-      {row}
-    </Tooltip>
-  );
+  walk(node);
+  return out;
 }
+

--- a/client/src/components/host-editor/GeneralSection.tsx
+++ b/client/src/components/host-editor/GeneralSection.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react';
-import Autocomplete from '@mui/material/Autocomplete';
 import Divider from '@mui/material/Divider';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import type { SshConfigResponse } from '@muxus/shared';
-import { useSavedHostProfiles } from '../../api/queries.js';
-import { knownHostGroups } from '../../managed-hosts.js';
+import { FolderPathField } from '../FolderPathField.js';
 import { HostColorPicker } from '../HostColorPicker.js';
 import type { HostDraft } from './draft.js';
 import { draftAliases } from './draft.js';
@@ -34,8 +32,6 @@ export function GeneralSection({
   config: SshConfigResponse | undefined;
 }) {
   const [newFileName, setNewFileName] = useState('');
-  const { data: savedData } = useSavedHostProfiles();
-  const groups = knownHostGroups(config?.hosts ?? [], savedData?.profiles ?? []);
   const rootPath = config?.path ?? '~/.ssh/config';
   const files = config?.files ?? [];
   const knownFile = !draft.file || files.includes(draft.file);
@@ -138,19 +134,10 @@ export function GeneralSection({
         helperText="Optional — only changes how this host appears in Muxus."
         fullWidth
       />
-      <Autocomplete
-        freeSolo
-        options={groups}
-        inputValue={draft.group}
-        onInputChange={(_event, value) => set({ group: value })}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            label="Group"
-            placeholder="e.g. Production"
-            helperText="Optional — groups this host in the sidebar."
-          />
-        )}
+      <FolderPathField
+        value={draft.group}
+        onChange={(group: string) => set({ group })}
+        helperText="Optional — use / to nest, e.g. Production/EU."
       />
       <HostColorPicker value={draft.color} onChange={(color) => set({ color })} />
     </Stack>

--- a/client/src/components/sidebar/FolderContextMenu.tsx
+++ b/client/src/components/sidebar/FolderContextMenu.tsx
@@ -1,0 +1,113 @@
+import Divider from '@mui/material/Divider';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import CreateNewFolderOutlinedIcon from '@mui/icons-material/CreateNewFolderOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
+import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
+import type { FolderNode } from '../../host-tree.js';
+import { loadFolderDialog } from '../../lazy-features.js';
+
+export interface FolderMenuState {
+  anchor: HTMLElement;
+  position?: { top: number; left: number };
+  node: FolderNode;
+}
+
+export function FolderContextMenu({
+  menu,
+  onClose,
+  onNewChild,
+  onEdit,
+  onLaunch,
+  onCollapseAll,
+  onDelete,
+  onMove,
+  canMoveUp,
+  canMoveDown,
+}: {
+  menu: FolderMenuState | null;
+  onClose: () => void;
+  onNewChild: (node: FolderNode) => void;
+  onEdit: (node: FolderNode) => void;
+  onLaunch: (node: FolderNode) => void;
+  onCollapseAll: (node: FolderNode) => void;
+  onDelete: (node: FolderNode) => void;
+  onMove: (node: FolderNode, delta: -1 | 1) => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+}) {
+  const run = (action: (node: FolderNode) => void) => () => {
+    if (menu) action(menu.node);
+    onClose();
+  };
+  const count = menu?.node.descendantHostCount ?? 0;
+
+  return (
+    <Menu
+      open={!!menu}
+      anchorEl={menu?.position ? undefined : menu?.anchor}
+      anchorReference={menu?.position ? 'anchorPosition' : 'anchorEl'}
+      anchorPosition={menu?.position}
+      onClose={onClose}
+    >
+      <MenuItem disabled={count === 0} onClick={run(onLaunch)}>
+        <ListItemIcon>
+          <PlayArrowOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        {count > 0 ? `Launch ${count} host${count === 1 ? '' : 's'}…` : 'Launch hosts…'}
+      </MenuItem>
+      <Divider />
+      <MenuItem disabled={!canMoveUp} onClick={run((node) => onMove(node, -1))}>
+        <ListItemIcon>
+          <KeyboardArrowUpIcon fontSize="small" />
+        </ListItemIcon>
+        Move up
+      </MenuItem>
+      <MenuItem disabled={!canMoveDown} onClick={run((node) => onMove(node, 1))}>
+        <ListItemIcon>
+          <KeyboardArrowDownIcon fontSize="small" />
+        </ListItemIcon>
+        Move down
+      </MenuItem>
+      <Divider />
+      <MenuItem
+        onMouseEnter={() => void loadFolderDialog()}
+        onFocus={() => void loadFolderDialog()}
+        onClick={run(onNewChild)}
+      >
+        <ListItemIcon>
+          <CreateNewFolderOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        New folder inside
+      </MenuItem>
+      <MenuItem
+        onMouseEnter={() => void loadFolderDialog()}
+        onFocus={() => void loadFolderDialog()}
+        onClick={run(onEdit)}
+      >
+        <ListItemIcon>
+          <EditOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Rename, move &amp; style…
+      </MenuItem>
+      <MenuItem onClick={run(onCollapseAll)}>
+        <ListItemIcon>
+          <UnfoldLessIcon fontSize="small" />
+        </ListItemIcon>
+        Collapse all inside
+      </MenuItem>
+      <Divider />
+      <MenuItem onClick={run(onDelete)} sx={{ color: 'error.main' }}>
+        <ListItemIcon sx={{ color: 'error.main' }}>
+          <DeleteOutlineIcon fontSize="small" />
+        </ListItemIcon>
+        Delete folder
+      </MenuItem>
+    </Menu>
+  );
+}

--- a/client/src/components/sidebar/FolderDialog.tsx
+++ b/client/src/components/sidebar/FolderDialog.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useApplyFolderMoves } from '../../api/host-groups.js';
+import { useSavedHostProfiles, useSshConfig } from '../../api/queries.js';
+import {
+  folderKey,
+  folderLabel,
+  folderParentPath,
+  folderPath,
+  folderSegments,
+  isDescendantPath,
+  isSamePath,
+  knownFolderPaths,
+  normalizeGroupPath,
+  sanitizeFolderName,
+} from '../../host-tree.js';
+import { managedHostKey } from '../../managed-hosts.js';
+import { showToast } from '../../state/toast.js';
+import { usePrefsStore } from '../../state/prefs.js';
+import { useUiStore } from '../../state/ui.js';
+import { HostColorPicker } from '../HostColorPicker.js';
+import { FolderPathField } from '../FolderPathField.js';
+import { folderIcon, FOLDER_ICONS } from './folder-icons.js';
+import {
+  folderProblemMessage,
+  folderRewritePlan,
+  folderTargetProblem,
+  moveHostPlan,
+} from './folder-mutations.js';
+import { useFolderPrefs } from './useFolderPrefs.js';
+import { useAllManagedHosts } from './useAllManagedHosts.js';
+
+/**
+ * Create, rename, re-parent and style a sidebar folder, and pick the folder a
+ * single host belongs to. All four are the same underlying edit — a rewrite of
+ * one group path — so they share a dialog rather than being three near-copies.
+ */
+export function FolderDialog() {
+  const state = useUiStore((s) => s.folderDialog);
+  const setState = useUiStore((s) => s.setFolderDialog);
+  const folders = useFolderPrefs();
+  const applyMoves = useApplyFolderMoves();
+  const allHosts = useAllManagedHosts();
+  const { data: config } = useSshConfig();
+  const { data: savedData } = useSavedHostProfiles();
+  const emptyFolders = usePrefsStore((s) => s.sidebarEmptyFolders);
+
+  const [name, setName] = useState('');
+  const [parent, setParent] = useState('');
+  const [color, setColor] = useState<string | undefined>();
+  const [icon, setIcon] = useState<string | undefined>();
+
+  // Load the folder's current shape once, when the dialog opens on it.
+  useEffect(() => {
+    if (state === false) return;
+    if (state.mode === 'move-host') {
+      setName('');
+      setParent(state.currentPath);
+      return;
+    }
+    if (state.mode === 'new') {
+      setName('');
+      setParent(state.parentPath ?? '');
+      setColor(undefined);
+      setIcon(undefined);
+      return;
+    }
+    const style = usePrefsStore.getState().sidebarFolderStyles[folderKey(state.path)];
+    setName(folderLabel(state.path));
+    setParent(folderParentPath(state.path));
+    setColor(style?.color);
+    setIcon(style?.icon);
+  }, [state]);
+
+  const movingHost = state !== false && state.mode === 'move-host' ? state : undefined;
+  const mode = state === false ? undefined : state.mode;
+  const sourcePath = state !== false && state.mode === 'edit' ? state.path : '';
+
+  const target = movingHost
+    ? normalizeGroupPath(parent)
+    : folderPath([...folderSegments(parent), sanitizeFolderName(name)]);
+  const problem = movingHost ? undefined : folderTargetProblem(sourcePath, target);
+  const renaming = mode === 'edit' && !!sourcePath && !isSamePath(sourcePath, target);
+  const affected = useMemo(
+    () => (renaming ? folderRewritePlan(allHosts, sourcePath, target) : []),
+    [renaming, allHosts, sourcePath, target],
+  );
+  const merging = useMemo(
+    () =>
+      renaming &&
+      knownFolderPaths(config?.hosts ?? [], savedData?.profiles ?? [], emptyFolders).some((path) =>
+        isSamePath(path, target),
+      ),
+    [renaming, config?.hosts, savedData?.profiles, emptyFolders, target],
+  );
+
+  if (state === false) return null;
+
+  const close = () => setState(false);
+
+  const submit = () => {
+    if (movingHost) {
+      const host = allHosts.find((entry) => managedHostKey(entry) === movingHost.hostKey);
+      if (host) {
+        applyMoves.mutate({ moves: [moveHostPlan(host, target)], label: movingHost.hostName });
+      }
+      close();
+      return;
+    }
+    if (problem) return;
+
+    if (mode === 'new') {
+      folders.addEmptyFolder(target);
+      folders.setFolderStyle(folderKey(target), { color, icon });
+      close();
+      return;
+    }
+
+    // Style first: it is local and instant, so the folder keeps its look while
+    // the hosts underneath it are still moving.
+    folders.setFolderStyle(folderKey(renaming ? target : sourcePath), { color, icon });
+    if (renaming) {
+      folders.renameFolderPrefs(sourcePath, target);
+      folders.removeEmptyFolder(sourcePath);
+      if (affected.length > 0) applyMoves.mutate({ moves: affected, label: target });
+      else folders.addEmptyFolder(target);
+      showToast('success', `Folder renamed to “${target}”.`);
+    }
+    close();
+  };
+
+  const Preview = folderIcon(icon, true);
+  const title = movingHost
+    ? `Move “${movingHost.hostName}”`
+    : mode === 'new'
+      ? 'New folder'
+      : `Edit “${folderLabel(sourcePath)}”`;
+  const parentPreview = folderParentPath(target);
+
+  return (
+    <Dialog open onClose={close} maxWidth="xs" fullWidth>
+      <Box
+        component="form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <DialogTitle sx={{ pb: 0.75 }}>{title}</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2.5 }}>
+            Folders are local to Muxus. They never change your ssh config.
+          </Typography>
+
+          <Stack spacing={2.25}>
+            {!movingHost && (
+              <TextField
+                label="Folder name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                helperText={
+                  name.includes('/')
+                    ? 'A name cannot contain “/” — use the field below to nest.'
+                    : 'The name shown in the sidebar.'
+                }
+                fullWidth
+              />
+            )}
+            <FolderPathField
+              value={parent}
+              onChange={setParent}
+              label={movingHost ? 'Folder' : 'Inside folder'}
+              error={!!problem && problem.kind !== 'empty'}
+              helperText={
+                problem && problem.kind !== 'empty'
+                  ? folderProblemMessage(problem)
+                  : movingHost
+                    ? 'Leave empty to move this host out of every folder.'
+                    : 'Leave empty for a top-level folder.'
+              }
+              exclude={
+                sourcePath
+                  ? (path) => isSamePath(path, sourcePath) || isDescendantPath(path, sourcePath)
+                  : undefined
+              }
+            />
+
+            {!movingHost && (
+              <>
+                <HostColorPicker value={color} onChange={setColor} />
+                <Box>
+                  <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+                    Icon
+                  </Typography>
+                  <Stack direction="row" spacing={0.75} useFlexGap sx={{ flexWrap: 'wrap' }}>
+                    {FOLDER_ICONS.map((entry) => {
+                      const selected = (icon ?? 'folder') === entry.id;
+                      const Glyph = entry.Icon;
+                      return (
+                        <Tooltip key={entry.id} title={entry.label}>
+                          <ButtonBase
+                            aria-label={`${entry.label} folder icon`}
+                            onClick={() => setIcon(entry.id === 'folder' ? undefined : entry.id)}
+                            sx={{
+                              width: 30,
+                              height: 30,
+                              borderRadius: 1,
+                              border: 1,
+                              borderColor: selected ? 'primary.main' : 'divider',
+                              color: selected ? (color ?? 'primary.main') : 'text.secondary',
+                            }}
+                          >
+                            <Glyph sx={{ fontSize: 17 }} />
+                          </ButtonBase>
+                        </Tooltip>
+                      );
+                    })}
+                  </Stack>
+                </Box>
+
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.25,
+                    p: 1.25,
+                    border: 1,
+                    borderColor: 'divider',
+                    borderRadius: 1.5,
+                    bgcolor: 'sidebar',
+                  }}
+                >
+                  <Preview sx={{ fontSize: 18, color: color ?? 'text.secondary' }} />
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
+                      {sanitizeFolderName(name) || 'Folder'}
+                    </Typography>
+                    {parentPreview && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        noWrap
+                        sx={{ display: 'block' }}
+                      >
+                        in {parentPreview.split('/').join(' / ')}
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              </>
+            )}
+
+            {renaming && affected.length > 0 && (
+              <Typography variant="caption" color="text.secondary">
+                {merging
+                  ? `Merges into the existing “${folderLabel(target)}” and moves ${affected.length} host${affected.length === 1 ? '' : 's'}.`
+                  : `Moves ${affected.length} host${affected.length === 1 ? '' : 's'}.`}
+              </Typography>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={close}>Cancel</Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={(!movingHost && !!problem) || applyMoves.isPending}
+          >
+            {movingHost ? 'Move' : mode === 'new' ? 'Create' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+}

--- a/client/src/components/sidebar/FolderDialog.tsx
+++ b/client/src/components/sidebar/FolderDialog.tsx
@@ -88,9 +88,12 @@ export function FolderDialog() {
 
   const target = movingHost
     ? normalizeGroupPath(parent)
-    : folderPath([...folderSegments(parent), sanitizeFolderName(name)]);
+    : normalizeGroupPath(folderPath([...folderSegments(parent), sanitizeFolderName(name)]));
   const problem = movingHost ? undefined : folderTargetProblem(sourcePath, target);
-  const renaming = mode === 'edit' && !!sourcePath && !isSamePath(sourcePath, target);
+  // Exact comparison, not folder identity: two paths that differ only in case
+  // are the same folder, but changing its capitalisation is still a rename and
+  // has to be written out, or the old spelling stays on screen.
+  const renaming = mode === 'edit' && !!sourcePath && target !== normalizeGroupPath(sourcePath);
   const affected = useMemo(
     () => (renaming ? folderRewritePlan(allHosts, sourcePath, target) : []),
     [renaming, allHosts, sourcePath, target],
@@ -98,10 +101,11 @@ export function FolderDialog() {
   const merging = useMemo(
     () =>
       renaming &&
-      knownFolderPaths(config?.hosts ?? [], savedData?.profiles ?? [], emptyFolders).some((path) =>
-        isSamePath(path, target),
+      knownFolderPaths(config?.hosts ?? [], savedData?.profiles ?? [], emptyFolders).some(
+        // Recapitalising a folder lands on itself, which is not a merge.
+        (path) => isSamePath(path, target) && !isSamePath(path, sourcePath),
       ),
-    [renaming, config?.hosts, savedData?.profiles, emptyFolders, target],
+    [renaming, config?.hosts, savedData?.profiles, emptyFolders, target, sourcePath],
   );
 
   if (state === false) return null;
@@ -131,7 +135,11 @@ export function FolderDialog() {
     folders.setFolderStyle(folderKey(renaming ? target : sourcePath), { color, icon });
     if (renaming) {
       folders.renameFolderPrefs(sourcePath, target);
-      folders.removeEmptyFolder(sourcePath);
+      // The rename above already carried the empty-folder markers over. Clearing
+      // the old path is only safe when it is a different folder: paths match
+      // case-insensitively, so after a recapitalisation it would take the marker
+      // it just rewrote — and every marker below it — with it.
+      if (!isSamePath(sourcePath, target)) folders.removeEmptyFolder(sourcePath);
       if (affected.length > 0) applyMoves.mutate({ moves: affected, label: target });
       else folders.addEmptyFolder(target);
       showToast('success', `Folder renamed to “${target}”.`);

--- a/client/src/components/sidebar/FolderRow.tsx
+++ b/client/src/components/sidebar/FolderRow.tsx
@@ -1,0 +1,204 @@
+import type { DragEvent, MouseEvent, ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import ListItemButton from '@mui/material/ListItemButton';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
+import type { VisibleNode } from '../../host-tree.js';
+import { folderIcon } from './folder-icons.js';
+import { TREE_BASE_INSET, indentPx, treeRowSx } from './tree-row-style.js';
+
+export interface FolderRowProps {
+  row: VisibleNode;
+  /** Label to draw; folders show their last segment, file groups their name. */
+  label: string;
+  tooltip?: string;
+  count: number;
+  color?: string;
+  iconId?: string;
+  focused: boolean;
+  /** Highlight the whole row as the "drop inside this folder" target. */
+  dropInto?: boolean;
+  /** Draw the insertion line above or below, for a "place beside" drop. */
+  dropEdge?: 'before' | 'after';
+  onToggle: () => void;
+  /** Alt+Arrow reorder, the keyboard equivalent of dragging this folder. */
+  onMove?: (delta: -1 | 1) => void;
+  onLaunch: () => void;
+  onMenu?: (anchor: HTMLElement, position?: { top: number; left: number }) => void;
+  registerRef: (element: HTMLElement | null) => void;
+  draggable?: boolean;
+  onDragStart?: (event: DragEvent<HTMLElement>) => void;
+  onDragEnd?: () => void;
+  dragging?: boolean;
+}
+
+/**
+ * A folder is a treeitem, not a list subheader: it has to be focusable, carry
+ * aria-expanded, and take drops. The uppercase subheader treatment goes with
+ * it — at four levels deep, letter-spaced caps stop being readable.
+ */
+export function FolderRow({
+  row,
+  label,
+  tooltip,
+  count,
+  color,
+  iconId,
+  focused,
+  dropInto,
+  dropEdge,
+  onToggle,
+  onMove,
+  onLaunch,
+  onMenu,
+  registerRef,
+  draggable,
+  onDragStart,
+  onDragEnd,
+  dragging,
+}: FolderRowProps) {
+  const expanded = row.expanded ?? false;
+  const Icon = folderIcon(iconId, expanded);
+
+  /** Actions inside the row must not start a drag or toggle the folder. */
+  const swallow = (event: MouseEvent) => event.stopPropagation();
+
+  const content: ReactNode = (
+    <ListItemButton
+      component="li"
+      role="treeitem"
+      dense
+      ref={registerRef}
+      data-node-key={row.key}
+      aria-label={label}
+      aria-level={row.level}
+      aria-setsize={row.setSize}
+      aria-posinset={row.posInSet}
+      aria-expanded={expanded}
+      aria-selected={focused}
+      tabIndex={focused ? 0 : -1}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onClick={onToggle}
+      aria-keyshortcuts={onMove ? 'Alt+ArrowUp Alt+ArrowDown' : undefined}
+      onKeyDown={(event) => {
+        if (!onMove || !event.altKey) return;
+        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+        event.preventDefault();
+        event.stopPropagation();
+        onMove(event.key === 'ArrowUp' ? -1 : 1);
+      }}
+      onContextMenu={(event) => {
+        if (!onMenu) return;
+        event.preventDefault();
+        onMenu(event.currentTarget, { top: event.clientY, left: event.clientX });
+      }}
+      sx={[
+        treeRowSx(row.depth, row.railColor),
+        {
+          gap: 0.5,
+          opacity: dragging ? 0.45 : 1,
+          '&:hover .folder-action, & .folder-action:focus-visible': { opacity: 1 },
+          ...(dropInto && {
+            bgcolor: 'action.selected',
+            boxShadow: (theme) => `inset 2px 0 ${theme.palette.primary.main}`,
+          }),
+          ...(dropEdge && {
+            [`&::${dropEdge === 'before' ? 'before' : 'after'}`]: {
+              content: '""',
+              position: 'absolute',
+              // Inset to this row's own indent so the line reads as "at this
+              // level", not "somewhere in the tree".
+              left: indentPx(row.depth),
+              right: TREE_BASE_INSET,
+              [dropEdge === 'before' ? 'top' : 'bottom']: -1,
+              height: 2,
+              borderRadius: 2,
+              bgcolor: 'primary.main',
+              zIndex: 2,
+            },
+          }),
+        },
+      ]}
+    >
+      <ChevronRightIcon
+        sx={{
+          fontSize: 16,
+          flexShrink: 0,
+          color: 'text.disabled',
+          transition: 'transform 150ms ease',
+          transform: expanded || dropInto ? 'rotate(90deg)' : 'none',
+        }}
+      />
+      <Icon sx={{ fontSize: 16, flexShrink: 0, color: color ?? 'text.secondary' }} />
+      <Box
+        component="span"
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 13,
+          fontWeight: 500,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </Box>
+      <Tooltip title={count > 0 ? `Launch all ${count} hosts…` : ''} disableInteractive>
+        <span>
+          <IconButton
+            className="folder-action"
+            size="small"
+            tabIndex={-1}
+            aria-label={`Launch ${label}`}
+            disabled={count === 0}
+            onMouseDown={swallow}
+            onClick={(event) => {
+              swallow(event);
+              onLaunch();
+            }}
+            sx={{ p: 0.125, opacity: { xs: 1, md: 0 }, transition: 'opacity 120ms ease' }}
+          >
+            <PlayArrowOutlinedIcon sx={{ fontSize: 14 }} />
+          </IconButton>
+        </span>
+      </Tooltip>
+      {onMenu && (
+        <IconButton
+          className="folder-action"
+          size="small"
+          tabIndex={-1}
+          aria-label={`Options for ${label}`}
+          onMouseDown={swallow}
+          onClick={(event) => {
+            swallow(event);
+            onMenu(event.currentTarget);
+          }}
+          sx={{ p: 0.125, opacity: { xs: 1, md: 0 }, transition: 'opacity 120ms ease' }}
+        >
+          <MoreVertIcon sx={{ fontSize: 14 }} />
+        </IconButton>
+      )}
+      <Typography
+        component="span"
+        sx={{ fontSize: 11, color: 'text.disabled', minWidth: 14, textAlign: 'right' }}
+      >
+        {count}
+      </Typography>
+    </ListItemButton>
+  );
+
+  return tooltip ? (
+    <Tooltip title={tooltip} placement="right" enterDelay={600} disableInteractive>
+      {content}
+    </Tooltip>
+  ) : (
+    content
+  );
+}

--- a/client/src/components/sidebar/HostContextMenu.tsx
+++ b/client/src/components/sidebar/HostContextMenu.tsx
@@ -1,0 +1,191 @@
+import Divider from '@mui/material/Divider';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import DriveFileMoveOutlinedIcon from '@mui/icons-material/DriveFileMoveOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import LibraryAddOutlinedIcon from '@mui/icons-material/LibraryAddOutlined';
+import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
+import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
+import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import { copyToClipboard } from '../../clipboard.js';
+import { managedHostCopyCommand, type ManagedHost } from '../../managed-hosts.js';
+import {
+  connectManagedHost,
+  openManagedHostInNewWindow,
+} from '../../session-actions.js';
+import {
+  loadFolderDialog,
+  loadHostEditorDialog,
+  loadHostOrganizationDialog,
+  loadTerminalViewImpl,
+} from '../../lazy-features.js';
+import { showToast } from '../../state/toast.js';
+import { useUiStore } from '../../state/ui.js';
+
+export interface HostMenuState {
+  anchor: HTMLElement;
+  position?: { top: number; left: number };
+  host: ManagedHost;
+}
+
+export function HostContextMenu({
+  menu,
+  onClose,
+  canMoveUp,
+  canMoveDown,
+  onMove,
+  onToggleFavorite,
+  onDelete,
+  onMoveToFolder,
+}: {
+  menu: HostMenuState | null;
+  onClose: () => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMove: (delta: -1 | 1) => void;
+  onToggleFavorite: (host: ManagedHost) => void;
+  onDelete: (host: ManagedHost) => void;
+  onMoveToFolder: (host: ManagedHost) => void;
+}) {
+  const setHostEditor = useUiStore((s) => s.setHostEditor);
+  const setHostOrganizer = useUiStore((s) => s.setHostOrganizer);
+  const copyAction = menu ? managedHostCopyCommand(menu.host) : undefined;
+  const favorite = menu?.host.entry.metadata?.favorite ?? false;
+
+  /** Every item closes the menu, so each handler is wrapped once here. */
+  const run = (action: (host: ManagedHost) => void) => () => {
+    if (menu) action(menu.host);
+    onClose();
+  };
+
+  return (
+    <Menu
+      open={!!menu}
+      anchorEl={menu?.position ? undefined : menu?.anchor}
+      anchorReference={menu?.position ? 'anchorPosition' : 'anchorEl'}
+      anchorPosition={menu?.position}
+      onClose={onClose}
+    >
+      <MenuItem
+        onMouseEnter={() => void loadTerminalViewImpl()}
+        onFocus={() => void loadTerminalViewImpl()}
+        onClick={run(connectManagedHost)}
+      >
+        <ListItemIcon>
+          <PlayArrowOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Connect
+      </MenuItem>
+      <MenuItem
+        onMouseEnter={() => void loadTerminalViewImpl()}
+        onFocus={() => void loadTerminalViewImpl()}
+        onClick={run(openManagedHostInNewWindow)}
+      >
+        <ListItemIcon>
+          <OpenInNewOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Open in new window
+      </MenuItem>
+      <MenuItem onClick={run(onToggleFavorite)}>
+        <ListItemIcon>
+          {favorite ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
+        </ListItemIcon>
+        {favorite ? 'Remove from favorites' : 'Add to favorites'}
+      </MenuItem>
+      <MenuItem disabled={!canMoveUp} onClick={run(() => onMove(-1))}>
+        <ListItemIcon>
+          <KeyboardArrowUpIcon fontSize="small" />
+        </ListItemIcon>
+        Move up
+      </MenuItem>
+      <MenuItem disabled={!canMoveDown} onClick={run(() => onMove(1))}>
+        <ListItemIcon>
+          <KeyboardArrowDownIcon fontSize="small" />
+        </ListItemIcon>
+        Move down
+      </MenuItem>
+      <Divider />
+      {/* The keyboard and assistive-tech equivalent of dragging a host into a
+          folder — the tree must not need a mouse to be organized. */}
+      <MenuItem
+        onMouseEnter={() => void loadFolderDialog()}
+        onFocus={() => void loadFolderDialog()}
+        onClick={run(onMoveToFolder)}
+      >
+        <ListItemIcon>
+          <DriveFileMoveOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Move to folder…
+      </MenuItem>
+      <MenuItem
+        onMouseEnter={() => void loadHostOrganizationDialog()}
+        onFocus={() => void loadHostOrganizationDialog()}
+        onClick={run((host) => setHostOrganizer(host.entry))}
+      >
+        <ListItemIcon>
+          <PaletteOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Organize &amp; color…
+      </MenuItem>
+      <MenuItem
+        onMouseEnter={() => void loadHostEditorDialog()}
+        onFocus={() => void loadHostEditorDialog()}
+        onClick={run((host) =>
+          setHostEditor(
+            host.kind === 'ssh'
+              ? { mode: 'edit', entry: host.entry }
+              : { mode: 'edit-profile', entry: host.entry },
+          ),
+        )}
+      >
+        <ListItemIcon>
+          <EditOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Edit host
+      </MenuItem>
+      <MenuItem
+        onMouseEnter={() => void loadHostEditorDialog()}
+        onFocus={() => void loadHostEditorDialog()}
+        onClick={run((host) =>
+          setHostEditor(
+            host.kind === 'ssh'
+              ? { mode: 'duplicate', entry: host.entry }
+              : { mode: 'duplicate-profile', entry: host.entry },
+          ),
+        )}
+      >
+        <ListItemIcon>
+          <LibraryAddOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Duplicate
+      </MenuItem>
+      <MenuItem
+        onClick={run(() => {
+          if (!copyAction) return;
+          void copyToClipboard(copyAction.text).then((ok) => {
+            if (ok) showToast('success', `Copied "${copyAction.text}"`);
+          });
+        })}
+      >
+        <ListItemIcon>
+          <ContentCopyIcon fontSize="small" />
+        </ListItemIcon>
+        {copyAction?.label ?? 'Copy'}
+      </MenuItem>
+      <Divider />
+      <MenuItem onClick={run(onDelete)} sx={{ color: 'error.main' }}>
+        <ListItemIcon sx={{ color: 'error.main' }}>
+          <DeleteOutlineIcon fontSize="small" />
+        </ListItemIcon>
+        Delete host
+      </MenuItem>
+    </Menu>
+  );
+}

--- a/client/src/components/sidebar/HostRow.tsx
+++ b/client/src/components/sidebar/HostRow.tsx
@@ -1,0 +1,217 @@
+import type { DragEvent } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import ListItemButton from '@mui/material/ListItemButton';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import StarIcon from '@mui/icons-material/Star';
+import { folderSegments, type VisibleNode } from '../../host-tree.js';
+import {
+  managedHostAddress,
+  managedHostDisplayName,
+  type ManagedHost,
+} from '../../managed-hosts.js';
+import { loadTerminalViewImpl } from '../../lazy-features.js';
+import { hostKindIcon } from '../host-kind-icon.js';
+import { hostDetailLines } from './host-details.js';
+import { TREE_BASE_INSET, indentPx, treeRowSx } from './tree-row-style.js';
+import type { LiveCounts } from './useLiveHostCounts.js';
+
+export interface HostRowProps {
+  row: VisibleNode;
+  host: ManagedHost;
+  live?: LiveCounts;
+  focused: boolean;
+  onConnect: () => void;
+  onMenu: (host: ManagedHost, anchor: HTMLElement, position?: { top: number; left: number }) => void;
+  onMove: (delta: -1 | 1) => void;
+  reorderEnabled: boolean;
+  registerRef: (element: HTMLElement | null) => void;
+  draggable?: boolean;
+  onDragStart?: (event: DragEvent<HTMLElement>) => void;
+  onDragEnd?: () => void;
+  dragging?: boolean;
+  dropEdge?: 'before' | 'after';
+}
+
+/**
+ * One line per host. The address, jump chain, key and forwards are reference
+ * material you read rather than act on, so they all live in the hover card and
+ * the row spends its width on the name.
+ */
+export function HostRow({
+  row,
+  host,
+  live,
+  focused,
+  onConnect,
+  onMenu,
+  onMove,
+  reorderEnabled,
+  registerRef,
+  draggable,
+  onDragStart,
+  onDragEnd,
+  dragging,
+  dropEdge,
+}: HostRowProps) {
+  const title = managedHostDisplayName(host);
+  const address = managedHostAddress(host);
+  const color = host.entry.metadata?.color;
+  const Icon = hostKindIcon(host.kind === 'ssh' ? 'ssh' : host.entry.kind);
+  const details = hostDetailLines(host);
+  const connected = live?.connected ?? 0;
+  const connecting = live?.connecting ?? 0;
+  const folderPath = folderSegments(host.entry.metadata?.group);
+
+  return (
+    <Tooltip
+      placement="right"
+      enterDelay={400}
+      enterNextDelay={200}
+      disableInteractive
+      title={
+        <Stack spacing={0.25} sx={{ py: 0.25 }}>
+          {folderPath.length > 0 && (
+            <Box sx={{ opacity: 0.6, fontSize: 11 }}>{folderPath.join(' / ')}</Box>
+          )}
+          <Box sx={{ fontWeight: 600 }}>{title}</Box>
+          {address !== title && <Box sx={{ opacity: 0.7 }}>{address}</Box>}
+          {details.length > 0 && (
+            <Stack spacing={0.25} sx={{ pt: 0.5, opacity: 0.7 }}>
+              {details.map((line) => (
+                <Box key={line}>{line}</Box>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      }
+    >
+      <ListItemButton
+        component="li"
+        role="treeitem"
+        dense
+        ref={registerRef}
+        data-node-key={row.key}
+        aria-label={title}
+        aria-level={row.level}
+        aria-setsize={row.setSize}
+        aria-posinset={row.posInSet}
+        aria-selected={focused}
+        tabIndex={focused ? 0 : -1}
+        aria-keyshortcuts={reorderEnabled ? 'Alt+ArrowUp Alt+ArrowDown' : undefined}
+        draggable={draggable}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onMouseEnter={() => void loadTerminalViewImpl()}
+        onFocus={() => void loadTerminalViewImpl()}
+        onClick={onConnect}
+        onKeyDown={(event) => {
+          if (!reorderEnabled || !event.altKey) return;
+          if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+          event.preventDefault();
+          event.stopPropagation();
+          onMove(event.key === 'ArrowUp' ? -1 : 1);
+        }}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          onMenu(host, event.currentTarget, { top: event.clientY, left: event.clientX });
+        }}
+        sx={[
+          treeRowSx(row.depth, row.railColor),
+          {
+            gap: 0.75,
+            opacity: dragging ? 0.45 : 1,
+            cursor: draggable ? 'grab' : 'pointer',
+            // A host's own colour sits at the very edge so it never collides
+            // with the folder rail drawn inside the indent.
+            borderLeft: 3,
+            borderLeftColor: color ?? 'transparent',
+            '&:hover .host-row-menu, & .host-row-menu:focus-visible': { opacity: 1 },
+            ...(dropEdge && {
+              [`&::${dropEdge === 'before' ? 'before' : 'after'}`]: {
+                content: '""',
+                position: 'absolute',
+                left: indentPx(row.depth),
+                right: TREE_BASE_INSET,
+                [dropEdge === 'before' ? 'top' : 'bottom']: -1,
+                height: 2,
+                borderRadius: 2,
+                bgcolor: 'primary.main',
+                zIndex: 2,
+              },
+            }),
+          },
+        ]}
+      >
+        <Box sx={{ position: 'relative', display: 'flex', flexShrink: 0 }}>
+          <Icon sx={{ fontSize: 16, color: color ?? 'text.secondary' }} />
+          {connected + connecting > 0 && (
+            <Box
+              sx={{
+                position: 'absolute',
+                right: -3,
+                bottom: -2,
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                bgcolor: connected > 0 ? 'success.main' : 'warning.main',
+                boxShadow: (theme) => `0 0 0 2px ${theme.palette.sidebar}`,
+                ...(connected === 0 && {
+                  animation: 'muxus-pulse 1.2s ease-in-out infinite',
+                  '@keyframes muxus-pulse': { '50%': { opacity: 0.3 } },
+                }),
+              }}
+            />
+          )}
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 0 }}>
+            <Box
+              component="span"
+              sx={{
+                minWidth: 0,
+                fontSize: 13,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {title}
+            </Box>
+            {host.entry.metadata?.favorite && (
+              <StarIcon sx={{ fontSize: 12, flexShrink: 0, color: 'warning.main' }} />
+            )}
+            {connected > 1 && (
+              <Typography component="span" sx={{ fontSize: 10, flexShrink: 0, color: 'success.main' }}>
+                ×{connected}
+              </Typography>
+            )}
+          </Stack>
+        </Box>
+        <IconButton
+          className="host-row-menu"
+          size="small"
+          edge="end"
+          tabIndex={-1}
+          aria-label={`Options for ${title}`}
+          sx={{
+            flexShrink: 0,
+            p: 0.125,
+            opacity: { xs: 1, md: 0 },
+            transition: 'opacity 120ms ease',
+          }}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onMenu(host, event.currentTarget);
+          }}
+        >
+          <MoreVertIcon sx={{ fontSize: 15 }} />
+        </IconButton>
+      </ListItemButton>
+    </Tooltip>
+  );
+}

--- a/client/src/components/sidebar/HostTree.tsx
+++ b/client/src/components/sidebar/HostTree.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import {
+  flattenVisibleTree,
+  type ContainerNode,
+  type HostTree as HostTreeModel,
+  type VisibleNode,
+} from '../../host-tree.js';
+import { managedHostDisplayName, type ManagedHost } from '../../managed-hosts.js';
+import { FolderRow } from './FolderRow.js';
+import { HostRow } from './HostRow.js';
+import { focusAfterChange } from './tree-navigation.js';
+import { useTreeKeyboard } from './useTreeKeyboard.js';
+import type { LiveCounts } from './useLiveHostCounts.js';
+
+export interface HostTreeProps {
+  tree: HostTreeModel;
+  isExpanded: (key: string) => boolean;
+  setExpanded: (key: string, expanded: boolean) => void;
+  folderColor: (key: string) => string | undefined;
+  folderIconId: (key: string) => string | undefined;
+  liveByKey: Map<string, LiveCounts>;
+  reorderEnabled: boolean;
+  onConnect: (host: ManagedHost) => void;
+  onHostMenu: (
+    host: ManagedHost,
+    anchor: HTMLElement,
+    position?: { top: number; left: number },
+  ) => void;
+  onFolderMenu: (
+    node: ContainerNode,
+    anchor: HTMLElement,
+    position?: { top: number; left: number },
+  ) => void;
+  onLaunch: (node: ContainerNode) => void;
+  onMoveHost: (row: VisibleNode, delta: -1 | 1) => void;
+  onMoveFolder: (row: VisibleNode, delta: -1 | 1) => void;
+  onEscape?: () => void;
+  /** Drag & drop wiring; absent until the tree is interactive. */
+  dnd?: TreeDndBinding;
+}
+
+export interface TreeDndBinding {
+  containerProps: {
+    onDragOver: (event: React.DragEvent<HTMLElement>) => void;
+    onDragLeave: (event: React.DragEvent<HTMLElement>) => void;
+    onDrop: (event: React.DragEvent<HTMLElement>) => void;
+  };
+  draggable: boolean;
+  onDragStart: (event: React.DragEvent<HTMLElement>, row: VisibleNode) => void;
+  onDragEnd: () => void;
+  isDragging: (key: string) => boolean;
+  dropIntoKey?: string;
+  dropEdgeFor: (key: string) => 'before' | 'after' | undefined;
+  /** Folders auto-expanded during a drag, on top of the persisted state. */
+  isDragExpanded: (key: string) => boolean;
+  /** Hit-testing needs the same flattened rows the tree is rendering. */
+  observeRows: (rows: readonly VisibleNode[]) => void;
+  /** True while something is being dragged, so the root target can be shown. */
+  dragging: boolean;
+}
+
+/**
+ * The whole host list as a single flat `role="tree"`. One flattened array backs
+ * rendering, arrow keys, type-ahead and drop hit-testing, so they can never
+ * disagree about what is on screen.
+ */
+export function HostTree({
+  tree,
+  isExpanded,
+  setExpanded,
+  folderColor,
+  folderIconId,
+  liveByKey,
+  reorderEnabled,
+  onConnect,
+  onHostMenu,
+  onFolderMenu,
+  onLaunch,
+  onMoveHost,
+  onMoveFolder,
+  onEscape,
+  dnd,
+}: HostTreeProps) {
+  const [focusedKey, setFocusedKey] = useState<string | undefined>();
+  const refs = useRef(new Map<string, HTMLElement>());
+  const lastIndex = useRef(0);
+
+  // Depend on the callback, not on the binding object: an inline `dnd` prop
+  // would otherwise re-flatten the whole tree on every parent render.
+  const isDragExpanded = dnd?.isDragExpanded;
+  const expandedFor = useCallback(
+    (key: string) => isExpanded(key) || (isDragExpanded?.(key) ?? false),
+    [isExpanded, isDragExpanded],
+  );
+
+  const nodes = useMemo(
+    () => flattenVisibleTree(tree, expandedFor, folderColor),
+    [tree, expandedFor, folderColor],
+  );
+  const labels = useMemo(
+    () =>
+      nodes.map((row) =>
+        row.node.kind === 'host' ? managedHostDisplayName(row.node.host) : row.node.label,
+      ),
+    [nodes],
+  );
+
+  const focusedIndex = nodes.findIndex((row) => row.key === focusedKey);
+  // The first row is the tab stop until something has been focused, so the
+  // tree is always reachable with a single Tab.
+  const activeKey = focusedIndex >= 0 ? focusedKey : nodes[0]?.key;
+
+  useEffect(() => {
+    if (focusedIndex >= 0) lastIndex.current = focusedIndex;
+  }, [focusedIndex]);
+
+  // Drop hit-testing resolves a row key back to its node, so it has to read the
+  // same flattened array this component is rendering.
+  const observeRows = dnd?.observeRows;
+  useEffect(() => observeRows?.(nodes), [observeRows, nodes]);
+
+  // Deleting a host or collapsing its parent must not strand the tab stop on a
+  // row that no longer exists.
+  useEffect(() => {
+    setFocusedKey((current) =>
+      current === undefined ? current : focusAfterChange(nodes, current, lastIndex.current),
+    );
+  }, [nodes]);
+
+  const focusKey = useCallback((key: string) => {
+    setFocusedKey(key);
+    const element = refs.current.get(key);
+    element?.focus();
+    element?.scrollIntoView({ block: 'nearest' });
+  }, []);
+
+  const activate = useCallback(
+    (row: VisibleNode) => {
+      if (row.node.kind === 'host') onConnect(row.node.host);
+      else setExpanded(row.key, !expandedFor(row.key));
+    },
+    [onConnect, setExpanded, expandedFor],
+  );
+
+  const onKeyDown = useTreeKeyboard({
+    nodes,
+    focusedIndex: focusedIndex >= 0 ? focusedIndex : 0,
+    focusKey,
+    setExpanded,
+    activate,
+    labels,
+    onEscape,
+  });
+
+  const registerRef = useCallback(
+    (key: string) => (element: HTMLElement | null) => {
+      if (element) refs.current.set(key, element);
+      else refs.current.delete(key);
+    },
+    [],
+  );
+
+  return (
+    <Box
+      component="ul"
+      role="tree"
+      aria-label="Hosts"
+      // The rows carry the roving tab stop; the container is only ever focused
+      // programmatically, never by tabbing.
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
+      {...dnd?.containerProps}
+      sx={{ m: 0, p: 0, listStyle: 'none' }}
+    >
+      {nodes.map((row) => {
+        const focused = row.key === activeKey;
+        if (row.node.kind === 'host') {
+          const host = row.node.host;
+          return (
+            <HostRow
+              key={row.key}
+              row={row}
+              host={host}
+              live={liveByKey.get(row.key)}
+              focused={focused}
+              onConnect={() => onConnect(host)}
+              onMenu={onHostMenu}
+              onMove={(delta) => onMoveHost(row, delta)}
+              reorderEnabled={reorderEnabled}
+              registerRef={registerRef(row.key)}
+              draggable={dnd?.draggable}
+              onDragStart={dnd ? (event) => dnd.onDragStart(event, row) : undefined}
+              onDragEnd={dnd?.onDragEnd}
+              dragging={dnd?.isDragging(row.key)}
+              dropEdge={dnd?.dropEdgeFor(row.key)}
+            />
+          );
+        }
+
+        const node = row.node;
+        const isFolder = node.kind === 'folder';
+        return (
+          <FolderRow
+            key={row.key}
+            row={row}
+            label={node.label}
+            tooltip={isFolder ? undefined : node.tooltip}
+            count={node.descendantHostCount}
+            color={isFolder ? folderColor(row.key) : undefined}
+            iconId={isFolder ? folderIconId(row.key) : 'server'}
+            focused={focused}
+            dropInto={dnd?.dropIntoKey === row.key}
+            dropEdge={isFolder ? dnd?.dropEdgeFor(row.key) : undefined}
+            onToggle={() => setExpanded(row.key, !expandedFor(row.key))}
+            onMove={
+              isFolder && reorderEnabled ? (delta) => onMoveFolder(row, delta) : undefined
+            }
+            onLaunch={() => onLaunch(node)}
+            onMenu={
+              isFolder
+                ? (anchor, position) => onFolderMenu(node, anchor, position)
+                : undefined
+            }
+            registerRef={registerRef(row.key)}
+            // ssh_config file groups are defined by the config, not by drags.
+            draggable={isFolder && (dnd?.draggable ?? false)}
+            onDragStart={
+              isFolder && dnd ? (event) => dnd.onDragStart(event, row) : undefined
+            }
+            onDragEnd={dnd?.onDragEnd}
+            dragging={dnd?.isDragging(row.key)}
+          />
+        );
+      })}
+      {dnd?.dragging && (
+        <Box
+          component="li"
+          aria-hidden
+          sx={{
+            m: '4px 8px 0',
+            height: 22,
+            borderRadius: 1,
+            border: '1px dashed',
+            borderColor: 'divider',
+            color: 'text.disabled',
+            fontSize: 11,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          Drop here for no folder
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/client/src/components/sidebar/LaunchGroupDialog.tsx
+++ b/client/src/components/sidebar/LaunchGroupDialog.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Typography from '@mui/material/Typography';
+import GridViewOutlinedIcon from '@mui/icons-material/GridViewOutlined';
+import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
+import TabOutlinedIcon from '@mui/icons-material/TabOutlined';
+import TableRowsOutlinedIcon from '@mui/icons-material/TableRowsOutlined';
+import ViewColumnOutlinedIcon from '@mui/icons-material/ViewColumnOutlined';
+import type { ManagedHost } from '../../managed-hosts.js';
+import { launchManagedHostGroup } from '../../session-actions.js';
+import { showToast } from '../../state/toast.js';
+import { useTabsStore, type SessionSetLayout } from '../../state/tabs.js';
+
+/** The set of hosts a launch targets: one folder, one file group, or a subtree. */
+export interface LaunchTarget {
+  label: string;
+  hosts: ManagedHost[];
+}
+
+const LAYOUTS: Array<{ value: SessionSetLayout; label: string; Icon: typeof TabOutlinedIcon }> = [
+  { value: 'tabs', label: 'Tabs', Icon: TabOutlinedIcon },
+  { value: 'columns', label: 'Columns', Icon: ViewColumnOutlinedIcon },
+  { value: 'rows', label: 'Rows', Icon: TableRowsOutlinedIcon },
+  { value: 'grid', label: 'Grid', Icon: GridViewOutlinedIcon },
+];
+
+export function LaunchGroupDialog({
+  target,
+  onClose,
+}: {
+  target: LaunchTarget | null;
+  onClose: () => void;
+}) {
+  const tabs = useTabsStore((s) => s.tabs);
+  const [layout, setLayout] = useState<SessionSetLayout>('tabs');
+
+  // Every launch starts from the default layout rather than the last one used.
+  const open = !!target;
+  useEffect(() => {
+    if (open) setLayout('tabs');
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Launch “{target?.label}”</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Start all {target?.hosts.length ?? 0} hosts and replace the current pane layout.
+        </Typography>
+        <ToggleButtonGroup
+          exclusive
+          fullWidth
+          size="small"
+          value={layout}
+          onChange={(_event, value: SessionSetLayout | null) => {
+            if (value) setLayout(value);
+          }}
+          aria-label="Host group layout"
+        >
+          {LAYOUTS.map(({ value, label, Icon }) => (
+            <ToggleButton key={value} value={value} aria-label={label}>
+              <Stack spacing={0.25} sx={{ alignItems: 'center' }}>
+                <Icon fontSize="small" />
+                <Typography variant="caption">{label}</Typography>
+              </Stack>
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        {tabs.some((tab) => tab.profile && tab.status !== 'closed') ? (
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            Existing live sessions will be closed when this group replaces the current layout.
+          </Alert>
+        ) : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          startIcon={<PlayArrowOutlinedIcon />}
+          disabled={!target?.hosts.length}
+          onClick={() => {
+            if (!target) return;
+            const { hosts, label } = target;
+            void launchManagedHostGroup(hosts, layout).then((ids) => {
+              if (ids.length === 0) return;
+              showToast(
+                'success',
+                `Launching ${ids.length} session${ids.length === 1 ? '' : 's'} from “${label}” in ${layout}.`,
+              );
+              onClose();
+            });
+          }}
+        >
+          Launch group
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/sidebar/SidebarMenus.tsx
+++ b/client/src/components/sidebar/SidebarMenus.tsx
@@ -1,0 +1,30 @@
+import type { ComponentProps } from 'react';
+import { FolderContextMenu } from './FolderContextMenu.js';
+import { HostContextMenu } from './HostContextMenu.js';
+import { LaunchGroupDialog } from './LaunchGroupDialog.js';
+
+/**
+ * The sidebar's on-demand surfaces in one lazy chunk.
+ *
+ * None of them can appear until the user right-clicks a row or asks to launch a
+ * folder, and together they pull in MUI's Menu, Dialog and a dozen icons — so
+ * they stay out of the initial bundle and load on the first hover that could
+ * open them.
+ */
+export function SidebarMenus({
+  host,
+  folder,
+  launch,
+}: {
+  host: ComponentProps<typeof HostContextMenu>;
+  folder: ComponentProps<typeof FolderContextMenu>;
+  launch: ComponentProps<typeof LaunchGroupDialog>;
+}) {
+  return (
+    <>
+      <HostContextMenu {...host} />
+      <FolderContextMenu {...folder} />
+      <LaunchGroupDialog {...launch} />
+    </>
+  );
+}

--- a/client/src/components/sidebar/folder-icons.ts
+++ b/client/src/components/sidebar/folder-icons.ts
@@ -1,0 +1,43 @@
+import type { SvgIconComponent } from '@mui/icons-material';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
+import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined';
+import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+import LanOutlinedIcon from '@mui/icons-material/LanOutlined';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined';
+import RouterOutlinedIcon from '@mui/icons-material/RouterOutlined';
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined';
+import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
+
+/**
+ * A deliberately short list. Every entry ships in the initial bundle, so this
+ * is curated rather than exposing the whole icon set.
+ */
+export const FOLDER_ICONS: ReadonlyArray<{ id: string; label: string; Icon: SvgIconComponent }> = [
+  { id: 'folder', label: 'Folder', Icon: FolderOutlinedIcon },
+  { id: 'cloud', label: 'Cloud', Icon: CloudOutlinedIcon },
+  { id: 'server', label: 'Servers', Icon: DnsOutlinedIcon },
+  { id: 'storage', label: 'Storage', Icon: StorageOutlinedIcon },
+  { id: 'router', label: 'Network', Icon: RouterOutlinedIcon },
+  { id: 'lan', label: 'LAN', Icon: LanOutlinedIcon },
+  { id: 'hub', label: 'Cluster', Icon: HubOutlinedIcon },
+  { id: 'public', label: 'Public', Icon: PublicOutlinedIcon },
+  { id: 'lock', label: 'Secure', Icon: LockOutlinedIcon },
+  { id: 'lab', label: 'Lab', Icon: ScienceOutlinedIcon },
+  { id: 'site', label: 'Site', Icon: WarehouseOutlinedIcon },
+];
+
+const BY_ID = new Map(FOLDER_ICONS.map((entry) => [entry.id, entry.Icon]));
+
+export function isFolderIconId(id: string): boolean {
+  return BY_ID.has(id);
+}
+
+/** The plain folder falls back to open/closed art; named icons do not. */
+export function folderIcon(id: string | undefined, expanded: boolean): SvgIconComponent {
+  if (!id || id === 'folder') return expanded ? FolderOpenOutlinedIcon : FolderOutlinedIcon;
+  return BY_ID.get(id) ?? FolderOutlinedIcon;
+}

--- a/client/src/components/sidebar/folder-mutations.ts
+++ b/client/src/components/sidebar/folder-mutations.ts
@@ -31,7 +31,10 @@ export function folderRewritePlan(
   to: string,
 ): FolderMove[] {
   const target = normalizeGroupPath(to);
-  if (!target || isSamePath(from, target)) return [];
+  // Compared exactly rather than by folder identity: folders match
+  // case-insensitively, but capitalisation is still part of the name, so
+  // "prod" → "Prod" is a rename the sidebar has to carry out.
+  if (!target || target === normalizeGroupPath(from)) return [];
   return hosts.flatMap((host) => {
     const current = host.entry.metadata?.group;
     if (!current) return [];

--- a/client/src/components/sidebar/folder-mutations.ts
+++ b/client/src/components/sidebar/folder-mutations.ts
@@ -1,0 +1,92 @@
+import {
+  folderDepth,
+  folderParentPath,
+  folderPath,
+  folderSegments,
+  isDescendantPath,
+  isSamePath,
+  MAX_FOLDER_DEPTH,
+  MAX_GROUP_PATH,
+  normalizeGroupPath,
+  renameFolderPath,
+} from '../../host-tree.js';
+import type { ManagedHost } from '../../managed-hosts.js';
+
+/** One host's group after a folder operation; null clears it to the root. */
+export interface FolderMove {
+  host: ManagedHost;
+  group: string | null;
+}
+
+/**
+ * Which hosts a rename or re-parent touches, and where each lands.
+ *
+ * Always call this with the *unfiltered* host lists. Computing it from the
+ * filtered sidebar would silently leave every non-matching host behind on the
+ * old path, splitting one folder into two.
+ */
+export function folderRewritePlan(
+  hosts: readonly ManagedHost[],
+  from: string,
+  to: string,
+): FolderMove[] {
+  const target = normalizeGroupPath(to);
+  if (!target || isSamePath(from, target)) return [];
+  return hosts.flatMap((host) => {
+    const current = host.entry.metadata?.group;
+    if (!current) return [];
+    const next = renameFolderPath(current, from, target);
+    return next === undefined || next === current ? [] : [{ host, group: next }];
+  });
+}
+
+/**
+ * Deleting a folder lifts its contents one level up rather than dropping them:
+ * removing `Production/EU` leaves its hosts in `Production` and promotes
+ * `Production/EU/Edge` to `Production/Edge`.
+ */
+export function deleteFolderPlan(hosts: readonly ManagedHost[], path: string): FolderMove[] {
+  const parentSegments = folderSegments(folderParentPath(path));
+  const depth = folderDepth(path);
+  return hosts.flatMap((host) => {
+    const current = host.entry.metadata?.group;
+    if (!current) return [];
+    if (!isSamePath(current, path) && !isDescendantPath(current, path)) return [];
+    const tail = folderSegments(current).slice(depth);
+    return [{ host, group: folderPath([...parentSegments, ...tail]) || null }];
+  });
+}
+
+/** Assign one host to a folder; an empty path moves it to the root. */
+export function moveHostPlan(host: ManagedHost, path: string): FolderMove {
+  return { host, group: normalizeGroupPath(path) || null };
+}
+
+export type FolderProblem =
+  | { kind: 'empty' }
+  | { kind: 'too-deep' }
+  | { kind: 'too-long' }
+  | { kind: 'into-descendant' };
+
+/** Why a folder cannot be renamed or moved to `to`, if it cannot. */
+export function folderTargetProblem(from: string, to: string): FolderProblem | undefined {
+  const target = normalizeGroupPath(to);
+  if (!target) return { kind: 'empty' };
+  if (target.length > MAX_GROUP_PATH) return { kind: 'too-long' };
+  if (folderDepth(target) > MAX_FOLDER_DEPTH) return { kind: 'too-deep' };
+  if (from && isDescendantPath(target, from)) return { kind: 'into-descendant' };
+  return undefined;
+}
+
+export function folderProblemMessage(problem: FolderProblem, name = 'folder'): string {
+  switch (problem.kind) {
+    case 'empty':
+      return 'Enter a folder name.';
+    case 'too-long':
+      return `That path is longer than ${MAX_GROUP_PATH} characters.`;
+    case 'too-deep':
+      return `Folders can nest ${MAX_FOLDER_DEPTH} levels deep.`;
+    case 'into-descendant':
+      return `A ${name} cannot be moved inside itself.`;
+  }
+}

--- a/client/src/components/sidebar/host-details.ts
+++ b/client/src/components/sidebar/host-details.ts
@@ -1,0 +1,25 @@
+import type { ManagedHost } from '../../managed-hosts.js';
+
+/**
+ * What a row deliberately does not draw. Jump chain, key, auth mode and
+ * forwards are reference material, not things you act on from the list, so
+ * they live in the row's hover card instead of as a row of grey glyphs.
+ */
+export function hostDetailLines(host: ManagedHost): string[] {
+  const lines: string[] = [];
+  if (host.kind !== 'ssh') return lines;
+  if (host.entry.description) lines.push(host.entry.description);
+  const resolved = host.entry.resolved;
+  if (!resolved) return lines;
+  if (resolved.proxyJump.length > 0) lines.push(`via ${resolved.proxyJump.join(' → ')}`);
+  if (resolved.identityFiles.length > 0) {
+    lines.push(`Key ${resolved.identityFiles.map((file) => file.split(/[\\/]/).pop()).join(', ')}`);
+  }
+  if (resolved.passwordOnly) lines.push('Password authentication');
+  if (resolved.forwards.length > 0) {
+    lines.push(
+      `${resolved.forwards.length} port forward${resolved.forwards.length > 1 ? 's' : ''} on connect`,
+    );
+  }
+  return lines;
+}

--- a/client/src/components/sidebar/tree-dnd.ts
+++ b/client/src/components/sidebar/tree-dnd.ts
@@ -1,0 +1,168 @@
+import {
+  folderDepth,
+  folderPath,
+  folderSegments,
+  isDescendantPath,
+  isSamePath,
+  MAX_FOLDER_DEPTH,
+  type ContainerNode,
+  type HostTree,
+  type VisibleNode,
+} from '../../host-tree.js';
+
+export type DragSource =
+  | { kind: 'host'; hostKey: string; parentKey: string }
+  | { kind: 'folder'; folderKey: string; path: string };
+
+export type DropTarget =
+  | { kind: 'into-folder'; folderKey: string }
+  | { kind: 'host-edge'; hostKey: string; parentKey: string; edge: 'before' | 'after' }
+  | {
+      kind: 'folder-edge';
+      folderKey: string;
+      /** Parent of the folder being dropped next to; absent means top level. */
+      parentKey?: string;
+      edge: 'before' | 'after';
+    }
+  | { kind: 'root' };
+
+/**
+ * What a pointer at `ratio` down a row means, per node kind. A folder's middle
+ * band drops inside it; its top and bottom quarters place the dragged item
+ * beside it, which is what makes folders manually orderable.
+ */
+export function dropTargetForRow(row: VisibleNode, ratio: number): DropTarget | undefined {
+  if (row.node.kind === 'host') {
+    return {
+      kind: 'host-edge',
+      hostKey: row.key,
+      parentKey: row.node.parentKey,
+      edge: ratio < 0.5 ? 'before' : 'after',
+    };
+  }
+  if (ratio > 0.25 && ratio < 0.75) return { kind: 'into-folder', folderKey: row.key };
+  // ssh_config file groups have no order of their own to join.
+  if (row.node.kind !== 'folder') return { kind: 'root' };
+  return {
+    kind: 'folder-edge',
+    folderKey: row.key,
+    parentKey: row.node.parentKey,
+    edge: ratio <= 0.25 ? 'before' : 'after',
+  };
+}
+
+export function dragSourceForRow(row: VisibleNode): DragSource | undefined {
+  if (row.node.kind === 'host') {
+    return { kind: 'host', hostKey: row.key, parentKey: row.node.parentKey };
+  }
+  // ssh_config file groups belong to the config file, not to the sidebar.
+  if (row.node.kind !== 'folder') return undefined;
+  return { kind: 'folder', folderKey: row.key, path: row.node.path };
+}
+
+/**
+ * The folder path a drop target lands in; '' is the root.
+ *
+ * Undefined rather than '' when the target resolves to an ssh_config file
+ * group: that is not a folder, and nothing may be dropped into it.
+ */
+export function targetPath(target: DropTarget, tree: HostTree): string | undefined {
+  switch (target.kind) {
+    case 'root':
+      return '';
+    case 'into-folder':
+      return tree.foldersByKey.get(target.folderKey)?.path;
+    case 'host-edge':
+      return tree.foldersByKey.get(target.parentKey)?.path;
+    case 'folder-edge':
+      // Beside a top-level folder means joining the top level.
+      return target.parentKey ? tree.foldersByKey.get(target.parentKey)?.path : '';
+  }
+}
+
+export function containerFor(target: DropTarget, tree: HostTree): ContainerNode | undefined {
+  const key =
+    target.kind === 'into-folder'
+      ? target.folderKey
+      : target.kind === 'host-edge' || target.kind === 'folder-edge'
+        ? target.parentKey
+        : undefined;
+  if (!key) return undefined;
+  return tree.foldersByKey.get(key) ?? tree.roots.find((root) => root.key === key);
+}
+
+/**
+ * Whether a drop is allowed. Kept pure and exhaustive because the drag preview
+ * and the commit both have to agree — a target that highlights but refuses on
+ * release reads as a bug.
+ */
+export function canDrop(source: DragSource, target: DropTarget, tree: HostTree): boolean {
+  const destination = targetPath(target, tree);
+
+  if (source.kind === 'host') {
+    if (target.kind === 'host-edge' && target.hostKey === source.hostKey) return false;
+    // Reordering within the container a host already sits in changes no group,
+    // so it stays available even inside a read-only ssh_config file group.
+    if (isPureReorder(source, target)) return true;
+    // Otherwise the host is changing folders, and a file group is not one.
+    return destination !== undefined;
+  }
+
+  if (destination === undefined) return false;
+  const folder = tree.foldersByKey.get(source.folderKey);
+  if (!folder) return false;
+  if (isSamePath(destination, source.path) || isDescendantPath(destination, source.path)) {
+    return false;
+  }
+  // Dropping a folder beside itself would not move it anywhere.
+  if (target.kind === 'folder-edge' && target.folderKey === source.folderKey) return false;
+  // Landing in the parent it already has is a reorder when a position was
+  // named, and a no-op when it was not.
+  const currentParent = folderPath(folderSegments(source.path).slice(0, -1));
+  if (isSamePath(destination, currentParent) && target.kind !== 'folder-edge') return false;
+  return folderDepth(destination) + subtreeHeight(folder) + 1 <= MAX_FOLDER_DEPTH;
+}
+
+/**
+ * The sibling order after dropping a folder beside another. The dragged folder
+ * may arrive from elsewhere, so its old key is removed and its new one — which
+ * differs whenever the drop also re-parents it — is inserted.
+ */
+export function folderOrderAfterDrop(
+  siblingKeys: readonly string[],
+  sourceOldKey: string,
+  sourceNewKey: string,
+  targetKey: string | undefined,
+  edge: 'before' | 'after' = 'after',
+): string[] {
+  const next = siblingKeys.filter((key) => key !== sourceOldKey && key !== sourceNewKey);
+  if (!targetKey) return [...next, sourceNewKey];
+  const index = next.indexOf(targetKey);
+  if (index < 0) return [...next, sourceNewKey];
+  next.splice(index + (edge === 'after' ? 1 : 0), 0, sourceNewKey);
+  return next;
+}
+
+/** A drop that only changes order, never which container the host is in. */
+export function isPureReorder(source: DragSource, target: DropTarget): boolean {
+  if (source.kind !== 'host') return false;
+  if (target.kind === 'host-edge') return target.parentKey === source.parentKey;
+  if (target.kind === 'folder-edge') return target.parentKey === source.parentKey;
+  return target.kind === 'into-folder' && target.folderKey === source.parentKey;
+}
+
+/** Deepest nesting below a folder, in levels; a leaf folder is 0. */
+function subtreeHeight(folder: ContainerNode): number {
+  if (folder.kind !== 'folder') return 0;
+  let deepest = 0;
+  for (const child of folder.children) {
+    if (child.kind === 'folder') deepest = Math.max(deepest, subtreeHeight(child) + 1);
+  }
+  return deepest;
+}
+
+/** The path a dragged folder ends up at, keeping its own name. */
+export function droppedFolderPath(source: DragSource, destination: string): string {
+  if (source.kind !== 'folder') return destination;
+  return folderPath([...folderSegments(destination), ...folderSegments(source.path).slice(-1)]);
+}

--- a/client/src/components/sidebar/tree-dnd.ts
+++ b/client/src/components/sidebar/tree-dnd.ts
@@ -143,6 +143,27 @@ export function folderOrderAfterDrop(
   return next;
 }
 
+/**
+ * Whether two drop targets mean the same landing spot, so a dragover that
+ * resolves to the one already held can leave state untouched.
+ *
+ * Every field that moves the drop has to be compared. Treating two edges of the
+ * same kind as interchangeable would keep the first one the pointer touched and
+ * commit there, wherever the drag was actually released.
+ */
+export function sameTarget(a: DropTarget | null, b: DropTarget): boolean {
+  if (!a || a.kind !== b.kind) return false;
+  if (a.kind === 'into-folder' && b.kind === 'into-folder') return a.folderKey === b.folderKey;
+  if (a.kind === 'host-edge' && b.kind === 'host-edge') {
+    return a.hostKey === b.hostKey && a.edge === b.edge;
+  }
+  if (a.kind === 'folder-edge' && b.kind === 'folder-edge') {
+    return a.folderKey === b.folderKey && a.edge === b.edge;
+  }
+  // Only the root is left, and there is one of it.
+  return true;
+}
+
 /** A drop that only changes order, never which container the host is in. */
 export function isPureReorder(source: DragSource, target: DropTarget): boolean {
   if (source.kind !== 'host') return false;

--- a/client/src/components/sidebar/tree-navigation.ts
+++ b/client/src/components/sidebar/tree-navigation.ts
@@ -1,0 +1,96 @@
+import type { VisibleNode } from '../../host-tree.js';
+
+export type TreeNavKey = 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'Home' | 'End';
+
+export type TreeNavAction =
+  | { kind: 'focus'; index: number }
+  | { kind: 'expand'; key: string }
+  | { kind: 'collapse'; key: string }
+  | { kind: 'none' };
+
+/**
+ * Arrow-key semantics for a flattened tree, per the WAI-ARIA tree pattern.
+ * Kept pure so the behaviour is testable without a DOM.
+ */
+export function treeNavAction(
+  nodes: readonly VisibleNode[],
+  index: number,
+  key: TreeNavKey,
+): TreeNavAction {
+  if (nodes.length === 0) return { kind: 'none' };
+  const current = nodes[index];
+
+  switch (key) {
+    case 'ArrowDown':
+      return index < nodes.length - 1 ? { kind: 'focus', index: index + 1 } : { kind: 'none' };
+    case 'ArrowUp':
+      return index > 0 ? { kind: 'focus', index: index - 1 } : { kind: 'none' };
+    case 'Home':
+      return { kind: 'focus', index: 0 };
+    case 'End':
+      return { kind: 'focus', index: nodes.length - 1 };
+    case 'ArrowRight': {
+      if (!current || current.expanded === undefined) return { kind: 'none' };
+      if (!current.expanded) return { kind: 'expand', key: current.key };
+      // An expanded container's first child is always the next visible row.
+      const child = nodes[index + 1];
+      return child && child.depth > current.depth
+        ? { kind: 'focus', index: index + 1 }
+        : { kind: 'none' };
+    }
+    case 'ArrowLeft': {
+      if (!current) return { kind: 'none' };
+      if (current.expanded) return { kind: 'collapse', key: current.key };
+      const parent = parentIndex(nodes, index);
+      return parent < 0 ? { kind: 'none' } : { kind: 'focus', index: parent };
+    }
+    default:
+      return { kind: 'none' };
+  }
+}
+
+/** Nearest preceding row one level shallower, or -1 at the top level. */
+export function parentIndex(nodes: readonly VisibleNode[], index: number): number {
+  const depth = nodes[index]?.depth;
+  if (depth === undefined || depth === 0) return -1;
+  for (let i = index - 1; i >= 0; i--) {
+    if (nodes[i]!.depth < depth) return i;
+  }
+  return -1;
+}
+
+/**
+ * Type-ahead: the next row after `from` whose label starts with `buffer`,
+ * wrapping around. Returns -1 when nothing matches so the caller can leave
+ * focus alone rather than jumping to the top.
+ */
+export function typeAheadIndex(
+  labels: readonly string[],
+  from: number,
+  buffer: string,
+): number {
+  const needle = buffer.toLocaleLowerCase();
+  if (!needle) return -1;
+  for (let offset = 1; offset <= labels.length; offset++) {
+    const index = (from + offset) % labels.length;
+    if (labels[index]!.toLocaleLowerCase().startsWith(needle)) return index;
+  }
+  // Repeating the same letter cycles; a longer buffer should still match the
+  // row already focused rather than reporting no match at all.
+  return needle.length > 1 && labels[from]?.toLocaleLowerCase().startsWith(needle) ? from : -1;
+}
+
+/**
+ * Where focus should land after the visible rows change. Keeping the same key
+ * wins; otherwise the row that took its place, clamped to the list.
+ */
+export function focusAfterChange(
+  nodes: readonly VisibleNode[],
+  previousKey: string | undefined,
+  previousIndex: number,
+): string | undefined {
+  if (nodes.length === 0) return undefined;
+  if (previousKey && nodes.some((node) => node.key === previousKey)) return previousKey;
+  const clamped = Math.min(Math.max(previousIndex, 0), nodes.length - 1);
+  return nodes[clamped]?.key;
+}

--- a/client/src/components/sidebar/tree-row-style.ts
+++ b/client/src/components/sidebar/tree-row-style.ts
@@ -1,0 +1,76 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+import { MAX_INDENT_DEPTH } from '../../host-tree.js';
+
+/** One entry of an `sx` array: the object or callback form, never an array. */
+type SxEntry = Exclude<SxProps<Theme>, readonly unknown[]>;
+
+/** One line of text, tight enough that nesting still leaves rows on screen. */
+export const TREE_ROW_HEIGHT = 28;
+export const TREE_INDENT_STEP = 14;
+export const TREE_BASE_INSET = 8;
+
+/** Where a row's content starts, clamped so deep trees keep a usable name column. */
+export function indentPx(depth: number): number {
+  return TREE_BASE_INSET + Math.min(depth, MAX_INDENT_DEPTH) * TREE_INDENT_STEP;
+}
+
+/**
+ * Indent guides drawn as stacked gradients rather than nested elements: one
+ * hairline per ancestor, plus a thicker line in the folder's colour for the
+ * nearest coloured one. No extra DOM, and the lines stay pixel-aligned as the
+ * sidebar resizes.
+ */
+export function indentGuides(
+  theme: Theme,
+  depth: number,
+  railColor: string | undefined,
+):
+  | {
+      backgroundImage: string;
+      backgroundRepeat: string;
+      backgroundPosition: string;
+      backgroundSize: string;
+    }
+  | undefined {
+  const levels = Math.min(depth, MAX_INDENT_DEPTH);
+  if (levels === 0) return undefined;
+  const layers: string[] = [];
+  const positions: string[] = [];
+  const sizes: string[] = [];
+  for (let level = 0; level < levels; level++) {
+    // The innermost guide marks this row's own parent, so it carries the colour.
+    const innermost = level === levels - 1;
+    const color = innermost && railColor ? railColor : theme.palette.divider;
+    const width = innermost && railColor ? 2 : 1;
+    layers.push(`linear-gradient(${color}, ${color})`);
+    positions.push(`${TREE_BASE_INSET + level * TREE_INDENT_STEP + 6}px 0`);
+    // Position and size must stay separate properties: packing them into the
+    // `x y / w h` shorthand makes the browser drop backgroundSize, and the
+    // gradient then fills the entire row.
+    sizes.push(`${width}px 100%`);
+  }
+  return {
+    backgroundImage: layers.join(', '),
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: positions.join(', '),
+    backgroundSize: sizes.join(', '),
+  };
+}
+
+/**
+ * Shared geometry for every row in the tree, whatever it holds. Returns the
+ * callback form specifically so callers can put it first in an `sx` array.
+ */
+export function treeRowSx(depth: number, railColor: string | undefined): SxEntry {
+  return (theme) => ({
+    minHeight: TREE_ROW_HEIGHT,
+    py: 0.25,
+    pr: 0.5,
+    pl: `${indentPx(depth)}px`,
+    position: 'relative',
+    userSelect: 'none',
+    contentVisibility: 'auto',
+    containIntrinsicSize: `0 ${TREE_ROW_HEIGHT}px`,
+    ...indentGuides(theme, depth, railColor),
+  });
+}

--- a/client/src/components/sidebar/useAllManagedHosts.ts
+++ b/client/src/components/sidebar/useAllManagedHosts.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useSavedHostProfiles, useSshConfig } from '../../api/queries.js';
+import type { ManagedHost } from '../../managed-hosts.js';
+
+/**
+ * Every host from both sources, unfiltered and ungrouped.
+ *
+ * Folder operations must be planned against this rather than against the
+ * sidebar's filtered tree: rewriting a path from a filtered list would leave
+ * every host the filter hid behind on the old path, splitting one folder in two.
+ */
+export function useAllManagedHosts(): ManagedHost[] {
+  const { data: config } = useSshConfig();
+  const { data: savedData } = useSavedHostProfiles();
+  return useMemo(
+    () => [
+      ...(config?.hosts ?? []).map((entry) => ({ kind: 'ssh' as const, entry })),
+      ...(savedData?.profiles ?? []).map((entry) => ({ kind: 'profile' as const, entry })),
+    ],
+    [config?.hosts, savedData?.profiles],
+  );
+}

--- a/client/src/components/sidebar/useFolderPrefs.ts
+++ b/client/src/components/sidebar/useFolderPrefs.ts
@@ -1,0 +1,158 @@
+import { useCallback, useMemo } from 'react';
+import {
+  folderKey,
+  isDescendantPath,
+  isSamePath,
+  normalizeGroupPath,
+  renameFolderPath,
+} from '../../host-tree.js';
+import { usePrefsStore, type FolderStyle } from '../../state/prefs.js';
+
+export interface FolderPrefs {
+  /** Collapsed folder keys, as a set for the flattener. */
+  collapsedKeys: Set<string>;
+  /** A folder absent from the collapsed set is expanded, so new ones open. */
+  isExpanded: (key: string) => boolean;
+  toggleFolder: (key: string) => void;
+  setCollapsed: (key: string, collapsed: boolean) => void;
+  folderStyle: (key: string) => FolderStyle | undefined;
+  setFolderStyle: (key: string, style: FolderStyle | undefined) => void;
+  /** Manual sibling order under a parent key, or undefined for alphabetical. */
+  folderOrder: (parentKey: string) => readonly string[] | undefined;
+  setFolderOrder: (parentKey: string, keys: readonly string[]) => void;
+  emptyFolders: string[];
+  addEmptyFolder: (path: string) => void;
+  removeEmptyFolder: (path: string) => void;
+  /** Carry collapse state, colours and empty markers across a folder rename. */
+  renameFolderPrefs: (from: string, to: string) => void;
+}
+
+export function useFolderPrefs(): FolderPrefs {
+  // Selectors return the stored arrays and records verbatim: zustand v5
+  // compares with Object.is, so deriving here would allocate every render.
+  const collapsedFolders = usePrefsStore((state) => state.sidebarCollapsedFolders);
+  const folderStyles = usePrefsStore((state) => state.sidebarFolderStyles);
+  const folderOrders = usePrefsStore((state) => state.sidebarFolderOrder);
+  const emptyFolders = usePrefsStore((state) => state.sidebarEmptyFolders);
+  const set = usePrefsStore((state) => state.set);
+
+  const collapsedKeys = useMemo(() => new Set(collapsedFolders), [collapsedFolders]);
+
+  const setCollapsed = useCallback(
+    (key: string, collapsed: boolean) => {
+      const current = usePrefsStore.getState().sidebarCollapsedFolders;
+      const has = current.includes(key);
+      if (has === collapsed) return;
+      set({
+        sidebarCollapsedFolders: collapsed
+          ? [...current, key]
+          : current.filter((entry) => entry !== key),
+      });
+    },
+    [set],
+  );
+
+  const toggleFolder = useCallback(
+    (key: string) => setCollapsed(key, !usePrefsStore.getState().sidebarCollapsedFolders.includes(key)),
+    [setCollapsed],
+  );
+
+  const setFolderStyle = useCallback(
+    (key: string, style: FolderStyle | undefined) => {
+      const current = usePrefsStore.getState().sidebarFolderStyles;
+      const next = { ...current };
+      if (!style || (!style.color && !style.icon)) delete next[key];
+      else next[key] = style;
+      set({ sidebarFolderStyles: next });
+    },
+    [set],
+  );
+
+  const setFolderOrder = useCallback(
+    (parentKey: string, keys: readonly string[]) => {
+      const current = usePrefsStore.getState().sidebarFolderOrder;
+      set({ sidebarFolderOrder: { ...current, [parentKey]: [...keys] } });
+    },
+    [set],
+  );
+
+  const addEmptyFolder = useCallback(
+    (path: string) => {
+      const normalized = normalizeGroupPath(path);
+      if (!normalized) return;
+      const current = usePrefsStore.getState().sidebarEmptyFolders;
+      if (current.some((entry) => isSamePath(entry, normalized))) return;
+      set({ sidebarEmptyFolders: [...current, normalized] });
+    },
+    [set],
+  );
+
+  const removeEmptyFolder = useCallback(
+    (path: string) => {
+      const current = usePrefsStore.getState().sidebarEmptyFolders;
+      const next = current.filter(
+        (entry) => !isSamePath(entry, path) && !isDescendantPath(entry, path),
+      );
+      if (next.length !== current.length) set({ sidebarEmptyFolders: next });
+    },
+    [set],
+  );
+
+  /**
+   * Rewrites the folder itself and everything under it. Running this before the
+   * network call keeps a renamed folder's colour and expansion in place while
+   * the host list reflows underneath it.
+   */
+  const renameFolderPrefs = useCallback(
+    (from: string, to: string) => {
+      const state = usePrefsStore.getState();
+      const target = normalizeGroupPath(to);
+      // A folder key is its lowercased path, so descendants can be rewritten in
+      // key space. The trailing separator keeps this segment-safe: the key for
+      // "Production" does not start with "folder:prod/".
+      const fromKey = folderKey(from);
+      const toKey = folderKey(target);
+      const remapKey = (key: string): string =>
+        key === fromKey
+          ? toKey
+          : key.startsWith(`${fromKey}/`)
+            ? `${toKey}${key.slice(fromKey.length)}`
+            : key;
+      set({
+        sidebarCollapsedFolders: [...new Set(state.sidebarCollapsedFolders.map(remapKey))],
+        sidebarFolderStyles: Object.fromEntries(
+          Object.entries(state.sidebarFolderStyles).map(([key, style]) => [remapKey(key), style]),
+        ),
+        // Both sides of the order map hold folder keys: the parent it is stored
+        // under, and every sibling listed inside it.
+        sidebarFolderOrder: Object.fromEntries(
+          Object.entries(state.sidebarFolderOrder).map(([parentKey, keys]) => [
+            remapKey(parentKey),
+            keys.map(remapKey),
+          ]),
+        ),
+        sidebarEmptyFolders: [
+          ...new Set(
+            state.sidebarEmptyFolders.map((path) => renameFolderPath(path, from, target) ?? path),
+          ),
+        ],
+      });
+    },
+    [set],
+  );
+
+  return {
+    collapsedKeys,
+    isExpanded: useCallback((key: string) => !collapsedKeys.has(key), [collapsedKeys]),
+    toggleFolder,
+    setCollapsed,
+    folderStyle: useCallback((key: string) => folderStyles[key], [folderStyles]),
+    setFolderStyle,
+    folderOrder: useCallback((parentKey: string) => folderOrders[parentKey], [folderOrders]),
+    setFolderOrder,
+    emptyFolders,
+    addEmptyFolder,
+    removeEmptyFolder,
+    renameFolderPrefs,
+  };
+}

--- a/client/src/components/sidebar/useLiveHostCounts.ts
+++ b/client/src/components/sidebar/useLiveHostCounts.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import { useTabsStore } from '../../state/tabs.js';
+
+export interface LiveCounts {
+  connected: number;
+  connecting: number;
+}
+
+/** Live session dots keyed like managedHostKey: connected/connecting tab counts. */
+export function useLiveHostCounts(): Map<string, LiveCounts> {
+  const tabs = useTabsStore((s) => s.tabs);
+  return useMemo(() => {
+    const map = new Map<string, LiveCounts>();
+    for (const tab of tabs) {
+      if (!tab.profile) continue;
+      const key =
+        tab.profile.kind === 'ssh'
+          ? `ssh:${tab.profile.target}`
+          : tab.profile.kind === 'telnet' || tab.profile.kind === 'serial'
+            ? tab.profile.profileId && `profile:${tab.profile.profileId}`
+            : undefined;
+      if (!key) continue;
+      const entry = map.get(key) ?? { connected: 0, connecting: 0 };
+      if (tab.status === 'connected') entry.connected++;
+      if (tab.status === 'connecting') entry.connecting++;
+      map.set(key, entry);
+    }
+    return map;
+  }, [tabs]);
+}

--- a/client/src/components/sidebar/useTreeDnd.ts
+++ b/client/src/components/sidebar/useTreeDnd.ts
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
+import {
+  folderKey,
+  rootFolderKeys,
+  siblingFolderKeys,
+  siblingHostKeys,
+  TREE_ROOT_KEY,
+  type HostTree,
+  type VisibleNode,
+} from '../../host-tree.js';
+import type { TreeDndBinding } from './HostTree.js';
+import {
+  canDrop,
+  containerFor,
+  dragSourceForRow,
+  dropTargetForRow,
+  droppedFolderPath,
+  folderOrderAfterDrop,
+  isPureReorder,
+  targetPath,
+  type DragSource,
+  type DropTarget,
+} from './tree-dnd.js';
+
+/** Where a dragged folder lands among its new siblings. */
+export interface FolderPlacement {
+  parentKey: string;
+  keys: string[];
+}
+
+/** Long enough not to fire while passing over, short enough to feel intentional. */
+const AUTO_EXPAND_MS = 500;
+
+export interface TreeDndOptions {
+  tree: HostTree;
+  enabled: boolean;
+  /**
+   * Settle a host's order among its new siblings. `path` is the folder it moves
+   * into ('' clears the folder); `undefined` means the container did not change
+   * and only the order should be written.
+   */
+  onDropHost: (hostKey: string, path: string | undefined, siblingOrder: string[]) => void;
+  /**
+   * Re-parent a whole folder subtree, and settle its position among its new
+   * siblings when the drop named one. `fromPath === toPath` is a pure reorder.
+   */
+  onDropFolder: (fromPath: string, toPath: string, placement?: FolderPlacement) => void;
+  hostOrderAfterDrop: (
+    keys: readonly string[],
+    sourceKey: string,
+    targetKey: string | undefined,
+    edge: 'before' | 'after',
+  ) => string[];
+}
+
+export interface TreeDnd {
+  binding: TreeDndBinding | undefined;
+  /** Rendered by the sidebar under the tree while a drag is in flight. */
+  dragging: boolean;
+}
+
+/**
+ * Drag and drop for the host tree.
+ *
+ * One set of listeners lives on the tree container rather than on every row:
+ * per-row dragleave handlers flicker as the pointer crosses child elements, and
+ * a few hundred of them is a lot of listeners for a list this long.
+ */
+export function useTreeDnd({
+  tree,
+  enabled,
+  onDropHost,
+  onDropFolder,
+  hostOrderAfterDrop,
+}: TreeDndOptions): TreeDnd {
+  const [source, setSource] = useState<DragSource | null>(null);
+  const [target, setTarget] = useState<DropTarget | null>(null);
+  const [dragExpanded, setDragExpanded] = useState<ReadonlySet<string>>(new Set());
+  const rowsRef = useRef<readonly VisibleNode[]>([]);
+  const expandTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const clearTimer = () => {
+    if (expandTimer.current === undefined) return;
+    clearTimeout(expandTimer.current);
+    expandTimer.current = undefined;
+  };
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setSource(null);
+    setTarget(null);
+    // Folders opened only to look inside during a drag close again: an
+    // accidental hover must not permanently change what the sidebar shows.
+    setDragExpanded(new Set());
+  }, []);
+
+  useEffect(() => clearTimer, []);
+
+  /**
+   * Which row the pointer is over, resolved purely from geometry.
+   *
+   * `event.target` is not trustworthy during a drag: Chrome keeps reporting the
+   * element the drag last settled on, so a pointer sitting over one row can
+   * arrive carrying another. Measuring against the rows' own boxes is the only
+   * reading that always matches what the user sees under the cursor.
+   */
+  const rowFromEvent = useCallback(
+    (event: DragEvent<HTMLElement>): { row: VisibleNode; ratio: number } | undefined => {
+      const element = nearestRow(event.currentTarget, event.clientY);
+      if (!element) return undefined;
+      const row = rowsRef.current.find((candidate) => candidate.key === element.dataset.nodeKey);
+      if (!row) return undefined;
+      const rect = element.getBoundingClientRect();
+      if (rect.height <= 0) return { row, ratio: 0.5 };
+      // Clamped only for the couple of pixels of gap between adjacent rows.
+      const ratio = Math.min(Math.max((event.clientY - rect.top) / rect.height, 0), 1);
+      return { row, ratio };
+    },
+    [],
+  );
+
+  const onDragStart = useCallback((event: DragEvent<HTMLElement>, row: VisibleNode) => {
+    const next = dragSourceForRow(row);
+    if (!next) {
+      event.preventDefault();
+      return;
+    }
+    event.dataTransfer.effectAllowed = 'move';
+    // getData is unreadable during dragover in every browser, so the source
+    // lives in state; this payload is only for the drag image and stray drops.
+    event.dataTransfer.setData('text/plain', row.key);
+    setSource(next);
+    setTarget(null);
+  }, []);
+
+  const onDragOver = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      if (!source) return;
+      const hit = rowFromEvent(event);
+      const next = hit ? dropTargetForRow(hit.row, hit.ratio) : { kind: 'root' as const };
+      if (!next || !canDrop(source, next, tree)) {
+        clearTimer();
+        setTarget((current) => (current ? null : current));
+        return;
+      }
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+      setTarget((current) => (sameTarget(current, next) ? current : next));
+
+      // Hovering a collapsed folder opens it so its children become targets.
+      if (next.kind !== 'into-folder' || dragExpanded.has(next.folderKey)) return;
+      const row = rowsRef.current.find((candidate) => candidate.key === next.folderKey);
+      if (row?.expanded !== false) return;
+      if (expandTimer.current !== undefined) return;
+      expandTimer.current = setTimeout(() => {
+        expandTimer.current = undefined;
+        setDragExpanded((current) => new Set([...current, next.folderKey]));
+      }, AUTO_EXPAND_MS);
+    },
+    [source, tree, rowFromEvent, dragExpanded],
+  );
+
+  const onDragLeave = useCallback((event: DragEvent<HTMLElement>) => {
+    const related = event.relatedTarget;
+    if (related instanceof Node && event.currentTarget.contains(related)) return;
+    clearTimer();
+    setTarget(null);
+  }, []);
+
+  const onDrop = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      event.preventDefault();
+      if (!source || !target || !canDrop(source, target, tree)) {
+        reset();
+        return;
+      }
+      const destination = targetPath(target, tree);
+
+      if (source.kind === 'folder') {
+        if (destination !== undefined) {
+          const toPath = droppedFolderPath(source, destination);
+          // Only an edge drop names a position; dropping inside a folder just
+          // joins it and sorts alphabetically among its unplaced siblings.
+          let placement: FolderPlacement | undefined;
+          if (target.kind === 'folder-edge') {
+            const container = containerFor(target, tree);
+            placement = {
+              parentKey: container ? container.key : TREE_ROOT_KEY,
+              keys: folderOrderAfterDrop(
+                container ? siblingFolderKeys(container) : rootFolderKeys(tree),
+                source.folderKey,
+                folderKey(toPath),
+                target.folderKey,
+                target.edge,
+              ),
+            };
+          }
+          onDropFolder(source.path, toPath, placement);
+        }
+        reset();
+        return;
+      }
+
+      // The order the host settles into among its new siblings. Dropping onto
+      // the folder itself appends; dropping on an edge inserts there.
+      const container = containerFor(target, tree);
+      const siblings = container ? siblingHostKeys(container) : [];
+      const order = hostOrderAfterDrop(
+        siblings,
+        source.hostKey,
+        target.kind === 'host-edge' ? target.hostKey : undefined,
+        target.kind === 'host-edge' ? target.edge : 'after',
+      );
+      onDropHost(source.hostKey, isPureReorder(source, target) ? undefined : destination, order);
+      reset();
+    },
+    [source, target, tree, onDropHost, onDropFolder, hostOrderAfterDrop, reset],
+  );
+
+  const observeRows = useCallback((rows: readonly VisibleNode[]) => {
+    rowsRef.current = rows;
+  }, []);
+  const isDragExpanded = useCallback((key: string) => dragExpanded.has(key), [dragExpanded]);
+  const isDragging = useCallback(
+    (key: string) =>
+      !!source && (source.kind === 'host' ? source.hostKey : source.folderKey) === key,
+    [source],
+  );
+  const dropEdgeFor = useCallback(
+    (key: string) => {
+      if (target?.kind === 'host-edge' && target.hostKey === key) return target.edge;
+      if (target?.kind === 'folder-edge' && target.folderKey === key) return target.edge;
+      return undefined;
+    },
+    [target],
+  );
+
+  const binding = useMemo<TreeDndBinding | undefined>(
+    () =>
+      enabled
+        ? {
+            containerProps: { onDragOver, onDragLeave, onDrop },
+            draggable: true,
+            onDragStart,
+            onDragEnd: reset,
+            isDragging,
+            dropIntoKey: target?.kind === 'into-folder' ? target.folderKey : undefined,
+            dropEdgeFor,
+            isDragExpanded,
+            observeRows,
+            dragging: !!source,
+          }
+        : undefined,
+    [
+      enabled,
+      onDragOver,
+      onDragLeave,
+      onDrop,
+      onDragStart,
+      reset,
+      isDragging,
+      target,
+      dropEdgeFor,
+      isDragExpanded,
+      observeRows,
+      source,
+    ],
+  );
+
+  return { binding, dragging: !!source };
+}
+
+/** The row whose box is closest to `clientY`, within a row's height. */
+function nearestRow(container: HTMLElement, clientY: number): HTMLElement | undefined {
+  let best: { element: HTMLElement; distance: number } | undefined;
+  for (const element of container.querySelectorAll<HTMLElement>('[data-node-key]')) {
+    const rect = element.getBoundingClientRect();
+    const distance =
+      clientY < rect.top ? rect.top - clientY : clientY > rect.bottom ? clientY - rect.bottom : 0;
+    if (!best || distance < best.distance) best = { element, distance };
+    if (distance === 0) break;
+  }
+  // Past the end of the list means the root, not the last row.
+  return best && best.distance <= 4 ? best.element : undefined;
+}
+
+function sameTarget(a: DropTarget | null, b: DropTarget): boolean {
+  if (!a || a.kind !== b.kind) return false;
+  if (a.kind === 'into-folder' && b.kind === 'into-folder') return a.folderKey === b.folderKey;
+  if (a.kind === 'host-edge' && b.kind === 'host-edge') {
+    return a.hostKey === b.hostKey && a.edge === b.edge;
+  }
+  return true;
+}

--- a/client/src/components/sidebar/useTreeDnd.ts
+++ b/client/src/components/sidebar/useTreeDnd.ts
@@ -17,6 +17,7 @@ import {
   droppedFolderPath,
   folderOrderAfterDrop,
   isPureReorder,
+  sameTarget,
   targetPath,
   type DragSource,
   type DropTarget,
@@ -282,13 +283,4 @@ function nearestRow(container: HTMLElement, clientY: number): HTMLElement | unde
   }
   // Past the end of the list means the root, not the last row.
   return best && best.distance <= 4 ? best.element : undefined;
-}
-
-function sameTarget(a: DropTarget | null, b: DropTarget): boolean {
-  if (!a || a.kind !== b.kind) return false;
-  if (a.kind === 'into-folder' && b.kind === 'into-folder') return a.folderKey === b.folderKey;
-  if (a.kind === 'host-edge' && b.kind === 'host-edge') {
-    return a.hostKey === b.hostKey && a.edge === b.edge;
-  }
-  return true;
 }

--- a/client/src/components/sidebar/useTreeKeyboard.ts
+++ b/client/src/components/sidebar/useTreeKeyboard.ts
@@ -1,0 +1,92 @@
+import { useCallback, useRef, type KeyboardEvent } from 'react';
+import type { VisibleNode } from '../../host-tree.js';
+import { treeNavAction, typeAheadIndex, type TreeNavKey } from './tree-navigation.js';
+
+const NAV_KEYS = new Set<string>([
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Home',
+  'End',
+]);
+
+/** Long enough to type a word, short enough that a pause starts a new search. */
+const TYPE_AHEAD_RESET_MS = 700;
+
+export interface TreeKeyboardOptions {
+  nodes: readonly VisibleNode[];
+  focusedIndex: number;
+  focusKey: (key: string) => void;
+  setExpanded: (key: string, expanded: boolean) => void;
+  /** Enter/Space on a row: connect a host, toggle a container. */
+  activate: (row: VisibleNode) => void;
+  /** Labels aligned with `nodes`, for type-ahead. */
+  labels: readonly string[];
+  onEscape?: () => void;
+}
+
+/**
+ * Tree keyboard handling for the container element. Every decision comes from
+ * `tree-navigation.ts`; this only owns focus effects and the type-ahead timer.
+ */
+export function useTreeKeyboard({
+  nodes,
+  focusedIndex,
+  focusKey,
+  setExpanded,
+  activate,
+  labels,
+  onEscape,
+}: TreeKeyboardOptions) {
+  const buffer = useRef({ text: '', at: 0 });
+
+  return useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      const index = Math.max(focusedIndex, 0);
+      const current = nodes[index];
+
+      if (NAV_KEYS.has(event.key)) {
+        // Alt+Arrow is the host reorder shortcut and belongs to the row.
+        if (event.altKey || event.ctrlKey || event.metaKey) return;
+        const action = treeNavAction(nodes, index, event.key as TreeNavKey);
+        if (action.kind === 'none') {
+          // Still swallow it: an arrow key must never scroll the sidebar out
+          // from under the row that has focus.
+          event.preventDefault();
+          return;
+        }
+        event.preventDefault();
+        if (action.kind === 'focus') focusKey(nodes[action.index]!.key);
+        else setExpanded(action.key, action.kind === 'expand');
+        return;
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        if (!current || event.altKey || event.ctrlKey || event.metaKey) return;
+        event.preventDefault();
+        activate(current);
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        if (!onEscape) return;
+        event.preventDefault();
+        onEscape();
+        return;
+      }
+
+      // Type-ahead: single printable characters only, so shortcuts still work.
+      if (event.key.length !== 1 || event.ctrlKey || event.metaKey || event.altKey) return;
+      const now = event.timeStamp;
+      const fresh = now - buffer.current.at > TYPE_AHEAD_RESET_MS;
+      const text = (fresh ? '' : buffer.current.text) + event.key;
+      buffer.current = { text, at: now };
+      const match = typeAheadIndex(labels, index, text);
+      if (match < 0) return;
+      event.preventDefault();
+      focusKey(nodes[match]!.key);
+    },
+    [nodes, focusedIndex, focusKey, setExpanded, activate, labels, onEscape],
+  );
+}

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -22,7 +22,8 @@ import {
   MIN_SIDEBAR_WIDTH,
 } from './sidebar-width.js';
 import { MIN_SFTP_PANEL_WIDTH } from './sftp-panel-width.js';
-import { usePrefsStore, type PrefsState } from './state/prefs.js';
+import { usePrefsStore, type FolderStyle, type PrefsState } from './state/prefs.js';
+import { isFolderIconId } from './components/sidebar/folder-icons.js';
 
 export const BACKUP_FORMAT = 'muxus-backup';
 export const TRANSFER_VERSION = 1;
@@ -48,6 +49,10 @@ const PREFERENCE_KEYS = [
   'keywordHighlights',
   'sidebarCollapsed',
   'sidebarWidth',
+  'sidebarCollapsedFolders',
+  'sidebarFolderStyles',
+  'sidebarFolderOrder',
+  'sidebarEmptyFolders',
   'sftpPanelWidth',
 ] as const satisfies readonly (keyof PrefsState)[];
 
@@ -536,7 +541,12 @@ function portableTunnelInput(tunnel: TunnelRecord): Omit<TunnelRecord, 'createdA
   return input;
 }
 
-function sanitizePreferences(input: BackupPreferences): Partial<PrefsState> {
+/**
+ * The second half of the restore barrier, next to `parseTransferDocument`:
+ * structure is validated there, individual values here. Anything that fails
+ * is dropped rather than rejecting the whole backup.
+ */
+export function sanitizePreferences(input: BackupPreferences): Partial<PrefsState> {
   const output: Partial<PrefsState> = {};
   if (['light', 'dark', 'os'].includes(input.themeMode)) {
     output.themeMode = input.themeMode;
@@ -606,11 +616,51 @@ function sanitizePreferences(input: BackupPreferences): Partial<PrefsState> {
   if (finiteRange(input.sftpPanelWidth, MIN_SFTP_PANEL_WIDTH, 1200)) {
     output.sftpPanelWidth = input.sftpPanelWidth;
   }
+  if (boundedPathList(input.sidebarCollapsedFolders)) {
+    output.sidebarCollapsedFolders = input.sidebarCollapsedFolders;
+  }
+  if (boundedPathList(input.sidebarEmptyFolders)) {
+    output.sidebarEmptyFolders = input.sidebarEmptyFolders;
+  }
+  if (validFolderStyles(input.sidebarFolderStyles)) {
+    output.sidebarFolderStyles = input.sidebarFolderStyles;
+  }
+  if (validFolderOrder(input.sidebarFolderOrder)) {
+    output.sidebarFolderOrder = input.sidebarFolderOrder;
+  }
   return output;
+}
+
+function validFolderOrder(value: unknown): value is Record<string, string[]> {
+  if (!isRecord(value) || Object.keys(value).length > 500) return false;
+  return Object.entries(value).every(
+    ([key, keys]) => key.length <= 400 && boundedPathList(keys),
+  );
 }
 
 function finiteRange(value: unknown, min: number, max: number): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max;
+}
+
+/** Folder keys and paths: bounded in both count and length. */
+function boundedPathList(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= 500 &&
+    value.every((entry) => typeof entry === 'string' && entry.length <= 400)
+  );
+}
+
+function validFolderStyles(value: unknown): value is Record<string, FolderStyle> {
+  if (!isRecord(value) || Object.keys(value).length > 500) return false;
+  return Object.entries(value).every(
+    ([key, style]) =>
+      key.length <= 400 &&
+      isRecord(style) &&
+      (style.color === undefined || validHexColor(style.color)) &&
+      (style.icon === undefined ||
+        (typeof style.icon === 'string' && isFolderIconId(style.icon))),
+  );
 }
 
 function validateConnections(data: Record<string, unknown>): void {

--- a/client/src/host-tree.ts
+++ b/client/src/host-tree.ts
@@ -1,0 +1,452 @@
+import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
+import {
+  knownHostGroups,
+  managedHostKey,
+  type ManagedHost,
+  type ManagedHostGroup,
+} from './managed-hosts.js';
+
+/**
+ * Folders are not a separate record type: a host's Muxus group string *is* its
+ * folder path, with `/` between levels. Nesting therefore needs no schema
+ * change, no new endpoint, and no migration — `Production/EU/Edge` is just a
+ * group name that this module knows how to read as three levels.
+ */
+export const FOLDER_SEPARATOR = '/';
+
+/** Deeper than this and the path stops being a useful organizational tool. */
+export const MAX_FOLDER_DEPTH = 8;
+
+/** Mirrors the server's `group` cap so the UI can refuse before the round trip. */
+export const MAX_GROUP_PATH = 300;
+
+/** How far rows keep indenting; deeper folders render at this level. */
+export const MAX_INDENT_DEPTH = 5;
+
+/** Stands in for "no parent" when keying the top level's manual order. */
+export const TREE_ROOT_KEY = 'root';
+
+export interface FolderNode {
+  kind: 'folder';
+  /** `folder:production/eu` — lowercased, so casing edits keep their identity. */
+  key: string;
+  /** Canonical display path, e.g. `Production/EU`. */
+  path: string;
+  /** Last segment only. */
+  label: string;
+  depth: number;
+  parentKey?: string;
+  children: TreeNode[];
+  descendantHostCount: number;
+  /** No host anywhere below — the folder exists only because prefs remember it. */
+  empty: boolean;
+}
+
+export interface HostNode {
+  kind: 'host';
+  key: string;
+  host: ManagedHost;
+  depth: number;
+  parentKey: string;
+}
+
+/**
+ * A group that came from an ssh_config file rather than a Muxus group. These
+ * stay flat and read-only: their membership is decided by the config file, not
+ * by anything the user can drag.
+ */
+export interface FileGroupNode {
+  kind: 'file';
+  key: string;
+  label: string;
+  tooltip?: string;
+  depth: 0;
+  children: HostNode[];
+  descendantHostCount: number;
+}
+
+export type TreeNode = FolderNode | HostNode | FileGroupNode;
+export type ContainerNode = FolderNode | FileGroupNode;
+
+export interface HostTree {
+  /** Custom folders first, ssh_config file groups pinned last. */
+  roots: ContainerNode[];
+  foldersByKey: Map<string, FolderNode>;
+  /** Every host in the tree, in render order. */
+  hosts: ManagedHost[];
+}
+
+/**
+ * Split a stored group string into folder segments. Leading, trailing and
+ * doubled separators collapse, and each segment is trimmed — normalization
+ * happens on read so no stored value ever has to be rewritten.
+ */
+export function folderSegments(group: string | null | undefined): string[] {
+  if (!group) return [];
+  return group
+    .split(FOLDER_SEPARATOR)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+/** The canonical stored form of a group string; '' means "no folder". */
+export function normalizeGroupPath(group: string | null | undefined): string {
+  return folderSegments(group).join(FOLDER_SEPARATOR);
+}
+
+/** A folder name is a single segment, so the separator can never appear in one. */
+export function sanitizeFolderName(name: string): string {
+  return name.split(FOLDER_SEPARATOR).join(' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Identity of a folder, case-insensitive per segment — the same rule the flat
+ * groups already used, applied at every level.
+ */
+export function folderKey(path: string): string {
+  return `folder:${folderSegments(path)
+    .map((segment) => segment.toLocaleLowerCase())
+    .join(FOLDER_SEPARATOR)}`;
+}
+
+export function folderPath(segments: readonly string[]): string {
+  return segments.join(FOLDER_SEPARATOR);
+}
+
+/** '' for a top-level folder. */
+export function folderParentPath(path: string): string {
+  const segments = folderSegments(path);
+  return folderPath(segments.slice(0, -1));
+}
+
+export function folderLabel(path: string): string {
+  const segments = folderSegments(path);
+  return segments[segments.length - 1] ?? '';
+}
+
+export function folderDepth(path: string): number {
+  return folderSegments(path).length;
+}
+
+/**
+ * Segment-aware ancestry. `Production` is not inside `Prod` — comparing the raw
+ * strings with startsWith would say otherwise and quietly move the wrong hosts.
+ */
+export function isDescendantPath(candidate: string, ancestor: string): boolean {
+  const parent = folderSegments(ancestor);
+  const child = folderSegments(candidate);
+  if (parent.length === 0 || child.length <= parent.length) return false;
+  return parent.every(
+    (segment, index) => segment.toLocaleLowerCase() === child[index]?.toLocaleLowerCase(),
+  );
+}
+
+export function isSamePath(a: string, b: string): boolean {
+  return folderKey(a) === folderKey(b);
+}
+
+/** The path `hostPath` ends up at when the folder `from` is renamed to `to`. */
+export function renameFolderPath(hostPath: string, from: string, to: string): string | undefined {
+  if (isSamePath(hostPath, from)) return normalizeGroupPath(to);
+  if (!isDescendantPath(hostPath, from)) return undefined;
+  const tail = folderSegments(hostPath).slice(folderDepth(from));
+  return folderPath([...folderSegments(to), ...tail]);
+}
+
+/** Re-parenting a folder is a rename to `<newParent>/<its own name>`. */
+export function moveFolderPath(path: string, newParentPath: string): string {
+  return folderPath([...folderSegments(newParentPath), folderLabel(path)]);
+}
+
+/** Every ancestor of a path, outermost first, excluding the path itself. */
+export function ancestorPaths(path: string): string[] {
+  const segments = folderSegments(path);
+  return segments.slice(0, -1).map((_segment, index) => folderPath(segments.slice(0, index + 1)));
+}
+
+/**
+ * Re-parent the flat groups `groupManagedHosts` produced into a folder tree.
+ *
+ * Only `custom` groups nest; ssh_config file groups keep their existing flat,
+ * read-only shape and are pinned below every folder. Intermediate folders are
+ * synthesized, so a lone `A/B/C` still yields navigable `A` and `A/B` levels.
+ */
+export function buildHostTree(
+  groups: readonly ManagedHostGroup[],
+  options: {
+    knownFolders?: readonly string[];
+    /** Manual sibling order for a parent, innermost-first by folder key. */
+    folderOrder?: (parentKey: string) => readonly string[] | undefined;
+  } = {},
+): HostTree {
+  const foldersByKey = new Map<string, FolderNode>();
+  const rootFolders: FolderNode[] = [];
+
+  /** Create the folder and every missing ancestor; first writer fixes casing. */
+  const ensureFolder = (path: string): FolderNode | undefined => {
+    const segments = folderSegments(path);
+    if (segments.length === 0) return undefined;
+    let parent: FolderNode | undefined;
+    for (let depth = 0; depth < segments.length; depth++) {
+      const currentPath = folderPath(segments.slice(0, depth + 1));
+      const key = folderKey(currentPath);
+      let node = foldersByKey.get(key);
+      if (!node) {
+        node = {
+          kind: 'folder',
+          key,
+          path: parent ? `${parent.path}${FOLDER_SEPARATOR}${segments[depth]}` : segments[depth]!,
+          label: segments[depth]!,
+          depth,
+          parentKey: parent?.key,
+          children: [],
+          descendantHostCount: 0,
+          empty: true,
+        };
+        foldersByKey.set(key, node);
+        if (parent) parent.children.push(node);
+        else rootFolders.push(node);
+      }
+      parent = node;
+    }
+    return parent;
+  };
+
+  // Folders are created in sorted path order so the label a case-insensitive
+  // collision settles on never depends on the order hosts arrived in.
+  const customGroups = groups.filter((group) => group.kind === 'custom');
+  const declaredPaths = [
+    ...customGroups.map((group) => group.label),
+    ...(options.knownFolders ?? []),
+  ]
+    .map(normalizeGroupPath)
+    .filter((path) => path.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  for (const path of declaredPaths) ensureFolder(path);
+
+  for (const group of customGroups) {
+    const folder = ensureFolder(group.label);
+    if (!folder) continue;
+    for (const host of group.hosts) {
+      folder.children.push({
+        kind: 'host',
+        key: managedHostKey(host),
+        host,
+        depth: folder.depth + 1,
+        parentKey: folder.key,
+      });
+    }
+  }
+
+  const fileGroups: FileGroupNode[] = groups
+    .filter((group) => group.kind === 'file')
+    .map((group) => ({
+      kind: 'file' as const,
+      key: group.key,
+      label: group.label,
+      tooltip: group.tooltip,
+      depth: 0 as const,
+      descendantHostCount: group.hosts.length,
+      children: group.hosts.map((host) => ({
+        kind: 'host' as const,
+        key: managedHostKey(host),
+        host,
+        depth: 1,
+        parentKey: group.key,
+      })),
+    }));
+
+  const rankIn = (parentKey: string) => {
+    const order = options.folderOrder?.(parentKey);
+    if (!order || order.length === 0) return undefined;
+    return new Map(order.map((key, index) => [key, index]));
+  };
+  for (const folder of rootFolders) finalizeFolder(folder, rankIn);
+  sortFolders(rootFolders, rankIn(TREE_ROOT_KEY));
+
+  const roots: ContainerNode[] = [...rootFolders, ...fileGroups];
+  const hosts: ManagedHost[] = [];
+  const collect = (nodes: readonly TreeNode[]) => {
+    for (const node of nodes) {
+      if (node.kind === 'host') hosts.push(node.host);
+      else collect(node.children);
+    }
+  };
+  collect(roots);
+
+  return { roots, foldersByKey, hosts };
+}
+
+type RankLookup = (parentKey: string) => Map<string, number> | undefined;
+
+/** Sort children and roll host counts up, depth-first. */
+function finalizeFolder(folder: FolderNode, rankIn: RankLookup): number {
+  let count = 0;
+  for (const child of folder.children) {
+    if (child.kind === 'folder') count += finalizeFolder(child, rankIn);
+    else count += 1;
+  }
+  // Folders sort before hosts; hosts keep the order groupManagedHosts settled
+  // (sortOrder → favorite → name), so the sortOrder column keeps working.
+  const folders = folder.children.filter((child) => child.kind === 'folder');
+  const rest = folder.children.filter((child) => child.kind !== 'folder');
+  sortFolders(folders, rankIn(folder.key));
+  folder.children = [...folders, ...rest];
+  folder.descendantHostCount = count;
+  folder.empty = count === 0;
+  return count;
+}
+
+/**
+ * Manual order first, then alphabetical for anything the user has not placed —
+ * the same rule hosts follow with `sortOrder`, so a folder a user dragged stays
+ * put while a newly created sibling still lands somewhere predictable.
+ */
+function sortFolders(folders: FolderNode[], rank: Map<string, number> | undefined): void {
+  folders.sort(
+    (a, b) =>
+      (rank?.get(a.key) ?? Number.MAX_SAFE_INTEGER) -
+        (rank?.get(b.key) ?? Number.MAX_SAFE_INTEGER) || a.label.localeCompare(b.label),
+  );
+}
+
+export interface VisibleNode {
+  node: TreeNode;
+  key: string;
+  depth: number;
+  /** aria-level is 1-based. */
+  level: number;
+  posInSet: number;
+  setSize: number;
+  /** Undefined for hosts — a leaf must not carry aria-expanded at all. */
+  expanded?: boolean;
+  /** Colour of the nearest coloured ancestor folder, for the indent rail. */
+  railColor?: string;
+  /** Ancestor folder keys, outermost first; one indent guide per entry. */
+  ancestors: string[];
+}
+
+/**
+ * The whole visible list, flattened once. Rendering, arrow-key navigation,
+ * type-ahead and drop hit-testing all read this single array, so they can never
+ * disagree about what is on screen.
+ */
+export function flattenVisibleTree(
+  tree: HostTree,
+  isExpanded: (key: string) => boolean,
+  folderColor: (key: string) => string | undefined = () => undefined,
+): VisibleNode[] {
+  const out: VisibleNode[] = [];
+
+  const walk = (
+    nodes: readonly TreeNode[],
+    depth: number,
+    ancestors: string[],
+    inheritedColor: string | undefined,
+  ) => {
+    nodes.forEach((node, index) => {
+      const ownColor = node.kind === 'folder' ? folderColor(node.key) : undefined;
+      const railColor = ownColor ?? inheritedColor;
+      const expanded = node.kind === 'host' ? undefined : isExpanded(node.key);
+      out.push({
+        node,
+        key: node.key,
+        depth,
+        level: depth + 1,
+        posInSet: index + 1,
+        setSize: nodes.length,
+        expanded,
+        railColor,
+        ancestors,
+      });
+      if (node.kind !== 'host' && expanded && node.children.length > 0) {
+        walk(node.children, depth + 1, [...ancestors, node.key], railColor);
+      }
+    });
+  };
+
+  walk(tree.roots, 0, [], undefined);
+  return out;
+}
+
+/** Sibling host keys of a container, in render order — what reordering acts on. */
+export function siblingHostKeys(node: ContainerNode): string[] {
+  return node.children.flatMap((child) => (child.kind === 'host' ? [child.key] : []));
+}
+
+/** Sibling folder keys of a container, in render order. */
+export function siblingFolderKeys(node: ContainerNode): string[] {
+  return node.children.flatMap((child) => (child.kind === 'folder' ? [child.key] : []));
+}
+
+/** Top-level folder keys, in render order; file groups are never reordered. */
+export function rootFolderKeys(tree: HostTree): string[] {
+  return tree.roots.flatMap((root) => (root.kind === 'folder' ? [root.key] : []));
+}
+
+/**
+ * Where a folder sits among its siblings, and under which order key. Top-level
+ * folders report `TREE_ROOT_KEY`, so callers never special-case the root.
+ */
+export function folderSiblings(
+  tree: HostTree,
+  key: string,
+): { parentKey: string; keys: string[] } | undefined {
+  const folder = tree.foldersByKey.get(key);
+  if (!folder) return undefined;
+  if (!folder.parentKey) return { parentKey: TREE_ROOT_KEY, keys: rootFolderKeys(tree) };
+  const parent = tree.foldersByKey.get(folder.parentKey);
+  return parent
+    ? { parentKey: parent.key, keys: siblingFolderKeys(parent) }
+    : undefined;
+}
+
+/** The order key a folder's children are stored under. */
+export function orderKeyForParent(parent: FolderNode | undefined): string {
+  return parent ? parent.key : TREE_ROOT_KEY;
+}
+
+/**
+ * Every folder path in use plus each of its ancestors, for pickers.
+ *
+ * Deeper paths are rebuilt from the casing their ancestors already settled on,
+ * so a picker never offers `production/eu` and `Production/EU/Edge` side by
+ * side. Sorting the input first makes the winning casing independent of the
+ * order the caller happened to collect paths in.
+ */
+export function expandFolderPaths(paths: Iterable<string>): string[] {
+  const canonical = new Map<string, string>();
+  const sorted = [...paths]
+    .map(normalizeGroupPath)
+    .filter((path) => path.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  for (const path of sorted) {
+    let prefix = '';
+    for (const segment of folderSegments(path)) {
+      const candidate = prefix ? `${prefix}${FOLDER_SEPARATOR}${segment}` : segment;
+      const key = folderKey(candidate);
+      const existing = canonical.get(key);
+      if (existing) {
+        prefix = existing;
+      } else {
+        canonical.set(key, candidate);
+        prefix = candidate;
+      }
+    }
+  }
+  return [...canonical.values()].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Every folder path a picker should offer: the groups in use, each of their
+ * ancestors, and any folder the user created that holds no host yet. Offering
+ * only leaf paths would make `Production` unreachable the moment its last host
+ * moved down into `Production/EU`.
+ */
+export function knownFolderPaths(
+  sshHosts: readonly SshHostEntry[],
+  savedProfiles: readonly SavedHostProfile[],
+  extraPaths: readonly string[] = [],
+): string[] {
+  return expandFolderPaths([...knownHostGroups(sshHosts, savedProfiles), ...extraPaths]);
+}

--- a/client/src/lazy-features.ts
+++ b/client/src/lazy-features.ts
@@ -1,6 +1,9 @@
 /** Statically analyzable feature loaders shared by React.lazy and intent preloads. */
 export const loadHostEditorDialog = () => import('./components/HostEditorDialog.js');
 export const loadHostOrganizationDialog = () => import('./components/HostOrganizationDialog.js');
+export const loadFolderDialog = () => import('./components/sidebar/FolderDialog.js');
+/** Sidebar surfaces that only exist once the user right-clicks or launches. */
+export const loadSidebarMenus = () => import('./components/sidebar/SidebarMenus.js');
 export const loadSettingsDialog = () => import('./components/SettingsDialog.js');
 export const loadCommandButtonsDialog = () => import('./components/CommandButtonsDialog.js');
 export const loadShortcutsDialog = () => import('./components/ShortcutsDialog.js');

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -8,6 +8,13 @@ import type { KeywordHighlightRule } from '@muxus/shared';
 export type ThemeMode = 'light' | 'dark' | 'os';
 export type RightClickAction = 'copy-paste' | 'paste' | 'menu';
 
+/** Presentation of one sidebar folder. Folders are paths, not records, so
+ *  their looks cannot hang off a host and live here instead. */
+export interface FolderStyle {
+  color?: string;
+  icon?: string;
+}
+
 export interface CommandButton {
   id: string;
   label: string;
@@ -67,9 +74,23 @@ export interface PrefsState {
   commandButtons: CommandButton[];
   /** Rules applied to every terminal; hosts may add to or replace these. */
   keywordHighlights: KeywordHighlightRule[];
+  /** Whether the whole hosts sidebar is hidden — not to be confused with
+   *  sidebarCollapsedFolders, which collapses individual folders inside it. */
   sidebarCollapsed: boolean;
   /** Width of the sessions and hosts sidebar. */
   sidebarWidth: number;
+  /** Folder keys the user collapsed. Absent means expanded, so a new folder
+   *  shows its contents the first time it appears. */
+  sidebarCollapsedFolders: string[];
+  /** Colour and icon per folder key. */
+  sidebarFolderStyles: Record<string, FolderStyle>;
+  /** Manual sibling order per parent folder key: parent → ordered child keys.
+   *  Folders missing from a list fall back to alphabetical, after the ranked
+   *  ones — the same rule hosts already follow with sortOrder. */
+  sidebarFolderOrder: Record<string, string[]>;
+  /** Folders the user created that hold no host yet; canonical paths, since an
+   *  empty folder has no host to carry its label. */
+  sidebarEmptyFolders: string[];
   /** Width of the per-session remote file browser. */
   sftpPanelWidth: number;
   toggleTheme: () => void;
@@ -85,7 +106,37 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
   if (version === 0 && state.terminalScheme === 'muxus') state.terminalScheme = 'vscode-dark';
   // TERM is fixed by the server now; remove the retired client override.
   delete state.termName;
+  // Folder presentation arrived in v5. A restored or hand-edited snapshot can
+  // carry the wrong shape here, and every reader assumes the right one.
+  if (!isStringArray(state.sidebarCollapsedFolders)) delete state.sidebarCollapsedFolders;
+  if (!isStringArray(state.sidebarEmptyFolders)) delete state.sidebarEmptyFolders;
+  if (!isFolderStyleMap(state.sidebarFolderStyles)) delete state.sidebarFolderStyles;
+  if (!isFolderOrderMap(state.sidebarFolderOrder)) delete state.sidebarFolderOrder;
   return state;
+}
+
+function isFolderOrderMap(value: unknown): value is Record<string, string[]> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  return Object.values(value).every(isStringArray);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isFolderStyleMap(value: unknown): value is Record<string, FolderStyle> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  return Object.values(value).every(
+    (style) =>
+      style !== null &&
+      typeof style === 'object' &&
+      !Array.isArray(style) &&
+      Object.entries(style).every(
+        ([key, entry]) =>
+          (key === 'color' || key === 'icon') &&
+          (entry === undefined || typeof entry === 'string'),
+      ),
+  );
 }
 
 export const usePrefsStore = create<PrefsState>()(
@@ -111,6 +162,10 @@ export const usePrefsStore = create<PrefsState>()(
       keywordHighlights: [],
       sidebarCollapsed: false,
       sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+      sidebarCollapsedFolders: [],
+      sidebarFolderStyles: {},
+      sidebarFolderOrder: {},
+      sidebarEmptyFolders: [],
       sftpPanelWidth: DEFAULT_SFTP_PANEL_WIDTH,
       toggleTheme: () =>
         set((s) => ({ themeMode: s.themeMode === 'light' ? 'dark' : s.themeMode === 'dark' ? 'os' : 'light' })),
@@ -118,7 +173,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 4,
+      version: 5,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/client/src/state/ui.ts
+++ b/client/src/state/ui.ts
@@ -10,6 +10,19 @@ export type HostEditorState =
   | { mode: 'duplicate-profile'; entry: SavedHostProfile }
   | { mode: 'edit-profile'; entry: SavedHostProfile };
 
+/**
+ * Sidebar folder editing. Folders are group paths rather than records, so each
+ * mode is ultimately a rewrite of one path prefix.
+ */
+export type FolderDialogState =
+  | false
+  /** Create a folder, optionally already nested under `parentPath`. */
+  | { mode: 'new'; parentPath?: string }
+  /** Rename, re-parent, colour or icon an existing folder. */
+  | { mode: 'edit'; path: string }
+  /** Pick the folder one host should live in. */
+  | { mode: 'move-host'; hostKey: string; hostName: string; currentPath: string };
+
 interface UiState {
   settingsOpen: boolean;
   commandButtonsOpen: boolean;
@@ -22,6 +35,8 @@ interface UiState {
   hostEditor: HostEditorState;
   /** Host whose Muxus-only display metadata is being organized. */
   hostOrganizer: SshHostEntry | SavedHostProfile | false;
+  /** Sidebar folder being created, renamed, styled, or picked as a target. */
+  folderDialog: FolderDialogState;
   /** Global forwarding side panel (saved tunnels + live forwards). */
   forwardingOpen: boolean;
   setSettingsOpen: (open: boolean) => void;
@@ -33,6 +48,7 @@ interface UiState {
   setWorkspacesOpen: (open: boolean) => void;
   setHostEditor: (value: HostEditorState) => void;
   setHostOrganizer: (value: SshHostEntry | SavedHostProfile | false) => void;
+  setFolderDialog: (value: FolderDialogState) => void;
   setForwardingOpen: (open: boolean) => void;
 }
 
@@ -46,6 +62,7 @@ export const useUiStore = create<UiState>()((set) => ({
   workspacesOpen: false,
   hostEditor: false,
   hostOrganizer: false,
+  folderDialog: false,
   forwardingOpen: false,
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
   setCommandButtonsOpen: (commandButtonsOpen) => set({ commandButtonsOpen }),
@@ -61,5 +78,6 @@ export const useUiStore = create<UiState>()((set) => ({
   setWorkspacesOpen: (workspacesOpen) => set({ workspacesOpen }),
   setHostEditor: (hostEditor) => set({ hostEditor }),
   setHostOrganizer: (hostOrganizer) => set({ hostOrganizer }),
+  setFolderDialog: (folderDialog) => set({ folderDialog }),
   setForwardingOpen: (forwardingOpen) => set({ forwardingOpen }),
 }));

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -1080,14 +1080,23 @@ export class MuxusDatabase {
   }
 
   /** Reuse group names case-insensitively so typing "work" and "Work" cannot
-   *  silently create two visually indistinguishable sidebar groups. */
+   *  silently create two visually indistinguishable sidebar groups. A spelling
+   *  that differs only by case updates the row instead of being discarded, so
+   *  renaming a folder to fix its capitalization actually takes effect. */
   private groupIdForName(name: string | null): string | null {
     const normalized = name?.trim();
     if (!normalized) return null;
     const existing = this.db
-      .prepare('SELECT id FROM connection_groups WHERE name = ? COLLATE NOCASE ORDER BY created_at LIMIT 1')
+      .prepare('SELECT id, name FROM connection_groups WHERE name = ? COLLATE NOCASE ORDER BY created_at LIMIT 1')
       .get(normalized);
-    if (existing) return String(existing.id);
+    if (existing) {
+      if (String(existing.name) !== normalized) {
+        this.db
+          .prepare('UPDATE connection_groups SET name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+          .run(normalized, String(existing.id));
+      }
+      return String(existing.id);
+    }
     const id = nanoid();
     this.db
       .prepare('INSERT INTO connection_groups(id, name) VALUES (?, ?)')

--- a/server/src/routes/metadata-schema.ts
+++ b/server/src/routes/metadata-schema.ts
@@ -21,7 +21,9 @@ export const metadataPatchSchema = z
   .object({
     favorite: z.boolean().optional(),
     displayName: z.string().max(200).nullable().optional(),
-    group: z.string().max(100).nullable().optional(),
+    // A group is a folder path ("Production/EU/Edge"), so the cap has to cover
+    // several nested names rather than a single one.
+    group: z.string().max(300).nullable().optional(),
     color: z.string().max(64).nullable().optional(),
     icon: z.string().max(64).nullable().optional(),
     keywordHighlights: hostKeywordHighlightsSchema.nullable().optional(),

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -3,6 +3,8 @@ import {
   BACKUP_FORMAT,
   TRANSFER_VERSION,
   parseTransferDocument,
+  sanitizePreferences,
+  type BackupPreferences,
 } from '../../../client/src/data-transfer.js';
 
 const connections = {
@@ -83,5 +85,66 @@ describe('Muxus transfer file parsing', () => {
         }),
       ),
     ).toThrow('The connection data in this file is incomplete or too large.');
+  });
+});
+
+describe('restoring sidebar folder preferences', () => {
+  /** Only the folder keys matter here; the rest of the shape is unvalidated. */
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores well-formed folder state', () => {
+    const input = {
+      sidebarCollapsedFolders: ['folder:prod', 'folder:prod/eu'],
+      sidebarEmptyFolders: ['Staging/Blue'],
+      sidebarFolderStyles: { 'folder:prod': { color: '#ef5350', icon: 'cloud' } },
+    };
+
+    expect(sanitizePreferences(prefs(input))).toMatchObject(input);
+  });
+
+  it('drops an oversized folder list rather than importing it', () => {
+    const tooMany = Array.from({ length: 501 }, (_entry, index) => `folder:${index}`);
+    const tooLong = ['x'.repeat(401)];
+
+    expect(sanitizePreferences(prefs({ sidebarEmptyFolders: tooMany })).sidebarEmptyFolders)
+      .toBeUndefined();
+    expect(sanitizePreferences(prefs({ sidebarCollapsedFolders: tooLong })).sidebarCollapsedFolders)
+      .toBeUndefined();
+  });
+
+  it('drops folder styles carrying a bad colour or an unknown icon', () => {
+    expect(
+      sanitizePreferences(prefs({ sidebarFolderStyles: { a: { color: 'red' } } }))
+        .sidebarFolderStyles,
+    ).toBeUndefined();
+    expect(
+      sanitizePreferences(prefs({ sidebarFolderStyles: { a: { icon: 'skull' } } }))
+        .sidebarFolderStyles,
+    ).toBeUndefined();
+    expect(
+      sanitizePreferences(prefs({ sidebarFolderStyles: { a: { icon: 'lab' } } }))
+        .sidebarFolderStyles,
+    ).toEqual({ a: { icon: 'lab' } });
+  });
+});
+
+describe('restoring manual folder order', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores a well-formed order map', () => {
+    const input = { sidebarFolderOrder: { root: ['folder:prod'], 'folder:prod': ['folder:prod/eu'] } };
+    expect(sanitizePreferences(prefs(input))).toMatchObject(input);
+  });
+
+  it('drops an order map that is oversized or the wrong shape', () => {
+    expect(
+      sanitizePreferences(prefs({ sidebarFolderOrder: { root: [1, 2] } })).sidebarFolderOrder,
+    ).toBeUndefined();
+    const tooMany = Object.fromEntries(
+      Array.from({ length: 501 }, (_entry, i) => [`folder:${i}`, []]),
+    );
+    expect(
+      sanitizePreferences(prefs({ sidebarFolderOrder: tooMany })).sidebarFolderOrder,
+    ).toBeUndefined();
   });
 });

--- a/tests/unit/client/folder-mutations.test.ts
+++ b/tests/unit/client/folder-mutations.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import type { SshHostEntry } from '@muxus/shared';
+import type { ManagedHost } from '../../../client/src/managed-hosts.js';
+import {
+  deleteFolderPlan,
+  folderProblemMessage,
+  folderRewritePlan,
+  folderTargetProblem,
+  moveHostPlan,
+} from '../../../client/src/components/sidebar/folder-mutations.js';
+
+const ROOT = '/home/test/.ssh/config';
+
+function host(alias: string, group?: string): ManagedHost {
+  const entry: SshHostEntry = {
+    alias,
+    aliases: [alias],
+    file: ROOT,
+    options: {},
+    resolved: {
+      hostname: `${alias}.example.test`,
+      port: 22,
+      identityFiles: [],
+      certificateFiles: [],
+      identitiesOnly: false,
+      forwardAgent: false,
+      proxyJump: [],
+      forwards: [],
+      passwordOnly: false,
+    },
+    metadata: { profileId: `ssh-${alias}`, favorite: false, group, connectCount: 0 },
+  };
+  return { kind: 'ssh', entry };
+}
+
+/** Terse view of a plan: alias → resulting group. */
+function summary(plan: ReturnType<typeof folderRewritePlan>) {
+  return Object.fromEntries(
+    plan.map((move) => [
+      move.host.kind === 'ssh' ? move.host.entry.alias : move.host.entry.id,
+      move.group,
+    ]),
+  );
+}
+
+const HOSTS = [
+  host('a', 'Prod'),
+  host('b', 'Prod/EU'),
+  host('c', 'Prod/EU/Edge'),
+  host('d', 'Production'),
+  host('e', 'Prodigy/EU'),
+  host('f'),
+];
+
+describe('folderRewritePlan', () => {
+  it('rewrites the folder and every descendant path', () => {
+    expect(summary(folderRewritePlan(HOSTS, 'Prod', 'Staging'))).toEqual({
+      a: 'Staging',
+      b: 'Staging/EU',
+      c: 'Staging/EU/Edge',
+    });
+  });
+
+  it('leaves folders that merely share a string prefix alone', () => {
+    const plan = folderRewritePlan(HOSTS, 'Prod', 'Staging');
+    const touched = Object.keys(summary(plan));
+    expect(touched).not.toContain('d');
+    expect(touched).not.toContain('e');
+    expect(touched).not.toContain('f');
+  });
+
+  it('re-parents a nested folder', () => {
+    expect(summary(folderRewritePlan(HOSTS, 'Prod/EU', 'Lab/EU'))).toEqual({
+      b: 'Lab/EU',
+      c: 'Lab/EU/Edge',
+    });
+  });
+
+  it('merges into an existing folder when the target already exists', () => {
+    expect(summary(folderRewritePlan(HOSTS, 'Prodigy', 'Prod'))).toEqual({ e: 'Prod/EU' });
+  });
+
+  it('plans nothing for an unused folder or a no-op rename', () => {
+    expect(folderRewritePlan(HOSTS, 'Nowhere', 'Elsewhere')).toEqual([]);
+    expect(folderRewritePlan(HOSTS, 'Prod', 'prod')).toEqual([]);
+    expect(folderRewritePlan(HOSTS, 'Prod', '  ')).toEqual([]);
+  });
+});
+
+describe('deleteFolderPlan', () => {
+  it('lifts a nested folder one level up', () => {
+    expect(summary(deleteFolderPlan(HOSTS, 'Prod/EU'))).toEqual({
+      b: 'Prod',
+      c: 'Prod/Edge',
+    });
+  });
+
+  it('clears the group entirely when a top-level folder goes', () => {
+    expect(summary(deleteFolderPlan(HOSTS, 'Prod'))).toEqual({
+      a: null,
+      b: 'EU',
+      c: 'EU/Edge',
+    });
+  });
+
+  it('plans nothing for an empty folder', () => {
+    expect(deleteFolderPlan(HOSTS, 'Staging')).toEqual([]);
+  });
+});
+
+describe('moveHostPlan', () => {
+  it('assigns a folder, normalizing the path', () => {
+    expect(moveHostPlan(HOSTS[0]!, ' /Lab// EU /').group).toBe('Lab/EU');
+  });
+
+  it('clears the folder when the path is empty', () => {
+    expect(moveHostPlan(HOSTS[0]!, '   ').group).toBeNull();
+  });
+});
+
+describe('folderTargetProblem', () => {
+  it('accepts an ordinary rename or re-parent', () => {
+    expect(folderTargetProblem('Prod', 'Staging')).toBeUndefined();
+    expect(folderTargetProblem('Prod', 'Lab/Prod')).toBeUndefined();
+  });
+
+  it('rejects an empty target', () => {
+    expect(folderTargetProblem('Prod', '  /  ')).toEqual({ kind: 'empty' });
+  });
+
+  it('rejects moving a folder inside itself', () => {
+    expect(folderTargetProblem('Prod', 'Prod/Sub')).toEqual({ kind: 'into-descendant' });
+    // Sharing a prefix is not the same as being a descendant.
+    expect(folderTargetProblem('Prod', 'Production')).toBeUndefined();
+  });
+
+  it('rejects paths past the depth and length caps', () => {
+    expect(folderTargetProblem('', 'a/b/c/d/e/f/g/h/i')).toEqual({ kind: 'too-deep' });
+    expect(folderTargetProblem('', 'x'.repeat(301))).toEqual({ kind: 'too-long' });
+  });
+
+  it('explains every problem it can report', () => {
+    for (const kind of ['empty', 'too-deep', 'too-long', 'into-descendant'] as const) {
+      expect(folderProblemMessage({ kind })).toMatch(/\S/);
+    }
+  });
+});

--- a/tests/unit/client/folder-mutations.test.ts
+++ b/tests/unit/client/folder-mutations.test.ts
@@ -82,8 +82,17 @@ describe('folderRewritePlan', () => {
 
   it('plans nothing for an unused folder or a no-op rename', () => {
     expect(folderRewritePlan(HOSTS, 'Nowhere', 'Elsewhere')).toEqual([]);
-    expect(folderRewritePlan(HOSTS, 'Prod', 'prod')).toEqual([]);
+    expect(folderRewritePlan(HOSTS, 'Prod', 'Prod')).toEqual([]);
+    expect(folderRewritePlan(HOSTS, 'Prod', ' Prod ')).toEqual([]);
     expect(folderRewritePlan(HOSTS, 'Prod', '  ')).toEqual([]);
+  });
+
+  it('rewrites a folder whose name changes only in capitalisation', () => {
+    expect(summary(folderRewritePlan(HOSTS, 'Prod', 'prod'))).toEqual({
+      a: 'prod',
+      b: 'prod/EU',
+      c: 'prod/EU/Edge',
+    });
   });
 });
 

--- a/tests/unit/client/host-tree.test.ts
+++ b/tests/unit/client/host-tree.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from 'vitest';
+import type { SshHostEntry } from '@muxus/shared';
+import { groupManagedHosts } from '../../../client/src/managed-hosts.js';
+import {
+  ancestorPaths,
+  buildHostTree,
+  expandFolderPaths,
+  flattenVisibleTree,
+  folderKey,
+  folderParentPath,
+  folderSegments,
+  folderSiblings,
+  isDescendantPath,
+  knownFolderPaths,
+  moveFolderPath,
+  normalizeGroupPath,
+  renameFolderPath,
+  sanitizeFolderName,
+  siblingHostKeys,
+  TREE_ROOT_KEY,
+  type FolderNode,
+} from '../../../client/src/host-tree.js';
+
+const ROOT = '/home/test/.ssh/config';
+
+function sshHost(alias: string, group?: string, sortOrder?: number): SshHostEntry {
+  return {
+    alias,
+    aliases: [alias],
+    file: ROOT,
+    options: {},
+    resolved: {
+      hostname: `${alias}.example.test`,
+      port: 22,
+      identityFiles: [],
+      certificateFiles: [],
+      identitiesOnly: false,
+      forwardAgent: false,
+      proxyJump: [],
+      forwards: [],
+      passwordOnly: false,
+    },
+    metadata:
+      group || sortOrder !== undefined
+        ? { profileId: `ssh-${alias}`, favorite: false, group, sortOrder, connectCount: 0 }
+        : undefined,
+  };
+}
+
+function tree(hosts: readonly SshHostEntry[], knownFolders?: readonly string[]) {
+  return buildHostTree(groupManagedHosts(hosts, [], [ROOT], ROOT), { knownFolders });
+}
+
+/** Every folder in the tree, keyed by path, for terse assertions. */
+function foldersByPath(roots: ReturnType<typeof tree>) {
+  return new Map([...roots.foldersByKey.values()].map((folder) => [folder.path, folder]));
+}
+
+describe('path helpers', () => {
+  it('normalizes padded, doubled and edge separators on read', () => {
+    expect(folderSegments('  Production / EU  ')).toEqual(['Production', 'EU']);
+    expect(folderSegments('/a//b/')).toEqual(['a', 'b']);
+    expect(folderSegments('')).toEqual([]);
+    expect(folderSegments(undefined)).toEqual([]);
+    expect(normalizeGroupPath(' /Prod// EU /')).toBe('Prod/EU');
+  });
+
+  it('keeps a folder name to one segment', () => {
+    expect(sanitizeFolderName('k8s/prod')).toBe('k8s prod');
+    expect(sanitizeFolderName('  spaced  out  ')).toBe('spaced out');
+  });
+
+  it('identifies folders case-insensitively at every level', () => {
+    expect(folderKey('Prod/EU')).toBe(folderKey('prod/eu'));
+    expect(folderKey('Prod/EU')).not.toBe(folderKey('Prod/US'));
+  });
+
+  it('compares ancestry by segment, not by string prefix', () => {
+    expect(isDescendantPath('Prod/EU', 'Prod')).toBe(true);
+    expect(isDescendantPath('Prod/EU/Edge', 'prod')).toBe(true);
+    // The bug this guards: 'Production'.startsWith('Prod') is true.
+    expect(isDescendantPath('Production', 'Prod')).toBe(false);
+    expect(isDescendantPath('Prod', 'Prod')).toBe(false);
+    expect(isDescendantPath('Prod', '')).toBe(false);
+  });
+
+  it('walks parents and ancestors', () => {
+    expect(folderParentPath('A/B/C')).toBe('A/B');
+    expect(folderParentPath('A')).toBe('');
+    expect(ancestorPaths('A/B/C')).toEqual(['A', 'A/B']);
+    expect(ancestorPaths('A')).toEqual([]);
+  });
+
+  it('rewrites descendants when a folder is renamed or re-parented', () => {
+    expect(renameFolderPath('Prod', 'Prod', 'Production')).toBe('Production');
+    expect(renameFolderPath('Prod/EU/Edge', 'Prod', 'Production')).toBe('Production/EU/Edge');
+    expect(renameFolderPath('Production', 'Prod', 'X')).toBeUndefined();
+    expect(renameFolderPath('Prodigy/EU', 'Prod', 'X')).toBeUndefined();
+    expect(moveFolderPath('Prod/EU', 'Lab')).toBe('Lab/EU');
+    expect(moveFolderPath('Prod/EU', '')).toBe('EU');
+  });
+});
+
+describe('buildHostTree', () => {
+  it('nests a three-level path with correct depth and parents', () => {
+    const built = tree([
+      sshHost('edge-1', 'Production/EU/Edge'),
+      sshHost('core-1', 'Production/EU/Core'),
+      sshHost('us-1', 'Production/US'),
+    ]);
+    const folders = foldersByPath(built);
+
+    expect(folders.get('Production')).toMatchObject({ depth: 0, parentKey: undefined });
+    expect(folders.get('Production/EU')).toMatchObject({
+      depth: 1,
+      parentKey: folderKey('Production'),
+      label: 'EU',
+    });
+    expect(folders.get('Production/EU/Edge')).toMatchObject({
+      depth: 2,
+      parentKey: folderKey('Production/EU'),
+    });
+    // Every host is grouped, so no ssh_config file group survives.
+    expect(built.roots.map((root) => root.label)).toEqual(['Production']);
+  });
+
+  it('synthesizes intermediate folders that hold no host of their own', () => {
+    const built = tree([sshHost('deep', 'A/B/C')]);
+    const folders = foldersByPath(built);
+
+    expect([...folders.keys()].sort()).toEqual(['A', 'A/B', 'A/B/C']);
+    expect(folders.get('A')!.children.map((child) => child.kind)).toEqual(['folder']);
+    expect(folders.get('A/B/C')!.children.map((child) => child.kind)).toEqual(['host']);
+  });
+
+  it('rolls the host count up through every ancestor', () => {
+    const built = tree([
+      sshHost('a', 'P/EU/Edge'),
+      sshHost('b', 'P/EU/Edge'),
+      sshHost('c', 'P/EU'),
+      sshHost('d', 'P/US'),
+    ]);
+    const folders = foldersByPath(built);
+
+    expect(folders.get('P')!.descendantHostCount).toBe(4);
+    expect(folders.get('P/EU')!.descendantHostCount).toBe(3);
+    expect(folders.get('P/EU/Edge')!.descendantHostCount).toBe(2);
+    expect(folders.get('P/US')!.descendantHostCount).toBe(1);
+  });
+
+  it('collapses case-variant paths onto one folder', () => {
+    const built = tree([sshHost('a', 'Prod/EU'), sshHost('b', 'prod/eu')]);
+    const folders = foldersByPath(built);
+
+    expect(folders.size).toBe(2);
+    expect([...folders.values()].find((folder) => folder.depth === 1)!.descendantHostCount).toBe(2);
+  });
+
+  it('picks a shared ancestor casing independently of host order', () => {
+    // Two distinct group labels disagree on how to spell their common parent;
+    // which spelling wins must not depend on which host was seen first.
+    const hosts = [sshHost('a', 'Prod/EU'), sshHost('b', 'prod/US')];
+    const forward = [...foldersByPath(tree(hosts)).keys()].sort();
+    const reversed = [...foldersByPath(tree([...hosts].reverse())).keys()].sort();
+
+    expect(forward).toEqual(reversed);
+    expect(forward).toHaveLength(3);
+  });
+
+  it('sorts folders before hosts and keeps the host order it was given', () => {
+    const built = tree([
+      sshHost('zulu', 'Ops', 2),
+      sshHost('alpha', 'Ops', 1),
+      sshHost('nested', 'Ops/Sub'),
+    ]);
+    const ops = foldersByPath(built).get('Ops')!;
+
+    expect(ops.children.map((child) => (child.kind === 'folder' ? child.label : child.key))).toEqual([
+      'Sub',
+      'ssh:alpha',
+      'ssh:zulu',
+    ]);
+    expect(siblingHostKeys(ops)).toEqual(['ssh:alpha', 'ssh:zulu']);
+  });
+
+  it('sorts sibling folders alphabetically until the user places them', () => {
+    const built = tree([sshHost('a', 'Zed'), sshHost('b', 'Alpha'), sshHost('c', 'mid')]);
+    expect(built.roots.map((root) => root.label)).toEqual(['Alpha', 'mid', 'Zed']);
+  });
+
+  it('honours a manual sibling order, alphabetical for the rest', () => {
+    const hosts = [sshHost('a', 'Zed'), sshHost('b', 'Alpha'), sshHost('c', 'mid')];
+    const order: Record<string, string[]> = {
+      [TREE_ROOT_KEY]: [folderKey('Zed'), folderKey('mid')],
+    };
+    const built = buildHostTree(groupManagedHosts(hosts, [], [ROOT], ROOT), {
+      folderOrder: (parentKey) => order[parentKey],
+    });
+
+    // Placed folders keep their order; Alpha was never dragged, so it follows.
+    expect(built.roots.map((root) => root.label)).toEqual(['Zed', 'mid', 'Alpha']);
+  });
+
+  it('orders nested folders under their own parent key', () => {
+    const hosts = [sshHost('a', 'P/Zed'), sshHost('b', 'P/Alpha')];
+    const order: Record<string, string[]> = {
+      [folderKey('P')]: [folderKey('P/Zed'), folderKey('P/Alpha')],
+    };
+    const built = buildHostTree(groupManagedHosts(hosts, [], [ROOT], ROOT), {
+      folderOrder: (parentKey) => order[parentKey],
+    });
+
+    expect(
+      foldersByPath(built)
+        .get('P')!
+        .children.map((child) => (child.kind === 'folder' ? child.label : child.key)),
+    ).toEqual(['Zed', 'Alpha']);
+  });
+
+  it('keeps folders before hosts whatever the manual order says', () => {
+    const hosts = [sshHost('nested', 'Ops/Sub'), sshHost('direct', 'Ops')];
+    const order: Record<string, string[]> = { [folderKey('Ops')]: [folderKey('Ops/Sub')] };
+    const built = buildHostTree(groupManagedHosts(hosts, [], [ROOT], ROOT), {
+      folderOrder: (parentKey) => order[parentKey],
+    });
+
+    expect(foldersByPath(built).get('Ops')!.children.map((child) => child.kind)).toEqual([
+      'folder',
+      'host',
+    ]);
+  });
+
+  it('ignores order entries for folders that no longer exist', () => {
+    const order: Record<string, string[]> = {
+      [TREE_ROOT_KEY]: [folderKey('Gone'), folderKey('Zed')],
+    };
+    const built = buildHostTree(
+      groupManagedHosts([sshHost('a', 'Zed'), sshHost('b', 'Alpha')], [], [ROOT], ROOT),
+      { folderOrder: (parentKey) => order[parentKey] },
+    );
+
+    expect(built.roots.map((root) => root.label)).toEqual(['Zed', 'Alpha']);
+  });
+
+  it('reports where a folder sits among its siblings', () => {
+    const built = tree([sshHost('a', 'Zed'), sshHost('b', 'Alpha'), sshHost('c', 'Alpha/Deep')]);
+
+    expect(folderSiblings(built, folderKey('Zed'))).toEqual({
+      parentKey: TREE_ROOT_KEY,
+      keys: [folderKey('Alpha'), folderKey('Zed')],
+    });
+    expect(folderSiblings(built, folderKey('Alpha/Deep'))).toEqual({
+      parentKey: folderKey('Alpha'),
+      keys: [folderKey('Alpha/Deep')],
+    });
+    expect(folderSiblings(built, 'folder:nope')).toBeUndefined();
+  });
+
+  it('pins ssh_config file groups last and never nests them', () => {
+    const built = tree([sshHost('grouped', 'Ops'), sshHost('loose')]);
+    const last = built.roots.at(-1)!;
+
+    expect(last.kind).toBe('file');
+    expect(last.depth).toBe(0);
+    expect(last.children.every((child) => child.kind === 'host')).toBe(true);
+  });
+
+  it('materializes known folders that hold no host yet', () => {
+    const built = tree([sshHost('a', 'Ops')], ['Staging/Blue']);
+    const folders = foldersByPath(built);
+
+    expect(folders.get('Staging')).toMatchObject({ empty: true, descendantHostCount: 0 });
+    expect(folders.get('Staging/Blue')).toMatchObject({ empty: true, descendantHostCount: 0 });
+    expect(folders.get('Ops')!.empty).toBe(false);
+  });
+});
+
+describe('flattenVisibleTree', () => {
+  const built = () =>
+    tree([sshHost('edge', 'P/EU/Edge'), sshHost('us', 'P/US'), sshHost('loose')]);
+
+  it('hides an entire subtree when its folder is collapsed', () => {
+    const collapsed = folderKey('P/EU');
+    const rows = flattenVisibleTree(built(), (key) => key !== collapsed);
+
+    expect(rows.map((row) => row.key)).toContain(collapsed);
+    expect(rows.some((row) => row.key === 'ssh:edge')).toBe(false);
+    expect(rows.some((row) => row.key === 'ssh:us')).toBe(true);
+  });
+
+  it('reports aria level, position and set size per level', () => {
+    const rows = flattenVisibleTree(built(), () => true);
+    const eu = rows.find((row) => row.key === folderKey('P/EU'))!;
+    const edgeHost = rows.find((row) => row.key === 'ssh:edge')!;
+
+    expect(eu).toMatchObject({ level: 2, posInSet: 1, setSize: 2 });
+    expect(edgeHost).toMatchObject({ level: 4, depth: 3 });
+    // Two roots: the P folder and the ssh_config file group.
+    expect(rows.filter((row) => row.level === 1).map((row) => row.setSize)).toEqual([2, 2]);
+  });
+
+  it('omits aria-expanded on hosts and reports it on containers', () => {
+    const rows = flattenVisibleTree(built(), () => true);
+    expect(rows.find((row) => row.key === 'ssh:edge')!.expanded).toBeUndefined();
+    expect(rows.find((row) => row.key === folderKey('P'))!.expanded).toBe(true);
+  });
+
+  it('inherits the rail colour from the nearest coloured ancestor', () => {
+    const colored = folderKey('P');
+    const rows = flattenVisibleTree(
+      built(),
+      () => true,
+      (key) => (key === colored ? '#ef5350' : undefined),
+    );
+
+    expect(rows.find((row) => row.key === folderKey('P/EU'))!.railColor).toBe('#ef5350');
+    expect(rows.find((row) => row.key === 'ssh:edge')!.railColor).toBe('#ef5350');
+    expect(rows.find((row) => row.key === 'ssh:loose')!.railColor).toBeUndefined();
+  });
+
+  it('lists ancestors outermost first so indent guides can be drawn', () => {
+    const rows = flattenVisibleTree(built(), () => true);
+    expect(rows.find((row) => row.key === 'ssh:edge')!.ancestors).toEqual([
+      folderKey('P'),
+      folderKey('P/EU'),
+      folderKey('P/EU/Edge'),
+    ]);
+  });
+});
+
+describe('expandFolderPaths', () => {
+  it('offers every ancestor and dedupes case-insensitively', () => {
+    expect(expandFolderPaths(['Production/EU/Edge', 'Production/EU', 'Lab'])).toEqual([
+      'Lab',
+      'Production',
+      'Production/EU',
+      'Production/EU/Edge',
+    ]);
+  });
+
+  it('rebuilds deeper paths from the casing their ancestors settled on', () => {
+    // Never offer "production/eu" and "Production/EU/Edge" in the same list.
+    expect(expandFolderPaths(['Production/EU/Edge', 'production/eu'])).toEqual([
+      'production',
+      'production/eu',
+      'production/eu/Edge',
+    ]);
+  });
+
+  it('drops blank and separator-only entries', () => {
+    expect(expandFolderPaths(['', '  ', '///'])).toEqual([]);
+  });
+});
+
+describe('tree invariants', () => {
+  it('exposes every host exactly once in render order', () => {
+    const built = tree([sshHost('b', 'Ops'), sshHost('a', 'Ops'), sshHost('loose')]);
+    const keys = built.hosts.map((host) =>
+      host.kind === 'ssh' ? host.entry.alias : host.entry.id,
+    );
+    expect(keys).toEqual(['a', 'b', 'loose']);
+  });
+
+  it('keeps foldersByKey and the root list consistent', () => {
+    const built = tree([sshHost('a', 'A/B')]);
+    const roots = built.roots.filter((root): root is FolderNode => root.kind === 'folder');
+    for (const root of roots) expect(built.foldersByKey.get(root.key)).toBe(root);
+  });
+});
+
+describe('knownFolderPaths', () => {
+  it('offers every folder in use plus its ancestors', () => {
+    expect(knownFolderPaths([sshHost('a', 'Production/EU/Edge'), sshHost('b', 'Lab')], [])).toEqual([
+      'Lab',
+      'Production',
+      'Production/EU',
+      'Production/EU/Edge',
+    ]);
+  });
+
+  it('includes folders that exist only in preferences', () => {
+    expect(knownFolderPaths([sshHost('a', 'Lab')], [], ['Staging/Blue'])).toEqual([
+      'Lab',
+      'Staging',
+      'Staging/Blue',
+    ]);
+  });
+
+  it('offers nothing when no host is grouped', () => {
+    expect(knownFolderPaths([sshHost('a')], [])).toEqual([]);
+  });
+});

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -30,6 +30,40 @@ describe('terminalFontStack', () => {
   });
 });
 
+describe('migratePrefsState folder preferences', () => {
+  it('keeps well-formed folder state', () => {
+    const persisted = {
+      sidebarCollapsedFolders: ['folder:prod'],
+      sidebarEmptyFolders: ['Prod/EU'],
+      sidebarFolderStyles: { 'folder:prod': { color: '#ef5350', icon: 'cloud' } },
+    };
+
+    expect(migratePrefsState(persisted, 4)).toEqual(persisted);
+  });
+
+  it('drops folder state of the wrong shape so readers get the defaults', () => {
+    const persisted = {
+      monoFontSize: 16,
+      sidebarCollapsedFolders: 'folder:prod',
+      sidebarEmptyFolders: [1, 2],
+      sidebarFolderStyles: { 'folder:prod': 'red' },
+    };
+
+    expect(migratePrefsState(persisted, 4)).toEqual({ monoFontSize: 16 });
+    // The stored snapshot itself is left untouched.
+    expect(persisted.sidebarCollapsedFolders).toBe('folder:prod');
+  });
+
+  it('rejects a style record carrying unknown keys', () => {
+    const migrated = migratePrefsState(
+      { sidebarFolderStyles: { 'folder:prod': { colour: '#ef5350' } } },
+      4,
+    ) as Record<string, unknown>;
+
+    expect(migrated.sidebarFolderStyles).toBeUndefined();
+  });
+});
+
 describe('migratePrefsState', () => {
   it('removes the retired TERM preference without mutating the snapshot', () => {
     const persisted = { termName: 'xterm-kitty', monoFontSize: 16 };
@@ -63,5 +97,20 @@ describe('interface zoom', () => {
     expect(INTERFACE_ZOOM_STEPS).toContain(1);
     expect(INTERFACE_ZOOM_STEPS.every((step) => clampInterfaceZoom(step) === step)).toBe(true);
     expect(interfaceZoomLabel(1.25)).toBe('125%');
+  });
+});
+
+describe('migratePrefsState folder order', () => {
+  it('keeps a well-formed order map', () => {
+    const persisted = { sidebarFolderOrder: { root: ['folder:prod', 'folder:lab'] } };
+    expect(migratePrefsState(persisted, 4)).toEqual(persisted);
+  });
+
+  it('drops an order map of the wrong shape', () => {
+    const migrated = migratePrefsState(
+      { sidebarFolderOrder: { root: 'folder:prod' } },
+      4,
+    ) as Record<string, unknown>;
+    expect(migrated.sidebarFolderOrder).toBeUndefined();
   });
 });

--- a/tests/unit/client/tree-dnd.test.ts
+++ b/tests/unit/client/tree-dnd.test.ts
@@ -15,6 +15,7 @@ import {
   droppedFolderPath,
   folderOrderAfterDrop,
   isPureReorder,
+  sameTarget,
   targetPath,
   type DragSource,
 } from '../../../client/src/components/sidebar/tree-dnd.js';
@@ -267,6 +268,43 @@ describe('containerFor', () => {
       )?.key,
     ).toBe(fileGroupKey);
     expect(containerFor({ kind: 'root' }, tree)).toBeUndefined();
+  });
+});
+
+describe('sameTarget', () => {
+  const folderEdge = (path: string, edge: 'before' | 'after') =>
+    ({ kind: 'folder-edge', folderKey: folderKey(path), edge }) as const;
+
+  it('holds the current target when the pointer resolves to the same spot', () => {
+    expect(sameTarget(folderEdge('Prod', 'before'), folderEdge('Prod', 'before'))).toBe(true);
+    expect(sameTarget({ kind: 'root' }, { kind: 'root' })).toBe(true);
+  });
+
+  it('separates the two edges of one folder', () => {
+    expect(sameTarget(folderEdge('Prod', 'before'), folderEdge('Prod', 'after'))).toBe(false);
+  });
+
+  it('separates the same edge of two folders', () => {
+    expect(sameTarget(folderEdge('Prod', 'before'), folderEdge('Lab', 'before'))).toBe(false);
+  });
+
+  it('separates host edges, folders and kinds', () => {
+    const before = {
+      kind: 'host-edge',
+      hostKey: 'ssh:edge',
+      parentKey: folderKey('Prod/EU'),
+      edge: 'before',
+    } as const;
+    expect(sameTarget(before, { ...before, edge: 'after' })).toBe(false);
+    expect(sameTarget(before, { ...before, hostKey: 'ssh:core' })).toBe(false);
+    expect(sameTarget(before, folderEdge('Prod', 'before'))).toBe(false);
+    expect(
+      sameTarget(
+        { kind: 'into-folder', folderKey: folderKey('Prod') },
+        { kind: 'into-folder', folderKey: folderKey('Lab') },
+      ),
+    ).toBe(false);
+    expect(sameTarget(null, { kind: 'root' })).toBe(false);
   });
 });
 

--- a/tests/unit/client/tree-dnd.test.ts
+++ b/tests/unit/client/tree-dnd.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest';
+import type { SshHostEntry } from '@muxus/shared';
+import { groupManagedHosts } from '../../../client/src/managed-hosts.js';
+import {
+  buildHostTree,
+  flattenVisibleTree,
+  folderKey,
+  type VisibleNode,
+} from '../../../client/src/host-tree.js';
+import {
+  canDrop,
+  containerFor,
+  dragSourceForRow,
+  dropTargetForRow,
+  droppedFolderPath,
+  folderOrderAfterDrop,
+  isPureReorder,
+  targetPath,
+  type DragSource,
+} from '../../../client/src/components/sidebar/tree-dnd.js';
+
+const ROOT = '/home/test/.ssh/config';
+
+function sshHost(alias: string, group?: string): SshHostEntry {
+  return {
+    alias,
+    aliases: [alias],
+    file: ROOT,
+    options: {},
+    resolved: {
+      hostname: `${alias}.example.test`,
+      port: 22,
+      identityFiles: [],
+      certificateFiles: [],
+      identitiesOnly: false,
+      forwardAgent: false,
+      proxyJump: [],
+      forwards: [],
+      passwordOnly: false,
+    },
+    metadata: group ? { profileId: alias, favorite: false, group, connectCount: 0 } : undefined,
+  };
+}
+
+/**
+ *  Prod            folder
+ *    EU            folder
+ *      edge        host
+ *    core          host
+ *  Lab             folder
+ *    lab-1         host
+ *  Hosts           ssh_config file group
+ *    loose         host
+ */
+const HOSTS = [
+  sshHost('edge', 'Prod/EU'),
+  sshHost('core', 'Prod'),
+  sshHost('lab-1', 'Lab'),
+  sshHost('loose'),
+];
+
+const tree = buildHostTree(groupManagedHosts(HOSTS, [], [ROOT], ROOT));
+const rows = flattenVisibleTree(tree, () => true);
+const row = (key: string): VisibleNode => rows.find((entry) => entry.key === key)!;
+
+const fileGroupKey = `file:${ROOT}`;
+const dragEdge: DragSource = { kind: 'host', hostKey: 'ssh:edge', parentKey: folderKey('Prod/EU') };
+const dragLoose: DragSource = { kind: 'host', hostKey: 'ssh:loose', parentKey: fileGroupKey };
+const dragProd: DragSource = { kind: 'folder', folderKey: folderKey('Prod'), path: 'Prod' };
+const dragLab: DragSource = { kind: 'folder', folderKey: folderKey('Lab'), path: 'Lab' };
+
+describe('dropTargetForRow', () => {
+  it('splits a host row into a before and an after half', () => {
+    expect(dropTargetForRow(row('ssh:edge'), 0.2)).toMatchObject({ edge: 'before' });
+    expect(dropTargetForRow(row('ssh:edge'), 0.8)).toMatchObject({ edge: 'after' });
+  });
+
+  it('treats the middle of a folder as "drop inside"', () => {
+    expect(dropTargetForRow(row(folderKey('Lab')), 0.5)).toEqual({
+      kind: 'into-folder',
+      folderKey: folderKey('Lab'),
+    });
+  });
+
+  it('treats a folder edge as "place beside this folder"', () => {
+    expect(dropTargetForRow(row(folderKey('Prod/EU')), 0.1)).toEqual({
+      kind: 'folder-edge',
+      folderKey: folderKey('Prod/EU'),
+      parentKey: folderKey('Prod'),
+      edge: 'before',
+    });
+    // A top-level folder has no parent key: its edges join the top level.
+    expect(dropTargetForRow(row(folderKey('Prod')), 0.9)).toEqual({
+      kind: 'folder-edge',
+      folderKey: folderKey('Prod'),
+      parentKey: undefined,
+      edge: 'after',
+    });
+  });
+
+  it('sends an ssh_config file group edge to the root', () => {
+    expect(dropTargetForRow(row(fileGroupKey), 0.9)).toEqual({ kind: 'root' });
+  });
+});
+
+describe('folder ordering', () => {
+  it('reorders a folder among the siblings it already has', () => {
+    const target = {
+      kind: 'folder-edge' as const,
+      folderKey: folderKey('Lab'),
+      parentKey: undefined,
+      edge: 'before' as const,
+    };
+    expect(canDrop(dragProd, target, tree)).toBe(true);
+    expect(targetPath(target, tree)).toBe('');
+  });
+
+  it('refuses to drop a folder beside itself', () => {
+    expect(
+      canDrop(
+        dragProd,
+        { kind: 'folder-edge', folderKey: folderKey('Prod'), parentKey: undefined, edge: 'after' },
+        tree,
+      ),
+    ).toBe(false);
+  });
+
+  it('still refuses a folder edge inside its own subtree', () => {
+    expect(
+      canDrop(
+        dragProd,
+        {
+          kind: 'folder-edge',
+          folderKey: folderKey('Prod/EU'),
+          parentKey: folderKey('Prod'),
+          edge: 'before',
+        },
+        tree,
+      ),
+    ).toBe(false);
+  });
+
+  it('inserts before or after the folder it was dropped on', () => {
+    const siblings = ['a', 'b', 'c'];
+    expect(folderOrderAfterDrop(siblings, 'c', 'c', 'a', 'before')).toEqual(['c', 'a', 'b']);
+    expect(folderOrderAfterDrop(siblings, 'a', 'a', 'b', 'after')).toEqual(['b', 'a', 'c']);
+  });
+
+  it('appends when no target folder was named', () => {
+    expect(folderOrderAfterDrop(['a', 'b'], 'x', 'x', undefined)).toEqual(['a', 'b', 'x']);
+  });
+
+  it('uses the new key when the drop also re-parents the folder', () => {
+    // Dragging Lab into Prod changes its key from folder:lab to folder:prod/lab.
+    expect(folderOrderAfterDrop(['a', 'b'], 'folder:lab', 'folder:prod/lab', 'a', 'after')).toEqual(
+      ['a', 'folder:prod/lab', 'b'],
+    );
+  });
+});
+
+describe('dragSourceForRow', () => {
+  it('describes hosts and folders', () => {
+    expect(dragSourceForRow(row('ssh:edge'))).toEqual(dragEdge);
+    expect(dragSourceForRow(row(folderKey('Prod')))).toEqual(dragProd);
+  });
+
+  it('refuses to drag an ssh_config file group', () => {
+    expect(dragSourceForRow(row(fileGroupKey))).toBeUndefined();
+  });
+});
+
+describe('targetPath', () => {
+  it('resolves folders and the root, but not file groups', () => {
+    expect(targetPath({ kind: 'root' }, tree)).toBe('');
+    expect(targetPath({ kind: 'into-folder', folderKey: folderKey('Prod/EU') }, tree)).toBe('Prod/EU');
+    expect(targetPath({ kind: 'into-folder', folderKey: fileGroupKey }, tree)).toBeUndefined();
+  });
+});
+
+describe('canDrop', () => {
+  it('moves a host between folders and out to the root', () => {
+    expect(canDrop(dragEdge, { kind: 'into-folder', folderKey: folderKey('Lab') }, tree)).toBe(true);
+    expect(canDrop(dragEdge, { kind: 'root' }, tree)).toBe(true);
+  });
+
+  it('never drops anything into an ssh_config file group', () => {
+    expect(canDrop(dragEdge, { kind: 'into-folder', folderKey: fileGroupKey }, tree)).toBe(false);
+    expect(canDrop(dragProd, { kind: 'into-folder', folderKey: fileGroupKey }, tree)).toBe(false);
+  });
+
+  it('still allows reordering inside a file group, which changes no folder', () => {
+    const target = {
+      kind: 'host-edge' as const,
+      hostKey: 'ssh:other',
+      parentKey: fileGroupKey,
+      edge: 'after' as const,
+    };
+    expect(canDrop(dragLoose, target, tree)).toBe(true);
+    expect(isPureReorder(dragLoose, target)).toBe(true);
+  });
+
+  it('refuses to drop a host onto itself', () => {
+    const onSelf = {
+      kind: 'host-edge' as const,
+      hostKey: 'ssh:edge',
+      parentKey: folderKey('Prod/EU'),
+      edge: 'before' as const,
+    };
+    expect(canDrop(dragEdge, onSelf, tree)).toBe(false);
+  });
+
+  it('refuses to move a folder into itself or a descendant', () => {
+    expect(canDrop(dragProd, { kind: 'into-folder', folderKey: folderKey('Prod') }, tree)).toBe(false);
+    expect(canDrop(dragProd, { kind: 'into-folder', folderKey: folderKey('Prod/EU') }, tree)).toBe(
+      false,
+    );
+  });
+
+  it('refuses a folder move that changes nothing', () => {
+    // Lab is already at the root.
+    expect(canDrop(dragLab, { kind: 'root' }, tree)).toBe(false);
+    // EU is already inside Prod.
+    const eu: DragSource = { kind: 'folder', folderKey: folderKey('Prod/EU'), path: 'Prod/EU' };
+    expect(canDrop(eu, { kind: 'into-folder', folderKey: folderKey('Prod') }, tree)).toBe(false);
+  });
+
+  it('allows a genuine folder re-parent', () => {
+    expect(canDrop(dragLab, { kind: 'into-folder', folderKey: folderKey('Prod') }, tree)).toBe(true);
+  });
+
+  it('allows a move that lands exactly on the depth cap', () => {
+    // target/a/b/c/d/e/f/g is eight levels, which is MAX_FOLDER_DEPTH.
+    const deep = buildHostTree(
+      groupManagedHosts([sshHost('x', 'a/b/c/d/e/f/g'), sshHost('y', 'target')], [], [ROOT], ROOT),
+    );
+    const source: DragSource = { kind: 'folder', folderKey: folderKey('a'), path: 'a' };
+    expect(canDrop(source, { kind: 'into-folder', folderKey: folderKey('target') }, deep)).toBe(
+      true,
+    );
+  });
+
+  it('refuses a move that would nest past the depth cap', () => {
+    const deeper = buildHostTree(
+      groupManagedHosts(
+        [sshHost('x', 'a/b/c/d/e/f/g/h'), sshHost('y', 'target')],
+        [],
+        [ROOT],
+        ROOT,
+      ),
+    );
+    const source: DragSource = { kind: 'folder', folderKey: folderKey('a'), path: 'a' };
+    expect(canDrop(source, { kind: 'into-folder', folderKey: folderKey('target') }, deeper)).toBe(
+      false,
+    );
+  });
+});
+
+describe('containerFor', () => {
+  it('finds folders and file groups alike', () => {
+    expect(containerFor({ kind: 'into-folder', folderKey: folderKey('Prod') }, tree)?.key).toBe(
+      folderKey('Prod'),
+    );
+    expect(
+      containerFor(
+        { kind: 'host-edge', hostKey: 'ssh:loose', parentKey: fileGroupKey, edge: 'after' },
+        tree,
+      )?.key,
+    ).toBe(fileGroupKey);
+    expect(containerFor({ kind: 'root' }, tree)).toBeUndefined();
+  });
+});
+
+describe('droppedFolderPath', () => {
+  it('keeps the folder name and swaps its parent', () => {
+    expect(droppedFolderPath(dragProd, 'Lab')).toBe('Lab/Prod');
+    expect(droppedFolderPath(dragProd, '')).toBe('Prod');
+    const eu: DragSource = { kind: 'folder', folderKey: folderKey('Prod/EU'), path: 'Prod/EU' };
+    expect(droppedFolderPath(eu, 'Lab')).toBe('Lab/EU');
+  });
+});

--- a/tests/unit/client/tree-navigation.test.ts
+++ b/tests/unit/client/tree-navigation.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { VisibleNode } from '../../../client/src/host-tree.js';
+import {
+  focusAfterChange,
+  parentIndex,
+  treeNavAction,
+  typeAheadIndex,
+} from '../../../client/src/components/sidebar/tree-navigation.js';
+
+/** Only the fields navigation reads; the node payload is irrelevant here. */
+function row(key: string, depth: number, expanded?: boolean): VisibleNode {
+  return {
+    node: { kind: 'host', key, host: null as never, depth, parentKey: '' },
+    key,
+    depth,
+    level: depth + 1,
+    posInSet: 1,
+    setSize: 1,
+    expanded,
+    ancestors: [],
+  };
+}
+
+/**
+ *  0 prod            folder, expanded
+ *  1   eu            folder, expanded
+ *  2     host-a
+ *  3   us            folder, collapsed
+ *  4 lab             folder, expanded
+ *  5   host-b
+ */
+const NODES: VisibleNode[] = [
+  row('prod', 0, true),
+  row('eu', 1, true),
+  row('host-a', 2),
+  row('us', 1, false),
+  row('lab', 0, true),
+  row('host-b', 1),
+];
+
+describe('treeNavAction', () => {
+  it('steps down and up through visible rows and stops at the ends', () => {
+    expect(treeNavAction(NODES, 0, 'ArrowDown')).toEqual({ kind: 'focus', index: 1 });
+    expect(treeNavAction(NODES, 5, 'ArrowDown')).toEqual({ kind: 'none' });
+    expect(treeNavAction(NODES, 3, 'ArrowUp')).toEqual({ kind: 'focus', index: 2 });
+    expect(treeNavAction(NODES, 0, 'ArrowUp')).toEqual({ kind: 'none' });
+  });
+
+  it('jumps to the first and last visible rows', () => {
+    expect(treeNavAction(NODES, 3, 'Home')).toEqual({ kind: 'focus', index: 0 });
+    expect(treeNavAction(NODES, 3, 'End')).toEqual({ kind: 'focus', index: 5 });
+  });
+
+  it('expands a collapsed folder, then steps into it', () => {
+    expect(treeNavAction(NODES, 3, 'ArrowRight')).toEqual({ kind: 'expand', key: 'us' });
+    expect(treeNavAction(NODES, 1, 'ArrowRight')).toEqual({ kind: 'focus', index: 2 });
+  });
+
+  it('does nothing on a host or an expanded but childless folder', () => {
+    expect(treeNavAction(NODES, 2, 'ArrowRight')).toEqual({ kind: 'none' });
+    const childless = [row('empty', 0, true), row('sibling', 0, true)];
+    expect(treeNavAction(childless, 0, 'ArrowRight')).toEqual({ kind: 'none' });
+  });
+
+  it('collapses an expanded folder, otherwise walks to the parent', () => {
+    expect(treeNavAction(NODES, 1, 'ArrowLeft')).toEqual({ kind: 'collapse', key: 'eu' });
+    expect(treeNavAction(NODES, 2, 'ArrowLeft')).toEqual({ kind: 'focus', index: 1 });
+    // A collapsed folder steps out rather than collapsing again.
+    expect(treeNavAction(NODES, 3, 'ArrowLeft')).toEqual({ kind: 'focus', index: 0 });
+    expect(treeNavAction(NODES, 0, 'ArrowLeft')).toEqual({ kind: 'collapse', key: 'prod' });
+  });
+
+  it('has nothing to do in an empty tree', () => {
+    expect(treeNavAction([], 0, 'ArrowDown')).toEqual({ kind: 'none' });
+  });
+});
+
+describe('parentIndex', () => {
+  it('finds the nearest shallower row above', () => {
+    expect(parentIndex(NODES, 2)).toBe(1);
+    expect(parentIndex(NODES, 3)).toBe(0);
+    expect(parentIndex(NODES, 5)).toBe(4);
+  });
+
+  it('reports no parent at the top level', () => {
+    expect(parentIndex(NODES, 0)).toBe(-1);
+    expect(parentIndex(NODES, 4)).toBe(-1);
+  });
+});
+
+describe('typeAheadIndex', () => {
+  const labels = ['Production', 'edge-1', 'edge-2', 'Lab'];
+
+  it('finds the next prefix match after the current row', () => {
+    expect(typeAheadIndex(labels, 0, 'e')).toBe(1);
+    expect(typeAheadIndex(labels, 1, 'e')).toBe(2);
+  });
+
+  it('wraps around the end of the list', () => {
+    expect(typeAheadIndex(labels, 2, 'e')).toBe(1);
+    expect(typeAheadIndex(labels, 3, 'p')).toBe(0);
+  });
+
+  it('ignores case', () => {
+    expect(typeAheadIndex(labels, 3, 'PROD')).toBe(0);
+  });
+
+  it('reports no match rather than moving focus', () => {
+    expect(typeAheadIndex(labels, 0, 'zz')).toBe(-1);
+    expect(typeAheadIndex(labels, 0, '')).toBe(-1);
+  });
+
+  it('keeps the focused row when a growing buffer still matches it', () => {
+    // Typing "e", "d", "g" must not hop away from the row it already selected.
+    expect(typeAheadIndex(labels, 1, 'edg')).toBe(2);
+    expect(typeAheadIndex(labels, 1, 'edge-1')).toBe(1);
+  });
+});
+
+describe('focusAfterChange', () => {
+  it('keeps the focused row when it survives', () => {
+    expect(focusAfterChange(NODES, 'host-a', 2)).toBe('host-a');
+  });
+
+  it('falls back to whatever took its place', () => {
+    expect(focusAfterChange(NODES, 'deleted', 3)).toBe('us');
+  });
+
+  it('clamps past the end of a shorter list', () => {
+    expect(focusAfterChange(NODES.slice(0, 2), 'deleted', 5)).toBe('eu');
+  });
+
+  it('reports nothing to focus in an empty tree', () => {
+    expect(focusAfterChange([], 'gone', 0)).toBeUndefined();
+  });
+});

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -174,10 +174,24 @@ describe('hybrid OpenSSH metadata', () => {
     const grouped = database.updateOpenSshMetadata('two', { group: 'production' });
     const cleared = database.updateOpenSshMetadata('one', { group: null, color: null });
 
-    expect(grouped).toMatchObject({ group: 'Production' });
+    // One group, not two — but the latest spelling wins, so renaming a sidebar
+    // folder to fix its capitalization actually takes effect.
+    expect(grouped).toMatchObject({ group: 'production' });
     expect(cleared).toMatchObject({ favorite: false });
     expect(cleared.group).toBeUndefined();
     expect(cleared.color).toBeUndefined();
+  });
+
+  it('applies a case-only group rename to every host already in it', () => {
+    database = new MuxusDatabase(':memory:');
+
+    database.updateOpenSshMetadata('one', { group: 'prod' });
+    database.updateOpenSshMetadata('two', { group: 'prod' });
+    database.updateOpenSshMetadata('one', { group: 'Prod' });
+
+    const metadata = database.openSshMetadata(['one', 'two']);
+    expect(metadata.get('one')).toMatchObject({ group: 'Prod' });
+    expect(metadata.get('two')).toMatchObject({ group: 'Prod' });
   });
 
   it('preserves the stable profile ID when an OpenSSH alias is renamed', () => {


### PR DESCRIPTION
The sidebar was a flat list of groups, and every host row spent two lines on a name and a `user@host` address it rarely needed. Past twenty hosts it stopped being scannable, and there was no way to express `Production/EU/Edge`.

## Approach

The Muxus group string becomes a folder path, with `/` between levels. Nesting therefore needs **no schema change, no new endpoint and no migration** — existing flat groups keep working untouched, and a legacy name containing a slash simply reads as nesting.

Host rows drop to a single line. The address, proxy jump, key and forwards move into the hover card that already existed, which roughly doubles how many hosts fit on screen.

## What you get

- **Nested folders** — create, rename, re-parent, colour, icon, delete. A folder's colour runs down its children as a rail.
- **Free ordering** — folders drag into position like hosts. Manual order is kept per parent and falls back to alphabetical for folders you haven't placed, mirroring how `sortOrder` already works for hosts, so a new folder still lands somewhere predictable.
- **A real tree** — `role="tree"` with a roving tabindex, so the whole sidebar is one tab stop. Arrow keys, Home/End and type-ahead navigate it; `←` collapses or steps to the parent.
- **Never mouse-only** — Alt+Arrow reorders, and the context menus offer Move up/down and Move to folder.
- **Search** shows only matching branches, auto-expanded, without disturbing your saved collapse state.
- Expansion, colours, icons and order persist across reloads and round-trip through a backup.

## Server changes

Two fixes this surfaced:

- `group` was capped at 100 characters, written for a single name. A nested path blows past it, and a deep rename would 400 mid-flight leaving a folder half moved. Raised to 300.
- `groupIdForName` matched an existing group case-insensitively but never updated its name, so renaming a folder to fix its capitalisation silently did nothing. The last spelling now wins, which is what a rename means.

> The second one is a deliberate behaviour change worth a look: assigning a host to `production` when `Production` exists now renames the shared folder rather than snapping the host to the existing casing. It updates one existing assertion in `database.test.ts`. The alternative — rejecting case-only renames in the dialog — is a one-line swap if you'd rather keep the old behaviour.

## Correctness notes

- Folder edits are planned from the **unfiltered** host list and disabled while searching. Rewriting a path from the filtered tree would strand every host the filter hid on the old path — the sharpest edge in this feature.
- A rename fans out through one batched mutation with a single optimistic update, one toast and one refetch, rather than one of each per host.
- Ancestry is compared by segment, so `Production` is not treated as living inside `Prod`.
- Drop targets resolve from row geometry rather than `event.target`, which Chrome leaves pointing at a stale row mid-drag.

## Bundle

The initial JS grows ~12 KiB: the tree model, keyboard navigation and drag-and-drop are the host list itself and can't be deferred. The context menus and dialogs it opens moved into a lazy chunk (~12 KiB back), and the budget moves to cover the difference.

## Verification

427 unit tests pass (up from 327); lint, typecheck and the bundle budget are green.

New pure-function coverage for path handling, tree building, flattening, keyboard navigation, drop rules and folder rewrite planning.

Driven end to end in the running app against an isolated config — nesting and ARIA levels, single tab stop, arrow navigation, rename fanning out to descendants while leaving siblings alone, new folder + move host, drag host into folder, drag folder to reorder at top level and nested, order surviving reload and rename, delete lifting hosts into the parent, search, and a 200px sidebar at depth 4 with no overflow.