### PR TITLE
feat: reconnect remote sessions and restore terminal history

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -68,9 +68,14 @@ const initialKeys = collectStaticGraph(entry[0]);
 // The sidebar's folder tree adds ~12 KiB raw on top of that. Its model,
 // keyboard navigation and drag-and-drop are the host list itself and cannot be
 // deferred; the menus and dialogs it opens are lazy (see SidebarMenus).
+//
+// Workspace restoration also reads the remote reconnect preference before
+// terminals mount. That startup decision adds ~0.2 KiB raw / ~0.1 KiB gzip;
+// the reconnect and scrollback implementations remain in the lazy terminal
+// feature graph measured below.
 check('Initial JavaScript', measureGraph(initialKeys), {
   raw: 782_000,
-  gzip: 249_000,
+  gzip: 250_000,
 });
 
 for (const feature of [

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -491,6 +491,48 @@ function BehaviorSection() {
           }
         />
       </Box>
+      <Box>
+        <SectionTitle>Restore & reconnect</SectionTitle>
+        <Stack spacing={1.5}>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={prefs.autoReconnectRemote}
+                onChange={(e) => prefs.set({ autoReconnectRemote: e.target.checked })}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body2">Automatically reconnect remote sessions</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Restoring a workspace dials its SSH, Telnet and serial tabs, and a dropped
+                  connection redials a few times before waiting for a key press. Off: remote
+                  tabs wait until asked.
+                </Typography>
+              </Box>
+            }
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={prefs.restoreScrollback}
+                onChange={(e) => prefs.set({ restoreScrollback: e.target.checked })}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body2">Restore terminal history</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Recent output is saved locally every few seconds and shown again above the
+                  new session after a restore or reconnect.
+                </Typography>
+              </Box>
+            }
+          />
+        </Stack>
+      </Box>
     </Stack>
   );
 }

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -70,13 +70,14 @@ import {
 } from '../connection-recovery.js';
 import {
   fetchTerminalSnapshot,
-  KEEPALIVE_BODY_LIMIT_BYTES,
   putTerminalSnapshot,
   serializeScrollback,
+  snapshotBodyBytes,
   TERMINAL_HISTORY_DIVIDER,
   TERMINAL_SNAPSHOT_INTERVAL_MS,
   TERMINAL_SNAPSHOT_QUIET_MS,
 } from '../terminal/scrollback-snapshots.js';
+import { registerUnloadKeepalive } from '../unload-keepalive.js';
 
 const SEARCH_DECORATIONS: ISearchOptions['decorations'] = {
   matchBackground: '#594b24',
@@ -425,6 +426,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     let sawAuthPrompt = false;
     let readyAt = 0;
     let snapshotDirty = false;
+    let snapshotRevision = 0;
+    let snapshotSaving = false;
+    let unloadQueuedRevision: number | undefined;
     let receivedTerminalOutput = false;
     let waitingForTerminalOutput = false;
     let transportSuspect = false;
@@ -436,17 +440,24 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     };
 
     // Persist recent output in the background so a later restore can replay it.
-    // A closing window can only send a keepalive request, which browsers cap
-    // at 64 KiB, so that path serializes into the smaller budget.
-    const persistSnapshot = (keepalive = false) => {
-      if (!snapshotDirty || !usePrefsStore.getState().restoreScrollback) return;
-      const data = serializeScrollback(
-        serialize,
-        keepalive ? { maxBodyBytes: KEEPALIVE_BODY_LIMIT_BYTES } : {},
-      );
+    // Keep the buffer dirty until the request succeeds: an unload that races
+    // an ordinary fetch must still queue a keepalive copy.
+    const persistSnapshot = () => {
+      if (
+        !snapshotDirty ||
+        snapshotSaving ||
+        !usePrefsStore.getState().restoreScrollback
+      ) {
+        return;
+      }
+      const data = serializeScrollback(serialize);
       if (data === undefined) return;
-      snapshotDirty = false;
-      putTerminalSnapshot(tab.id, data, { keepalive });
+      const savedRevision = snapshotRevision;
+      snapshotSaving = true;
+      void putTerminalSnapshot(tab.id, data).then((saved) => {
+        snapshotSaving = false;
+        if (saved && snapshotRevision === savedRevision) snapshotDirty = false;
+      });
     };
     const snapshotTimer = setInterval(() => persistSnapshot(), TERMINAL_SNAPSHOT_INTERVAL_MS);
     // The interval alone would lose a command run seconds before the window
@@ -459,9 +470,45 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         persistSnapshot();
       }, TERMINAL_SNAPSHOT_QUIET_MS);
     };
-    const flushSnapshotOnUnload = () => persistSnapshot(true);
-    window.addEventListener('beforeunload', flushSnapshotOnUnload);
-    window.addEventListener('pagehide', flushSnapshotOnUnload);
+    const unregisterUnloadFlush = registerUnloadKeepalive(
+      (maxBodyBytes) => {
+        if (!snapshotDirty || !usePrefsStore.getState().restoreScrollback) return 0;
+        if (unloadQueuedRevision === snapshotRevision) return 0;
+        const data = serializeScrollback(serialize, { maxBodyBytes });
+        if (data === undefined) return 0;
+        const savedRevision = snapshotRevision;
+        unloadQueuedRevision = savedRevision;
+        void putTerminalSnapshot(tab.id, data, { keepalive: true }).then((saved) => {
+          if (saved && snapshotRevision === savedRevision) snapshotDirty = false;
+          if (unloadQueuedRevision === savedRevision) unloadQueuedRevision = undefined;
+        });
+        return snapshotBodyBytes(data);
+      },
+      {
+        priority: 0,
+        isPending: () =>
+          snapshotDirty &&
+          usePrefsStore.getState().restoreScrollback &&
+          unloadQueuedRevision !== snapshotRevision,
+      },
+    );
+    const unsubscribeReconnectPreference = usePrefsStore.subscribe((state, previous) => {
+      if (
+        previous.autoReconnectRemote &&
+        !state.autoReconnectRemote &&
+        autoReconnectTimer !== undefined
+      ) {
+        clearTimeout(autoReconnectTimer);
+        autoReconnectTimer = undefined;
+        autoReconnectAttemptsRef.current = Math.max(
+          0,
+          autoReconnectAttemptsRef.current - 1,
+        );
+        term.write(
+          '\x1b[1;36mAutomatic reconnect disabled — press any key to reconnect\x1b[0m\r\n',
+        );
+      }
+    });
 
     const openSocket = () => {
       ws = new WebSocket(wsUrl('/ws/terminal'), wsProtocols());
@@ -485,6 +532,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
           clearTransientStatus();
           receivedTerminalOutput = true;
           snapshotDirty = true;
+          snapshotRevision += 1;
           scheduleQuietSnapshot();
           if (waitingForTerminalOutput) {
             waitingForTerminalOutput = false;
@@ -635,6 +683,14 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               `\x1b[1;36mReconnecting in ${Math.round(redialDelay / 1000)}s (attempt ${autoReconnectAttemptsRef.current} of ${AUTO_RECONNECT_DELAYS_MS.length}) — any key reconnects now\x1b[0m\r\n`,
             );
             autoReconnectTimer = setTimeout(() => {
+              autoReconnectTimer = undefined;
+              if (!usePrefsStore.getState().autoReconnectRemote) {
+                autoReconnectAttemptsRef.current = Math.max(
+                  0,
+                  autoReconnectAttemptsRef.current - 1,
+                );
+                return;
+              }
               const state = useTabsStore.getState();
               const current = state.tabs.find((candidate) => candidate.id === tab.id);
               if (current?.status !== 'closed') return;
@@ -695,8 +751,6 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       if (replay) {
         term.write(replay);
         term.write(TERMINAL_HISTORY_DIVIDER);
-        snapshotDirty = true;
-        scheduleQuietSnapshot();
       }
       if (shouldConnect) {
         openSocket();
@@ -761,16 +815,15 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       disposed = true;
       clearInterval(snapshotTimer);
       if (quietSnapshotTimer !== undefined) clearTimeout(quietSnapshotTimer);
-      window.removeEventListener('beforeunload', flushSnapshotOnUnload);
-      window.removeEventListener('pagehide', flushSnapshotOnUnload);
+      unregisterUnloadFlush();
+      unsubscribeReconnectPreference();
       // The buffer outlives this socket generation: a reconnect replays it in
       // place, and the stored copy keeps the tail output a restart would lose.
       if (usePrefsStore.getState().restoreScrollback) {
         const data = serializeScrollback(serialize);
         carryBufferRef.current = data ?? null;
         if (snapshotDirty && data !== undefined) {
-          snapshotDirty = false;
-          putTerminalSnapshot(tab.id, data);
+          void putTerminalSnapshot(tab.id, data);
         }
       } else {
         carryBufferRef.current = null;

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -57,6 +57,9 @@ import { AuthPromptDialog, type AuthPromptRequest } from './AuthPromptDialog.js'
 import { HostKeyDialog, type HostKeyRequest } from './HostKeyDialog.js';
 import { PasteConfirmDialog } from './PasteConfirmDialog.js';
 import {
+  AUTO_RECONNECT_DELAYS_MS,
+  AUTO_RECONNECT_STABLE_MS,
+  autoReconnectDelayMs,
   CONNECTION_INTERRUPTION_GRACE_MS,
   connectionFailureReason,
   reattachCommand,
@@ -65,6 +68,15 @@ import {
   terminalNotice,
   type TerminalExitMessage,
 } from '../connection-recovery.js';
+import {
+  fetchTerminalSnapshot,
+  KEEPALIVE_BODY_LIMIT_BYTES,
+  putTerminalSnapshot,
+  serializeScrollback,
+  TERMINAL_HISTORY_DIVIDER,
+  TERMINAL_SNAPSHOT_INTERVAL_MS,
+  TERMINAL_SNAPSHOT_QUIET_MS,
+} from '../terminal/scrollback-snapshots.js';
 
 const SEARCH_DECORATIONS: ISearchOptions['decorations'] = {
   matchBackground: '#594b24',
@@ -106,6 +118,12 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const lastSearchRequestRef = useRef(tab.searchRequest);
   /** Per-tab zoom offset added to the preference font size. */
   const zoomRef = useRef(0);
+  /** Automatic redials since the last stable connection; survives remounts of the socket. */
+  const autoReconnectAttemptsRef = useRef(0);
+  /** Serialized buffer carried across socket generations by a reconnect. */
+  const carryBufferRef = useRef<string | null>(null);
+  /** Stored history is fetched at most once per mounted tab. */
+  const snapshotFetchedRef = useRef(false);
   const theme = useTheme();
   const [authPrompt, setAuthPrompt] = useState<AuthPromptRequest | null>(null);
   const [hostKey, setHostKey] = useState<HostKeyRequest | null>(null);
@@ -253,6 +271,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       cursorBlink: prefs.cursorBlink,
       cursorStyle: prefs.cursorStyle,
       scrollback: prefs.scrollback,
+      // ED2 pushes the screen into scrollback instead of blanking it, so a
+      // shell that clears on login cannot destroy freshly restored history.
+      scrollOnEraseInDisplay: true,
       allowProposedApi: true,
       // ImageAddon uses a bottom layer for negative-z Kitty placements.
       allowTransparency: true,
@@ -396,9 +417,14 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     });
 
     let ws: WebSocket | undefined;
+    let disposed = false;
     let socketFailed = false;
     let exitMessage: TerminalExitMessage | undefined;
     let interruptionTimer: ReturnType<typeof setTimeout> | undefined;
+    let autoReconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let sawAuthPrompt = false;
+    let readyAt = 0;
+    let snapshotDirty = false;
     let receivedTerminalOutput = false;
     let waitingForTerminalOutput = false;
     let transportSuspect = false;
@@ -409,7 +435,35 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       term.write('\r\x1b[2K');
     };
 
-    if (shouldConnect) {
+    // Persist recent output in the background so a later restore can replay it.
+    // A closing window can only send a keepalive request, which browsers cap
+    // at 64 KiB, so that path serializes into the smaller budget.
+    const persistSnapshot = (keepalive = false) => {
+      if (!snapshotDirty || !usePrefsStore.getState().restoreScrollback) return;
+      const data = serializeScrollback(
+        serialize,
+        keepalive ? { maxBodyBytes: KEEPALIVE_BODY_LIMIT_BYTES } : {},
+      );
+      if (data === undefined) return;
+      snapshotDirty = false;
+      putTerminalSnapshot(tab.id, data, { keepalive });
+    };
+    const snapshotTimer = setInterval(() => persistSnapshot(), TERMINAL_SNAPSHOT_INTERVAL_MS);
+    // The interval alone would lose a command run seconds before the window
+    // closes, so snapshot once output goes quiet as well.
+    let quietSnapshotTimer: ReturnType<typeof setTimeout> | undefined;
+    const scheduleQuietSnapshot = () => {
+      if (quietSnapshotTimer !== undefined) clearTimeout(quietSnapshotTimer);
+      quietSnapshotTimer = setTimeout(() => {
+        quietSnapshotTimer = undefined;
+        persistSnapshot();
+      }, TERMINAL_SNAPSHOT_QUIET_MS);
+    };
+    const flushSnapshotOnUnload = () => persistSnapshot(true);
+    window.addEventListener('beforeunload', flushSnapshotOnUnload);
+    window.addEventListener('pagehide', flushSnapshotOnUnload);
+
+    const openSocket = () => {
       ws = new WebSocket(wsUrl('/ws/terminal'), wsProtocols());
       wsRef.current = ws;
       ws.binaryType = 'arraybuffer';
@@ -430,6 +484,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         if (ev.data instanceof ArrayBuffer) {
           clearTransientStatus();
           receivedTerminalOutput = true;
+          snapshotDirty = true;
+          scheduleQuietSnapshot();
           if (waitingForTerminalOutput) {
             waitingForTerminalOutput = false;
             if (!transportSuspect) {
@@ -491,6 +547,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             }
             break;
           case 'auth-prompt':
+            sawAuthPrompt = true;
             setAuthPrompt({ name: ctl.name, instructions: ctl.instructions, host: ctl.host, prompts: ctl.prompts });
             break;
           case 'host-key':
@@ -498,6 +555,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             break;
           case 'ready': {
             ready = true;
+            readyAt = Date.now();
             clearTransientStatus();
             waitingForTerminalOutput = shouldWaitForTerminalOutput(
               tab.profile.kind,
@@ -552,12 +610,40 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         setHostKey(null);
 
         const showFinalState = () => {
+          // A drop after a stable stretch is a fresh incident, not one more
+          // failure of the previous redial chain.
+          if (readyAt !== 0 && Date.now() - readyAt >= AUTO_RECONNECT_STABLE_MS) {
+            autoReconnectAttemptsRef.current = 0;
+          }
+          const redialDelay = autoReconnectDelayMs({
+            enabled: usePrefsStore.getState().autoReconnectRemote,
+            profileKind: tab.profile.kind,
+            reason: reasonKind,
+            attempts: autoReconnectAttemptsRef.current,
+            sawAuthPrompt,
+          });
           term.write(
             `\r\n\x1b[${reasonKind === 'completed' ? '33' : '31'}m[${
               reasonKind === 'completed' ? 'session ended' : 'connection lost'
             }: ${terminalNotice(reason)}]\x1b[0m\r\n`,
           );
-          term.write('\x1b[1;36mPress any key to reconnect\x1b[0m\r\n');
+          if (redialDelay === undefined) {
+            term.write('\x1b[1;36mPress any key to reconnect\x1b[0m\r\n');
+          } else {
+            autoReconnectAttemptsRef.current += 1;
+            term.write(
+              `\x1b[1;36mReconnecting in ${Math.round(redialDelay / 1000)}s (attempt ${autoReconnectAttemptsRef.current} of ${AUTO_RECONNECT_DELAYS_MS.length}) — any key reconnects now\x1b[0m\r\n`,
+            );
+            autoReconnectTimer = setTimeout(() => {
+              const state = useTabsStore.getState();
+              const current = state.tabs.find((candidate) => candidate.id === tab.id);
+              if (current?.status !== 'closed') return;
+              state.reconnect(
+                [tab.id],
+                current.reconnectMode ? { reattach: current.reconnectMode } : undefined,
+              );
+            }, redialDelay);
+          }
           updateTab(tab.id, {
             status: 'closed',
             connId: undefined,
@@ -585,10 +671,41 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
           showFinalState();
         }, CONNECTION_INTERRUPTION_GRACE_MS);
       };
-    } else {
-      term.write('\x1b[90m[restored session]\x1b[0m\r\n');
-      term.write('\x1b[1;36mPress any key to reconnect\x1b[0m\r\n');
-    }
+    };
+
+    // Replay what this tab showed before — buffer carried over a reconnect,
+    // or the stored snapshot on the first mount of a restored tab — and only
+    // then let the new session write, so its output lands below the divider.
+    const boot = async () => {
+      let replay = carryBufferRef.current;
+      carryBufferRef.current = null;
+      if (
+        replay === null &&
+        tab.restored &&
+        !snapshotFetchedRef.current &&
+        usePrefsStore.getState().restoreScrollback
+      ) {
+        const fetched = await fetchTerminalSnapshot(tab.id);
+        // A torn-down run must not latch the ref: the replacement effect run
+        // repeats the fetch instead of silently restoring nothing.
+        if (disposed) return;
+        snapshotFetchedRef.current = true;
+        replay = fetched;
+      }
+      if (replay) {
+        term.write(replay);
+        term.write(TERMINAL_HISTORY_DIVIDER);
+        snapshotDirty = true;
+        scheduleQuietSnapshot();
+      }
+      if (shouldConnect) {
+        openSocket();
+      } else {
+        term.write('\x1b[90m[restored session]\x1b[0m\r\n');
+        term.write('\x1b[1;36mPress any key to reconnect\x1b[0m\r\n');
+      }
+    };
+    void boot();
 
     const reconnectFromTerminalInput = (): boolean => {
       const state = useTabsStore.getState();
@@ -641,6 +758,23 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     observer.observe(el);
 
     return () => {
+      disposed = true;
+      clearInterval(snapshotTimer);
+      if (quietSnapshotTimer !== undefined) clearTimeout(quietSnapshotTimer);
+      window.removeEventListener('beforeunload', flushSnapshotOnUnload);
+      window.removeEventListener('pagehide', flushSnapshotOnUnload);
+      // The buffer outlives this socket generation: a reconnect replays it in
+      // place, and the stored copy keeps the tail output a restart would lose.
+      if (usePrefsStore.getState().restoreScrollback) {
+        const data = serializeScrollback(serialize);
+        carryBufferRef.current = data ?? null;
+        if (snapshotDirty && data !== undefined) {
+          snapshotDirty = false;
+          putTerminalSnapshot(tab.id, data);
+        }
+      } else {
+        carryBufferRef.current = null;
+      }
       if (fitTimer !== undefined) clearTimeout(fitTimer);
       observer.disconnect();
       unregister();
@@ -654,6 +788,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       commandTracker.dispose();
       keywordHighlighterRef.current?.dispose();
       if (interruptionTimer !== undefined) clearTimeout(interruptionTimer);
+      if (autoReconnectTimer !== undefined) clearTimeout(autoReconnectTimer);
       if (ws) {
         ws.onopen = null;
         ws.onmessage = null;

--- a/client/src/connection-recovery.ts
+++ b/client/src/connection-recovery.ts
@@ -4,6 +4,36 @@ export type ReattachMode = 'tmux' | 'screen';
 export type TerminalExitMessage = Extract<TerminalServerMessage, { op: 'exit' }>;
 export const CONNECTION_INTERRUPTION_GRACE_MS = 5_000;
 
+/** Delays before each automatic reconnect attempt after a lost connection. */
+export const AUTO_RECONNECT_DELAYS_MS: readonly number[] = [2_000, 5_000, 15_000];
+
+/** Uptime after which a drop is a fresh incident with a fresh attempt budget. */
+export const AUTO_RECONNECT_STABLE_MS = 30_000;
+
+export interface AutoReconnectInput {
+  /** The auto-reconnect preference. */
+  enabled: boolean;
+  profileKind: 'ssh' | 'local' | 'telnet' | 'serial';
+  reason: 'completed' | 'failed' | 'disconnected';
+  /** Automatic attempts already made since the last stable connection. */
+  attempts: number;
+  /** An interactive auth prompt was shown; redialling would only re-prompt. */
+  sawAuthPrompt: boolean;
+}
+
+/** Delay before the next automatic redial, or undefined to wait for the user. */
+export function autoReconnectDelayMs(input: AutoReconnectInput): number | undefined {
+  if (!input.enabled || input.profileKind === 'local') return undefined;
+  if (input.reason === 'completed') return undefined;
+  // A failed dial may continue a chain that a real drop started, but never
+  // start one — that would loop on hosts that refuse to connect at all — and
+  // never talk over an auth prompt the user walked away from.
+  if (input.reason === 'failed' && (input.attempts === 0 || input.sawAuthPrompt)) {
+    return undefined;
+  }
+  return AUTO_RECONNECT_DELAYS_MS[input.attempts];
+}
+
 const ANSI_CSI_PATTERN = new RegExp(
   `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
   'g',

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -61,6 +61,10 @@ export interface PrefsState {
   pasteWarnMultiline: boolean;
   /** Ask before closing a tab with a live session. */
   confirmCloseConnected: boolean;
+  /** Dial remote sessions on workspace restore and retry dropped connections. */
+  autoReconnectRemote: boolean;
+  /** Persist recent terminal output and replay it on restore and reconnect. */
+  restoreScrollback: boolean;
   /** Scale of the whole interface, 1 = 100%. */
   interfaceZoom: number;
   /** Splitting a pane opens a second session on the same host. */
@@ -163,6 +167,8 @@ export const usePrefsStore = create<PrefsState>()(
       rightClickAction: 'copy-paste',
       pasteWarnMultiline: true,
       confirmCloseConnected: true,
+      autoReconnectRemote: true,
+      restoreScrollback: true,
       interfaceZoom: 1,
       splitInheritsSession: true,
       keybindings: {},

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -17,6 +17,7 @@ import {
   type PaneDirection,
   type PaneLeaf,
   type PaneNode,
+  type RestoreWorkspaceOptions,
 } from './workspace-layout.js';
 
 export type TabStatus = 'connecting' | 'connected' | 'interrupted' | 'closed';
@@ -49,6 +50,8 @@ interface TabBase {
   /** Most recent connection/end reason, shown without requiring terminal scrollback. */
   failureReason?: string;
   disconnectReason?: 'completed' | 'failed' | 'disconnected';
+  /** Tab came from a persisted workspace layout, so stored scrollback may exist. */
+  restored?: boolean;
 }
 
 export interface SessionTab extends TabBase {
@@ -133,7 +136,7 @@ interface TabsState {
   openEditor: (tabId: string, path: string) => void;
   activateEditor: (tabId: string, path: string) => void;
   closeEditor: (tabId: string, path: string) => void;
-  restore: (layout: WorkspaceLayoutV1) => void;
+  restore: (layout: WorkspaceLayoutV1, options?: RestoreWorkspaceOptions) => void;
   /** Replace the pane canvas with a freshly connected, arranged session set. */
   launchSet: (entries: readonly SessionSetEntry[], layout: SessionSetLayout) => string[];
   /** Start fresh connections for selected ended/restored sessions. */
@@ -514,7 +517,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
         return { ...tab, editorPaths, activeEditorPath };
       }),
     })),
-  restore: (layout) =>
+  restore: (layout, options) =>
     set((state) => {
       if (!layout.root) {
         const pane = initialPane();
@@ -526,13 +529,14 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           zoomedPaneId: null,
         };
       }
-      const restored = restoreWorkspaceLayout(layout);
+      const restored = restoreWorkspaceLayout(layout, options);
       if (!restored) return state;
       return {
         ...restored,
         zoomedPaneId: null,
         tabs: restored.tabs.map((tab) => ({
           ...tab,
+          restored: true,
           status: tab.connectOnMount ? 'connecting' as const : 'closed' as const,
           sftpOpen: false,
           searchRequest: 0,

--- a/client/src/state/workspace-layout.ts
+++ b/client/src/state/workspace-layout.ts
@@ -44,8 +44,13 @@ export interface PersistableTerminalTab {
 }
 
 export interface RestoredTerminalTab extends PersistableTerminalTab {
-  /** Local shells start fresh immediately; remote sessions still wait for consent. */
+  /** Local shells start fresh immediately; remote sessions dial only when the restore opts in. */
   connectOnMount: boolean;
+}
+
+export interface RestoreWorkspaceOptions {
+  /** Dial restored remote sessions instead of waiting for a key press. */
+  connectRemote?: boolean;
 }
 
 export interface LayoutRect {
@@ -272,6 +277,7 @@ export function serializeWorkspace(
 
 export function restoreWorkspace(
   layout: WorkspaceLayoutV1,
+  options?: RestoreWorkspaceOptions,
 ): {
   root: PaneNode;
   tabs: RestoredTerminalTab[];
@@ -302,7 +308,8 @@ export function restoreWorkspace(
         title: tab.title,
         profile,
         color: tab.color,
-        connectOnMount: profile.kind === 'local',
+        connectOnMount:
+          profile.kind === 'local' || (options?.connectRemote === true && tab.offerReconnect),
       });
     }
     const activeTabId =

--- a/client/src/terminal/scrollback-snapshots.ts
+++ b/client/src/terminal/scrollback-snapshots.ts
@@ -1,6 +1,7 @@
 import type { SerializeAddon } from '@xterm/addon-serialize';
 import { TERMINAL_SNAPSHOT_MAX_CHARS, type TerminalSnapshotRecord } from '@muxus/shared';
 import { apiFetch, authToken } from '../api/http.js';
+import { requestBodyBytes } from '../unload-keepalive.js';
 
 /** Scrollback depths a snapshot tries, largest first, until one fits its budget. */
 export const SNAPSHOT_SCROLLBACK_LADDER: readonly number[] = [1_000, 400, 150, 50, 10];
@@ -11,12 +12,6 @@ export const TERMINAL_SNAPSHOT_INTERVAL_MS = 10_000;
 /** Idle gap after which output is snapshotted, so closing right after a
  *  command does not lose it to the interval above. */
 export const TERMINAL_SNAPSHOT_QUIET_MS = 1_500;
-
-/**
- * Browsers cap the total body of keepalive requests at 64 KiB, and a request
- * that exceeds it fails outright — the unload snapshot has to fit under it.
- */
-export const KEEPALIVE_BODY_LIMIT_BYTES = 60_000;
 
 /** Written after replayed history, before the new session's output. */
 export const TERMINAL_HISTORY_DIVIDER = '\r\n\x1b[90m[end of restored output]\x1b[0m\r\n';
@@ -61,7 +56,7 @@ export function snapshotRequestBody(data: string): string {
 /** Wire size of a snapshot. JSON escapes every ESC to six characters, so the
  *  body is several times the buffer and has to be measured, not estimated. */
 export function snapshotBodyBytes(data: string): number {
-  return new TextEncoder().encode(snapshotRequestBody(data)).length;
+  return requestBodyBytes(snapshotRequestBody(data));
 }
 
 /**
@@ -103,31 +98,36 @@ export async function fetchTerminalSnapshot(tabId: string): Promise<string | nul
   }
 }
 
-/** Fire-and-forget: losing a snapshot only costs some replayable history. */
-export function putTerminalSnapshot(
+/** Save a snapshot without surfacing an optional-history failure to the UI. */
+export async function putTerminalSnapshot(
   tabId: string,
   data: string,
   options: { keepalive?: boolean } = {},
-): void {
+): Promise<boolean> {
   const path = `/api/terminal-snapshots/${encodeURIComponent(tabId)}`;
   const body = snapshotRequestBody(data);
-  if (!options.keepalive) {
-    void apiFetch(path, {
+  try {
+    if (!options.keepalive) {
+      await apiFetch(path, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body,
+      });
+      return true;
+    }
+    // A closing window cancels its in-flight requests; keepalive lets this
+    // last snapshot outlive the page.
+    const response = await fetch(path, {
       method: 'PUT',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        authorization: `Bearer ${authToken()}`,
+        'content-type': 'application/json',
+      },
       body,
-    }).catch(() => undefined);
-    return;
+      keepalive: true,
+    });
+    return response.ok;
+  } catch {
+    return false;
   }
-  // A closing window cancels its in-flight requests; keepalive lets this last
-  // snapshot outlive the page, the way the workspace layout flush does.
-  void fetch(path, {
-    method: 'PUT',
-    headers: {
-      authorization: `Bearer ${authToken()}`,
-      'content-type': 'application/json',
-    },
-    body,
-    keepalive: true,
-  }).catch(() => undefined);
 }

--- a/client/src/terminal/scrollback-snapshots.ts
+++ b/client/src/terminal/scrollback-snapshots.ts
@@ -1,0 +1,133 @@
+import type { SerializeAddon } from '@xterm/addon-serialize';
+import { TERMINAL_SNAPSHOT_MAX_CHARS, type TerminalSnapshotRecord } from '@muxus/shared';
+import { apiFetch, authToken } from '../api/http.js';
+
+/** Scrollback depths a snapshot tries, largest first, until one fits its budget. */
+export const SNAPSHOT_SCROLLBACK_LADDER: readonly number[] = [1_000, 400, 150, 50, 10];
+
+/** Ceiling on the background snapshot while output keeps arriving. */
+export const TERMINAL_SNAPSHOT_INTERVAL_MS = 10_000;
+
+/** Idle gap after which output is snapshotted, so closing right after a
+ *  command does not lose it to the interval above. */
+export const TERMINAL_SNAPSHOT_QUIET_MS = 1_500;
+
+/**
+ * Browsers cap the total body of keepalive requests at 64 KiB, and a request
+ * that exceeds it fails outright — the unload snapshot has to fit under it.
+ */
+export const KEEPALIVE_BODY_LIMIT_BYTES = 60_000;
+
+/** Written after replayed history, before the new session's output. */
+export const TERMINAL_HISTORY_DIVIDER = '\r\n\x1b[90m[end of restored output]\x1b[0m\r\n';
+
+const ESC = String.fromCharCode(27);
+const CURSOR_MOVE_FINALS = 'ABCDEFGHdf`';
+
+/** Start index of a cursor-move sequence (ESC [ params final) ending exactly
+ *  at `end`, or `end` itself when none does. A plain scan — regexes over
+ *  newline runs backtrack catastrophically on this input. */
+function trailingCursorMoveStart(data: string, end: number): number {
+  if (end < 3 || !CURSOR_MOVE_FINALS.includes(data[end - 1]!)) return end;
+  let index = end - 2;
+  while (index >= 0 && ((data[index]! >= '0' && data[index]! <= '9') || data[index] === ';')) {
+    index--;
+  }
+  return index >= 1 && data[index] === '[' && data[index - 1] === ESC ? index - 1 : end;
+}
+
+/**
+ * A serialized buffer ends with the blank remainder of the old viewport and a
+ * cursor-repositioning sequence. Replayed as-is, that tail pushes the history
+ * a screenful above the divider — drop it so the divider hugs the last line.
+ */
+export function trimReplayTail(data: string): string {
+  let end = data.length;
+  for (;;) {
+    if (end > 0 && (data[end - 1] === '\n' || data[end - 1] === '\r')) {
+      end--;
+      continue;
+    }
+    const start = trailingCursorMoveStart(data, end);
+    if (start === end) return data.slice(0, end);
+    end = start;
+  }
+}
+
+export function snapshotRequestBody(data: string): string {
+  return JSON.stringify({ data });
+}
+
+/** Wire size of a snapshot. JSON escapes every ESC to six characters, so the
+ *  body is several times the buffer and has to be measured, not estimated. */
+export function snapshotBodyBytes(data: string): number {
+  return new TextEncoder().encode(snapshotRequestBody(data)).length;
+}
+
+/**
+ * Serialized recent buffer, or undefined when there is nothing worth keeping.
+ * Modes and the alt buffer are excluded so a replay can never leave a fresh
+ * terminal stuck in a full-screen application's state. Depth steps down until
+ * the result fits both the stored cap and any caller-supplied wire budget.
+ */
+export function serializeScrollback(
+  addon: SerializeAddon,
+  options: { maxBodyBytes?: number } = {},
+): string | undefined {
+  try {
+    for (const scrollback of SNAPSHOT_SCROLLBACK_LADDER) {
+      const data = trimReplayTail(
+        addon.serialize({ scrollback, excludeModes: true, excludeAltBuffer: true }),
+      );
+      if (data.length === 0) return undefined;
+      if (data.length > TERMINAL_SNAPSHOT_MAX_CHARS) continue;
+      if (options.maxBodyBytes !== undefined && snapshotBodyBytes(data) > options.maxBodyBytes) {
+        continue;
+      }
+      return data;
+    }
+  } catch {
+    /* a terminal mid-teardown cannot be serialized */
+  }
+  return undefined;
+}
+
+export async function fetchTerminalSnapshot(tabId: string): Promise<string | null> {
+  try {
+    const { snapshot } = await apiFetch<{ snapshot: TerminalSnapshotRecord | null }>(
+      `/api/terminal-snapshots/${encodeURIComponent(tabId)}`,
+    );
+    return snapshot?.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Fire-and-forget: losing a snapshot only costs some replayable history. */
+export function putTerminalSnapshot(
+  tabId: string,
+  data: string,
+  options: { keepalive?: boolean } = {},
+): void {
+  const path = `/api/terminal-snapshots/${encodeURIComponent(tabId)}`;
+  const body = snapshotRequestBody(data);
+  if (!options.keepalive) {
+    void apiFetch(path, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body,
+    }).catch(() => undefined);
+    return;
+  }
+  // A closing window cancels its in-flight requests; keepalive lets this last
+  // snapshot outlive the page, the way the workspace layout flush does.
+  void fetch(path, {
+    method: 'PUT',
+    headers: {
+      authorization: `Bearer ${authToken()}`,
+      'content-type': 'application/json',
+    },
+    body,
+    keepalive: true,
+  }).catch(() => undefined);
+}

--- a/client/src/unload-keepalive.ts
+++ b/client/src/unload-keepalive.ts
@@ -1,0 +1,95 @@
+/** Conservative share of the browser's 64 KiB page-wide keepalive body quota. */
+export const PAGE_KEEPALIVE_BODY_LIMIT_BYTES = 60_000;
+
+export interface UnloadKeepaliveFlush {
+  /** Higher-priority work consumes its share before lower-priority work. */
+  priority: number;
+  /** Cheap check used to divide a priority group's share only among active work. */
+  isPending?: () => boolean;
+  /** Queue at most `maxBodyBytes`, returning the body bytes actually queued. */
+  flush: (maxBodyBytes: number) => number;
+}
+
+const flushes = new Set<UnloadKeepaliveFlush>();
+let listening = false;
+
+/** UTF-8 wire size of a request body. */
+export function requestBodyBytes(body: string): number {
+  return new TextEncoder().encode(body).length;
+}
+
+/**
+ * Run page-unload work inside one shared body budget.
+ *
+ * Equal-priority callbacks split the remaining quota fairly. A multi-pane
+ * workspace therefore gives every terminal a chance to save a smaller tail
+ * instead of letting the first terminal consume the whole allowance.
+ */
+export function flushUnloadKeepalives(
+  pending: readonly UnloadKeepaliveFlush[],
+  maxBodyBytes = PAGE_KEEPALIVE_BODY_LIMIT_BYTES,
+): number {
+  const totalBudget = Math.max(0, Math.floor(maxBodyBytes));
+  let remaining = totalBudget;
+  const groups = new Map<number, UnloadKeepaliveFlush[]>();
+  for (const task of pending) {
+    try {
+      if (task.isPending && !task.isPending()) continue;
+    } catch {
+      continue;
+    }
+    const group = groups.get(task.priority) ?? [];
+    group.push(task);
+    groups.set(task.priority, group);
+  }
+
+  const priorities = [...groups.keys()].sort((left, right) => right - left);
+  for (const priority of priorities) {
+    const group = groups.get(priority)!;
+    for (let index = 0; index < group.length && remaining > 0; index++) {
+      const fairShare = Math.floor(remaining / (group.length - index));
+      if (fairShare === 0) break;
+      try {
+        const used = group[index]!.flush(fairShare);
+        if (Number.isFinite(used) && used > 0) {
+          remaining -= Math.min(fairShare, Math.floor(used));
+        }
+      } catch {
+        // One optional persistence task must not prevent the others from flushing.
+      }
+    }
+  }
+  return totalBudget - remaining;
+}
+
+function flushPage(): void {
+  flushUnloadKeepalives([...flushes]);
+}
+
+function startListening(): void {
+  if (listening) return;
+  listening = true;
+  window.addEventListener('beforeunload', flushPage);
+  window.addEventListener('pagehide', flushPage);
+}
+
+function stopListening(): void {
+  if (!listening || flushes.size > 0) return;
+  listening = false;
+  window.removeEventListener('beforeunload', flushPage);
+  window.removeEventListener('pagehide', flushPage);
+}
+
+/** Register unload persistence while keeping one pair of page-wide listeners. */
+export function registerUnloadKeepalive(
+  flush: UnloadKeepaliveFlush['flush'],
+  options: Pick<UnloadKeepaliveFlush, 'priority' | 'isPending'> = { priority: 0 },
+): () => void {
+  const task = { ...options, flush };
+  flushes.add(task);
+  startListening();
+  return () => {
+    flushes.delete(task);
+    stopListening();
+  };
+}

--- a/client/src/workspace-persistence.ts
+++ b/client/src/workspace-persistence.ts
@@ -11,10 +11,16 @@ import { usePrefsStore } from './state/prefs.js';
 import { useTabsStore, type SessionTab } from './state/tabs.js';
 import { serializeWorkspace } from './state/workspace-layout.js';
 import { useWorkspacesStore } from './state/workspaces.js';
+import {
+  PAGE_KEEPALIVE_BODY_LIMIT_BYTES,
+  registerUnloadKeepalive,
+  requestBodyBytes,
+} from './unload-keepalive.js';
 
 const SAVE_DELAY_MS = 350;
 const RETRY_DELAY_MS = 2_000;
 const DEFAULT_WORKSPACE_NAME = 'Workspace 1';
+const WORKSPACE_UNLOAD_PRIORITY = 100;
 
 interface WorkspaceSnapshot {
   layout: WorkspaceLayoutV1;
@@ -340,8 +346,8 @@ class WorkspaceRuntime {
     }
   }
 
-  private flushOnUnload(): void {
-    if (!this.pending) return;
+  flushOnUnload(maxBodyBytes = PAGE_KEEPALIVE_BODY_LIMIT_BYTES): number {
+    if (!this.pending) return 0;
     const { activeId, activeName } = useWorkspacesStore.getState();
     const body = JSON.stringify({
       id: activeId,
@@ -349,6 +355,9 @@ class WorkspaceRuntime {
       layout: this.pending.layout,
       multiExecGroups: this.pending.multiExecGroups,
     });
+    const bodyBytes = requestBodyBytes(body);
+    if (bodyBytes > maxBodyBytes) return 0;
+    this.pending = undefined;
     void fetch('/api/workspaces', {
       method: 'PUT',
       headers: {
@@ -358,6 +367,7 @@ class WorkspaceRuntime {
       body,
       keepalive: true,
     }).catch(() => undefined);
+    return bodyBytes;
   }
 }
 
@@ -380,11 +390,13 @@ export function useWorkspacePersistence(enabled = true): void {
     if (!enabled) return;
     const runtime = new WorkspaceRuntime();
     activeRuntime = runtime;
-    const flushOnUnload = () => runtime.stop();
-    window.addEventListener('beforeunload', flushOnUnload, { once: true });
+    const unregisterUnloadFlush = registerUnloadKeepalive(
+      (maxBodyBytes) => runtime.flushOnUnload(maxBodyBytes),
+      { priority: WORKSPACE_UNLOAD_PRIORITY },
+    );
     void runtime.start();
     return () => {
-      window.removeEventListener('beforeunload', flushOnUnload);
+      unregisterUnloadFlush();
       runtime.stop();
       if (activeRuntime === runtime) activeRuntime = undefined;
     };

--- a/client/src/workspace-persistence.ts
+++ b/client/src/workspace-persistence.ts
@@ -7,6 +7,7 @@ import type {
 } from '@muxus/shared';
 import { apiFetch, authToken } from './api/http.js';
 import { useMultiExecStore } from './state/multi-exec.js';
+import { usePrefsStore } from './state/prefs.js';
 import { useTabsStore, type SessionTab } from './state/tabs.js';
 import { serializeWorkspace } from './state/workspace-layout.js';
 import { useWorkspacesStore } from './state/workspaces.js';
@@ -35,6 +36,11 @@ function currentSnapshot(): WorkspaceSnapshot {
     multiExecGroups,
     serialized: JSON.stringify({ layout, multiExecGroups }),
   };
+}
+
+/** Restores dial remote sessions too unless the preference turned that off. */
+function restoreOptions() {
+  return { connectRemote: usePrefsStore.getState().autoReconnectRemote };
 }
 
 function summaryOf(workspace: WorkspaceRecord): WorkspaceSummary {
@@ -83,7 +89,7 @@ class WorkspaceRuntime {
             layout: workspace.layout,
             multiExecGroups: workspace.multiExecGroups,
           });
-          state.restore(workspace.layout);
+          state.restore(workspace.layout, restoreOptions());
           useMultiExecStore.getState().setGroups(workspace.multiExecGroups);
           this.restoring = false;
           restored = true;
@@ -198,7 +204,7 @@ class WorkspaceRuntime {
         { method: 'POST' },
       );
       this.restoring = true;
-      useTabsStore.getState().restore(workspace.layout);
+      useTabsStore.getState().restore(workspace.layout, restoreOptions());
       useMultiExecStore.getState().setGroups(workspace.multiExecGroups);
       this.restoring = false;
       this.pending = undefined;

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -67,7 +67,12 @@ global set.
 ## Behavior
 
 Tab behaviour, including **confirm before closing a live session**, which is on by default
-because closing a connected tab ends its shell.
+because closing a connected tab ends its shell, and the restore switches, both on by
+default: **automatically reconnect remote sessions** — restoring a workspace dials its
+remote tabs, and a dropped connection redials a few times on its own; turn it off to
+restore remote tabs without logging in — and **restore terminal history**, which saves
+recent output locally every few seconds and replays it above the new session after a
+restore or reconnect.
 
 ## Keyboard
 

--- a/docs/guide/workspaces.md
+++ b/docs/guide/workspaces.md
@@ -34,15 +34,25 @@ closes with live tabs flushes its layout on exit.
 
 ## What restore does
 
-Restore treats local and remote sessions differently:
+By default, restore brings the whole workspace back:
 
 - **Local shells start fresh.** A new PTY, in the same pane, in the same position.
-- **Remote sessions wait.** SSH, Telnet and serial tabs are restored as tabs, with their
-  titles and colours, but are not dialled until requested, so restoring a layout does not
-  trigger a set of simultaneous logins and 2FA prompts.
+- **Remote sessions reconnect.** SSH, Telnet and serial tabs are dialled again with their
+  titles and colours; hosts that authenticate interactively prompt as usual. Restoring a
+  layout never resumes a remote process — pair it with tmux or screen for that.
+- **Terminal history comes back.** Each tab replays its recent output (about the last
+  thousand lines, saved locally every few seconds while you work) above a dim divider;
+  the new session continues below it. Reconnects keep the buffer the same way.
 
-Reconnect them individually from the tab menu, or use the workspace dialog to reconnect
-selected sessions or all of them.
+The reconnect setting also covers a session lost mid-flight: a dropped connection redials
+a few times with growing delays before falling back to *press any key to reconnect*.
+
+Both behaviours have switches in Settings → Behavior. Turning **Automatically reconnect
+remote sessions** off restores remote tabs without dialling them, so a large layout does
+not trigger a set of simultaneous logins and 2FA prompts — reconnect them individually
+from the tab menu, or use the workspace dialog to reconnect selected sessions or all of
+them. Turning **Restore terminal history** off keeps scrollback out of local storage and
+restores every tab empty.
 
 ## Launching a set at once
 
@@ -67,4 +77,7 @@ restores each group whose layout still contains at least two of its tabs.
 ## Storage
 
 Workspaces are stored in the local SQLite database, next to folders, colours and saved
-tunnels. They are not written to `ssh_config` and are not sent off the machine.
+tunnels. They are not written to `ssh_config` and are not sent off the machine. Terminal
+history snapshots live in the same local database and are dropped when their tab leaves
+every stored workspace; disable **Restore terminal history** to keep scrollback out of
+storage entirely.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,6 +18,7 @@ import { registerSftpLeaseSocket } from './ws/sftp-lease-socket.js';
 import { websocketHeaderHasToken } from './auth.js';
 import { MuxusDatabase } from './persistence/database.js';
 import { registerWorkspaceRoutes } from './routes/workspaces.js';
+import { registerTerminalSnapshotRoutes } from './routes/terminal-snapshots.js';
 import { registerSerialRoutes } from './routes/serial.js';
 import { registerProfileRoutes } from './routes/profiles.js';
 import { registerHostOrderRoutes } from './routes/host-order.js';
@@ -78,6 +79,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   });
   database.finalizeSessionHistorySeparation(hadLegacyHistory);
   const ctx: AppContext = { config, connections, forwards, database, history };
+  database.pruneTerminalSnapshots();
 
   // SFTP uploads stream through as-is — no buffering, no size limit.
   app.addContentTypeParser('application/octet-stream', (_req, payload, done) => done(null, payload));
@@ -135,6 +137,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   registerForwardRoutes(app, ctx);
   registerTunnelRoutes(app, ctx);
   registerWorkspaceRoutes(app, ctx);
+  registerTerminalSnapshotRoutes(app, ctx);
   registerSerialRoutes(app);
   registerProfileRoutes(app, ctx);
   registerHostOrderRoutes(app, ctx);

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -259,6 +259,17 @@ const MIGRATIONS = [
       ALTER TABLE connection_profiles DROP COLUMN favorite;
     `,
   },
+  {
+    version: 10,
+    name: 'terminal-scrollback-snapshots',
+    sql: `
+      CREATE TABLE terminal_snapshots (
+        tab_id TEXT PRIMARY KEY,
+        data TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    `,
+  },
 ] as const;
 
 const DEFAULT_SESSION_LOGGING_POLICY: SessionLoggingPolicyInput = {
@@ -313,6 +324,12 @@ export interface WorkspaceRecord {
 }
 
 export type WorkspaceSummary = Omit<WorkspaceRecord, 'layout' | 'multiExecGroups'>;
+
+export interface TerminalSnapshotRecord {
+  tabId: string;
+  data: string;
+  updatedAt: string;
+}
 
 export interface SessionLogCreateInput {
   profileKey: string;
@@ -843,6 +860,54 @@ export class MuxusDatabase {
     return this.db.prepare('DELETE FROM workspaces WHERE id = ?').run(id).changes > 0;
   }
 
+  saveTerminalSnapshot(tabId: string, data: string): void {
+    requireNonEmpty(tabId, 'tabId');
+    this.db
+      .prepare(`
+        INSERT INTO terminal_snapshots(tab_id, data, updated_at)
+        VALUES (?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(tab_id) DO UPDATE SET
+          data = excluded.data,
+          updated_at = CURRENT_TIMESTAMP
+      `)
+      .run(tabId, data);
+  }
+
+  terminalSnapshot(tabId: string): TerminalSnapshotRecord | undefined {
+    const row = this.db
+      .prepare('SELECT tab_id, data, updated_at FROM terminal_snapshots WHERE tab_id = ?')
+      .get(tabId);
+    if (!row) return undefined;
+    return {
+      tabId: String(row.tab_id),
+      data: String(row.data),
+      updatedAt: String(row.updated_at),
+    };
+  }
+
+  /**
+   * Drop snapshots for tabs no stored workspace references. Recent rows are
+   * spared: a fresh tab's snapshot can land before its first layout autosave.
+   */
+  pruneTerminalSnapshots(graceSeconds = 3600): number {
+    const referenced = new Set<string>();
+    for (const workspace of this.listWorkspaces()) {
+      const layout = workspace.layout as { root?: unknown } | null | undefined;
+      collectLayoutTabIds(layout?.root, referenced);
+    }
+    const stale = this.db
+      .prepare(`SELECT tab_id FROM terminal_snapshots WHERE updated_at <= datetime('now', ?)`)
+      .all(`-${graceSeconds} seconds`);
+    let pruned = 0;
+    for (const row of stale) {
+      const tabId = String(row.tab_id);
+      if (referenced.has(tabId)) continue;
+      this.db.prepare('DELETE FROM terminal_snapshots WHERE tab_id = ?').run(tabId);
+      pruned++;
+    }
+    return pruned;
+  }
+
   listTunnels(): TunnelRecord[] {
     return this.db
       .prepare(`
@@ -1141,6 +1206,22 @@ export class MuxusDatabase {
 }
 
 type SqlRow = Record<string, SQLOutputValue>;
+
+/** Walk a stored layout tree defensively — its shape is `unknown` in the DB. */
+function collectLayoutTabIds(node: unknown, into: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  const record = node as { type?: unknown; children?: unknown; tabs?: unknown };
+  if (record.type === 'split' && Array.isArray(record.children)) {
+    for (const child of record.children) collectLayoutTabIds(child, into);
+    return;
+  }
+  if (!Array.isArray(record.tabs)) return;
+  for (const tab of record.tabs) {
+    if (tab && typeof tab === 'object' && typeof (tab as { id?: unknown }).id === 'string') {
+      into.add((tab as { id: string }).id);
+    }
+  }
+}
 
 function workspaceFromRow(row: SqlRow): WorkspaceRecord {
   return {

--- a/server/src/routes/terminal-snapshots.ts
+++ b/server/src/routes/terminal-snapshots.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { TERMINAL_SNAPSHOT_MAX_CHARS, type TerminalSnapshotRecord } from '@muxus/shared';
+import type { AppContext } from '../app.js';
+import { HttpProblem, sendError } from '../util/errors.js';
+
+const snapshotSaveSchema = z.object({
+  data: z.string().min(1).max(TERMINAL_SNAPSHOT_MAX_CHARS),
+});
+
+// Serialized scrollback rides in a JSON string, where every ESC byte inflates
+// to six characters, so the body can be several times the raw snapshot cap.
+const SNAPSHOT_BODY_LIMIT = 4 * 1024 * 1024;
+
+export function registerTerminalSnapshotRoutes(app: FastifyInstance, ctx: AppContext): void {
+  app.get(
+    '/api/terminal-snapshots/:tabId',
+    (req): { snapshot: TerminalSnapshotRecord | null } => {
+      const { tabId } = req.params as { tabId: string };
+      return { snapshot: ctx.database.terminalSnapshot(tabId) ?? null };
+    },
+  );
+
+  app.put(
+    '/api/terminal-snapshots/:tabId',
+    { bodyLimit: SNAPSHOT_BODY_LIMIT },
+    async (req, reply): Promise<{ saved: boolean } | void> => {
+      const { tabId } = req.params as { tabId: string };
+      const parsed = snapshotSaveSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return sendError(reply, new HttpProblem(400, 'invalid terminal snapshot'));
+      }
+      ctx.database.saveTerminalSnapshot(tabId, parsed.data.data);
+      return { saved: true };
+    },
+  );
+}

--- a/server/src/routes/workspaces.ts
+++ b/server/src/routes/workspaces.ts
@@ -207,7 +207,9 @@ export function registerWorkspaceRoutes(app: FastifyInstance, ctx: AppContext): 
       if (!parsed.success) {
         throw new HttpProblem(400, parsed.error.issues[0]?.message ?? 'invalid workspace');
       }
-      return ctx.database.saveWorkspace(parsed.data) as WorkspaceRecord;
+      const saved = ctx.database.saveWorkspace(parsed.data) as WorkspaceRecord;
+      ctx.database.pruneTerminalSnapshots();
+      return saved;
     } catch (err) {
       return sendError(reply, err);
     }
@@ -243,6 +245,8 @@ export function registerWorkspaceRoutes(app: FastifyInstance, ctx: AppContext): 
 
   app.delete('/api/workspaces/:id', (req) => {
     const { id } = req.params as { id: string };
-    return { deleted: ctx.database.deleteWorkspace(id) };
+    const deleted = ctx.database.deleteWorkspace(id);
+    if (deleted) ctx.database.pruneTerminalSnapshots();
+    return { deleted };
   });
 }

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -374,6 +374,17 @@ export interface WorkspaceRecord {
 
 export type WorkspaceSummary = Omit<WorkspaceRecord, 'layout' | 'multiExecGroups'>;
 
+/** Persisted scrollback for one workspace terminal tab. */
+export interface TerminalSnapshotRecord {
+  tabId: string;
+  /** Serialized terminal buffer, replayable by writing it back to a terminal. */
+  data: string;
+  updatedAt: string;
+}
+
+/** Upper bound for one tab's serialized scrollback, enforced on both sides. */
+export const TERMINAL_SNAPSHOT_MAX_CHARS = 512_000;
+
 export interface SshConfigResponse {
   /** Root config path (~/.ssh/config). */
   path: string;

--- a/tests/unit/client/connection-recovery.test.ts
+++ b/tests/unit/client/connection-recovery.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
+  AUTO_RECONNECT_DELAYS_MS,
+  autoReconnectDelayMs,
   CONNECTION_INTERRUPTION_GRACE_MS,
   connectionFailureReason,
   reattachCommand,
   shouldDelayConnectionLost,
   shouldWaitForTerminalOutput,
   terminalNotice,
+  type AutoReconnectInput,
 } from '../../../client/src/connection-recovery.js';
 
 describe('connection failure presentation', () => {
@@ -57,6 +60,42 @@ describe('connection failure presentation', () => {
     expect(shouldWaitForTerminalOutput('local', false)).toBe(false);
     expect(shouldWaitForTerminalOutput('telnet', false)).toBe(false);
     expect(shouldWaitForTerminalOutput('serial', false)).toBe(false);
+  });
+});
+
+describe('automatic reconnection', () => {
+  const drop = (overrides: Partial<AutoReconnectInput> = {}): AutoReconnectInput => ({
+    enabled: true,
+    profileKind: 'ssh',
+    reason: 'disconnected',
+    attempts: 0,
+    sawAuthPrompt: false,
+    ...overrides,
+  });
+
+  it('redials a dropped remote session with growing delays until the budget runs out', () => {
+    expect(autoReconnectDelayMs(drop())).toBe(2_000);
+    expect(autoReconnectDelayMs(drop({ attempts: 1 }))).toBe(5_000);
+    expect(autoReconnectDelayMs(drop({ attempts: 2 }))).toBe(15_000);
+    expect(autoReconnectDelayMs(drop({ attempts: AUTO_RECONNECT_DELAYS_MS.length }))).toBeUndefined();
+  });
+
+  it('never dials on its own when disabled, local, or exited normally', () => {
+    expect(autoReconnectDelayMs(drop({ enabled: false }))).toBeUndefined();
+    expect(autoReconnectDelayMs(drop({ profileKind: 'local' }))).toBeUndefined();
+    expect(autoReconnectDelayMs(drop({ reason: 'completed' }))).toBeUndefined();
+  });
+
+  it('continues a chain through failed dials but never starts one from a failure', () => {
+    expect(autoReconnectDelayMs(drop({ reason: 'failed' }))).toBeUndefined();
+    expect(autoReconnectDelayMs(drop({ reason: 'failed', attempts: 1 }))).toBe(5_000);
+    expect(
+      autoReconnectDelayMs(drop({ reason: 'failed', attempts: 1, sawAuthPrompt: true })),
+    ).toBeUndefined();
+  });
+
+  it('still redials after a drop when auth was interactive', () => {
+    expect(autoReconnectDelayMs(drop({ sawAuthPrompt: true }))).toBe(2_000);
   });
 });
 

--- a/tests/unit/client/scrollback-snapshots.test.ts
+++ b/tests/unit/client/scrollback-snapshots.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KEEPALIVE_BODY_LIMIT_BYTES,
+  serializeScrollback,
+  snapshotBodyBytes,
+  SNAPSHOT_SCROLLBACK_LADDER,
+  TERMINAL_HISTORY_DIVIDER,
+  trimReplayTail,
+} from '../../../client/src/terminal/scrollback-snapshots.js';
+
+/** Stand-in addon whose output shrinks with the requested scrollback depth.
+ *  Typed off serializeScrollback so the tests package needs no xterm dependency. */
+type Addon = Parameters<typeof serializeScrollback>[0];
+
+function fakeAddon(charsPerLine: number, options: { escapes?: boolean } = {}): Addon {
+  const unit = options.escapes ? '\u001b[31mx\u001b[0m' : 'x';
+  return {
+    serialize: ({ scrollback = 0 }: { scrollback?: number } = {}) =>
+      unit.repeat(scrollback * charsPerLine),
+  } as unknown as Addon;
+}
+
+describe('replay tail trimming', () => {
+  it('drops the blank viewport remainder and the cursor repositioning', () => {
+    const serialized =
+      'deploy@web-01:~$ echo hi\r\nhi\r\n\u001b[38;5;114mdeploy@web-01\u001b[0m$ ' +
+      '\r\n'.repeat(37) +
+      '\u001b[37A\u001b[17C';
+
+    expect(trimReplayTail(serialized)).toBe(
+      'deploy@web-01:~$ echo hi\r\nhi\r\n\u001b[38;5;114mdeploy@web-01\u001b[0m$ ',
+    );
+  });
+
+  it('leaves content without a trailing tail untouched', () => {
+    expect(trimReplayTail('plain output')).toBe('plain output');
+    expect(trimReplayTail('')).toBe('');
+  });
+
+  it('strips interleaved newline and cursor-move runs completely', () => {
+    expect(trimReplayTail('kept\r\n\u001b[2A\r\n\u001b[5;7H')).toBe('kept');
+  });
+
+  it('keeps colours and non-movement sequences in place', () => {
+    const colored = '\u001b[31mred\u001b[0m';
+    expect(trimReplayTail(colored)).toBe(colored);
+  });
+
+  it('keeps plain text ending in a cursor-move letter', () => {
+    expect(trimReplayTail('cd /srv && make USA')).toBe('cd /srv && make USA');
+    expect(trimReplayTail('PATH')).toBe('PATH');
+    expect(trimReplayTail('[17C')).toBe('[17C');
+  });
+
+  it('handles long interior newline runs in linear time', () => {
+    const pathological = ('\r\n'.repeat(1_000) + 'x').repeat(20);
+    const started = Date.now();
+    expect(trimReplayTail(pathological)).toBe(pathological);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+});
+
+describe('history divider', () => {
+  it('is a dim single line between restored and live output', () => {
+    expect(TERMINAL_HISTORY_DIVIDER).toContain('[end of restored output]');
+    expect(TERMINAL_HISTORY_DIVIDER.startsWith('\r\n')).toBe(true);
+    expect(TERMINAL_HISTORY_DIVIDER.endsWith('\r\n')).toBe(true);
+  });
+});
+
+describe('snapshot size budgeting', () => {
+  it('measures the JSON body, not the buffer — escapes inflate ESC sixfold', () => {
+    expect(snapshotBodyBytes('ab')).toBe('{"data":"ab"}'.length);
+    // One ESC becomes the six characters \u001b in the JSON body.
+    expect(snapshotBodyBytes('\u001b')).toBe('{"data":""}'.length + 6);
+  });
+
+  it('serializes at the deepest scrollback that fits the wire budget', () => {
+    const data = serializeScrollback(fakeAddon(40), { maxBodyBytes: 8_000 });
+    expect(data).toBeDefined();
+    expect(snapshotBodyBytes(data!)).toBeLessThanOrEqual(8_000);
+    // Deeper than the smallest rung: the ladder stepped down, it did not bottom out.
+    expect(data!.length).toBeGreaterThan(SNAPSHOT_SCROLLBACK_LADDER.at(-1)! * 40);
+  });
+
+  it('keeps a colour-heavy buffer under the keepalive cap', () => {
+    const data = serializeScrollback(fakeAddon(80, { escapes: true }), {
+      maxBodyBytes: KEEPALIVE_BODY_LIMIT_BYTES,
+    });
+    expect(data).toBeDefined();
+    expect(snapshotBodyBytes(data!)).toBeLessThanOrEqual(KEEPALIVE_BODY_LIMIT_BYTES);
+  });
+
+  it('takes the full depth when no budget is imposed', () => {
+    const data = serializeScrollback(fakeAddon(40));
+    expect(data).toBe('x'.repeat(SNAPSHOT_SCROLLBACK_LADDER[0]! * 40));
+  });
+
+  it('reports nothing for an empty buffer', () => {
+    expect(serializeScrollback(fakeAddon(0))).toBeUndefined();
+  });
+});

--- a/tests/unit/client/scrollback-snapshots.test.ts
+++ b/tests/unit/client/scrollback-snapshots.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
-  KEEPALIVE_BODY_LIMIT_BYTES,
   serializeScrollback,
   snapshotBodyBytes,
   SNAPSHOT_SCROLLBACK_LADDER,
   TERMINAL_HISTORY_DIVIDER,
   trimReplayTail,
 } from '../../../client/src/terminal/scrollback-snapshots.js';
+import { PAGE_KEEPALIVE_BODY_LIMIT_BYTES } from '../../../client/src/unload-keepalive.js';
 
 /** Stand-in addon whose output shrinks with the requested scrollback depth.
  *  Typed off serializeScrollback so the tests package needs no xterm dependency. */
@@ -85,10 +85,10 @@ describe('snapshot size budgeting', () => {
 
   it('keeps a colour-heavy buffer under the keepalive cap', () => {
     const data = serializeScrollback(fakeAddon(80, { escapes: true }), {
-      maxBodyBytes: KEEPALIVE_BODY_LIMIT_BYTES,
+      maxBodyBytes: PAGE_KEEPALIVE_BODY_LIMIT_BYTES,
     });
     expect(data).toBeDefined();
-    expect(snapshotBodyBytes(data!)).toBeLessThanOrEqual(KEEPALIVE_BODY_LIMIT_BYTES);
+    expect(snapshotBodyBytes(data!)).toBeLessThanOrEqual(PAGE_KEEPALIVE_BODY_LIMIT_BYTES);
   });
 
   it('takes the full depth when no budget is imposed', () => {

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -112,11 +112,45 @@ describe('workspace restoration', () => {
         id: 'local-tab',
         status: 'connecting',
         connectOnMount: true,
+        restored: true,
       }),
       expect.objectContaining({
         id: 'ssh-tab',
         status: 'closed',
         connectOnMount: false,
+        restored: true,
+      }),
+    ]);
+  });
+
+  it('dials restored remote sessions when the restore opts in', () => {
+    useTabsStore.getState().restore(
+      {
+        version: 1,
+        root: {
+          id: 'pane-restored',
+          type: 'pane',
+          activeTabId: 'ssh-tab',
+          tabs: [
+            {
+              id: 'ssh-tab',
+              kind: 'terminal',
+              title: 'Router',
+              profile: { kind: 'ssh', target: 'router' },
+              offerReconnect: true,
+            },
+          ],
+        },
+        activePaneId: 'pane-restored',
+      },
+      { connectRemote: true },
+    );
+
+    expect(useTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({
+        id: 'ssh-tab',
+        status: 'connecting',
+        connectOnMount: true,
       }),
     ]);
   });

--- a/tests/unit/client/unload-keepalive.test.ts
+++ b/tests/unit/client/unload-keepalive.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  flushUnloadKeepalives,
+  requestBodyBytes,
+  type UnloadKeepaliveFlush,
+} from '../../../client/src/unload-keepalive.js';
+
+describe('page unload keepalive coordination', () => {
+  it('reserves budget for higher-priority work, then shares the remainder fairly', () => {
+    const offered: number[] = [];
+    const task = (priority: number, consume: (offeredBytes: number) => number) =>
+      ({
+        priority,
+        flush: (maxBodyBytes) => {
+          offered.push(maxBodyBytes);
+          return consume(maxBodyBytes);
+        },
+      }) satisfies UnloadKeepaliveFlush;
+
+    const used = flushUnloadKeepalives(
+      [
+        task(0, (budget) => budget),
+        task(100, () => 10_000),
+        task(0, (budget) => budget),
+      ],
+      60_000,
+    );
+
+    expect(offered).toEqual([60_000, 25_000, 25_000]);
+    expect(used).toBe(60_000);
+  });
+
+  it('passes unused shares to the callbacks that remain', () => {
+    const offered: number[] = [];
+    const tasks: UnloadKeepaliveFlush[] = [0, 0, 0].map((_, index) => ({
+      priority: 0,
+      flush: (maxBodyBytes) => {
+        offered.push(maxBodyBytes);
+        return index === 0 ? 0 : maxBodyBytes;
+      },
+    }));
+
+    expect(flushUnloadKeepalives(tasks, 60_000)).toBe(60_000);
+    expect(offered).toEqual([20_000, 30_000, 30_000]);
+  });
+
+  it('does not dilute dirty terminals with registered callbacks that have no work', () => {
+    const activeFlush = vi.fn((budget: number) => budget);
+    const tasks: UnloadKeepaliveFlush[] = [
+      { priority: 0, isPending: () => false, flush: vi.fn() },
+      { priority: 0, isPending: () => true, flush: activeFlush },
+      { priority: 0, isPending: () => false, flush: vi.fn() },
+    ];
+
+    expect(flushUnloadKeepalives(tasks, 60_000)).toBe(60_000);
+    expect(activeFlush).toHaveBeenCalledWith(60_000);
+  });
+
+  it('isolates a failing optional flush', () => {
+    const finalFlush = vi.fn(() => 10);
+    const tasks: UnloadKeepaliveFlush[] = [
+      { priority: 0, flush: () => { throw new Error('teardown'); } },
+      { priority: 0, flush: finalFlush },
+    ];
+
+    expect(flushUnloadKeepalives(tasks, 100)).toBe(10);
+    expect(finalFlush).toHaveBeenCalledWith(100);
+  });
+
+  it('measures non-ASCII bodies in UTF-8 bytes', () => {
+    expect(requestBodyBytes('a€')).toBe(4);
+  });
+});

--- a/tests/unit/client/workspace-layout.test.ts
+++ b/tests/unit/client/workspace-layout.test.ts
@@ -222,6 +222,33 @@ describe('workspace serialization', () => {
     ]);
   });
 
+  it('dials remote tabs too when the restore opts in', () => {
+    const layout = serializeWorkspace(
+      root,
+      [
+        {
+          id: 'tab-a',
+          paneId: 'pane-left',
+          title: 'Production',
+          profile: { kind: 'ssh', target: 'production' },
+        },
+        {
+          id: 'tab-b',
+          paneId: 'pane-bottom',
+          title: 'Local',
+          profile: { kind: 'local', cwd: '/srv/app' },
+        },
+      ],
+      'pane-bottom',
+    );
+
+    const restored = restoreWorkspace(layout, { connectRemote: true })!;
+    expect(restored.tabs).toEqual([
+      expect.objectContaining({ id: 'tab-a', connectOnMount: true }),
+      expect.objectContaining({ id: 'tab-b', connectOnMount: true }),
+    ]);
+  });
+
   it('strips retired TERM overrides from restored profiles', () => {
     const layout = serializeWorkspace(
       { id: 'pane', type: 'pane', activeTabId: 'ssh-tab' },

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -21,7 +21,55 @@ describe('MuxusDatabase migrations', () => {
       { version: 7, name: 'bounded-session-history-settings' },
       { version: 8, name: 'named-workspace-session-sets' },
       { version: 9, name: 'drop-favorites' },
+      { version: 10, name: 'terminal-scrollback-snapshots' },
     ]);
+  });
+});
+
+describe('terminal scrollback snapshots', () => {
+  const layoutWith = (tabId: string) => ({
+    version: 1,
+    root: {
+      id: 'pane-1',
+      type: 'pane',
+      tabs: [
+        {
+          id: tabId,
+          kind: 'terminal',
+          title: 'Router',
+          profile: { kind: 'ssh', target: 'router' },
+          offerReconnect: true,
+        },
+      ],
+    },
+  });
+
+  it('stores and replaces one snapshot per tab', () => {
+    database = new MuxusDatabase(':memory:');
+    database.saveTerminalSnapshot('tab-1', 'first');
+    database.saveTerminalSnapshot('tab-1', 'second');
+
+    expect(database.terminalSnapshot('tab-1')).toMatchObject({ tabId: 'tab-1', data: 'second' });
+    expect(database.terminalSnapshot('tab-2')).toBeUndefined();
+  });
+
+  it('prunes snapshots no stored workspace references', () => {
+    database = new MuxusDatabase(':memory:');
+    database.saveWorkspace({ name: 'Ops', layout: layoutWith('kept-tab') });
+    database.saveTerminalSnapshot('kept-tab', 'kept');
+    database.saveTerminalSnapshot('orphan-tab', 'orphan');
+
+    expect(database.pruneTerminalSnapshots(0)).toBe(1);
+    expect(database.terminalSnapshot('kept-tab')).toBeDefined();
+    expect(database.terminalSnapshot('orphan-tab')).toBeUndefined();
+  });
+
+  it('spares fresh snapshots that may precede their first layout autosave', () => {
+    database = new MuxusDatabase(':memory:');
+    database.saveTerminalSnapshot('brand-new-tab', 'early output');
+
+    expect(database.pruneTerminalSnapshots()).toBe(0);
+    expect(database.terminalSnapshot('brand-new-tab')).toBeDefined();
   });
 });
 

--- a/tests/unit/server/terminal-snapshot-routes.test.ts
+++ b/tests/unit/server/terminal-snapshot-routes.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../../../server/src/app.js';
+import { resolveConfig } from '../../../server/src/config.js';
+
+const TOKEN = 'snapshot-test-token';
+let app: Awaited<ReturnType<typeof buildApp>>['app'];
+
+beforeEach(async () => {
+  ({ app } = await buildApp(
+    resolveConfig({
+      token: TOKEN,
+      databasePath: ':memory:',
+      openBrowser: false,
+      prettyLogs: false,
+      staticRoot: '/path/that/does/not/exist',
+    }),
+  ));
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+function auth() {
+  return { authorization: `Bearer ${TOKEN}` };
+}
+
+describe('terminal snapshot routes', () => {
+  it('round-trips a snapshot for a tab', async () => {
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/terminal-snapshots/tab-1',
+      headers: auth(),
+      payload: { data: 'deploy@web-01:~$ uptime\r\n 09:15 up 42 days' },
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toEqual({ saved: true });
+
+    const get = await app.inject({
+      method: 'GET',
+      url: '/api/terminal-snapshots/tab-1',
+      headers: auth(),
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json().snapshot).toMatchObject({
+      tabId: 'tab-1',
+      data: 'deploy@web-01:~$ uptime\r\n 09:15 up 42 days',
+    });
+  });
+
+  it('answers null for a tab that never saved output', async () => {
+    const get = await app.inject({
+      method: 'GET',
+      url: '/api/terminal-snapshots/never-seen',
+      headers: auth(),
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json()).toEqual({ snapshot: null });
+  });
+
+  it('rejects empty and malformed snapshots', async () => {
+    const empty = await app.inject({
+      method: 'PUT',
+      url: '/api/terminal-snapshots/tab-1',
+      headers: auth(),
+      payload: { data: '' },
+    });
+    expect(empty.statusCode).toBe(400);
+
+    const wrongShape = await app.inject({
+      method: 'PUT',
+      url: '/api/terminal-snapshots/tab-1',
+      headers: auth(),
+      payload: { scrollback: 'not the field' },
+    });
+    expect(wrongShape.statusCode).toBe(400);
+  });
+
+  it('requires the bearer token', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/terminal-snapshots/tab-1' });
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
Restoring a workspace used to relay only the layout. Remote tabs came back as tabs but waited for a key press, and every terminal came back empty. Both are restored now, each behind its own switch in **Settings → Behavior**, on by default.

## Reconnect

Restoring dials SSH, Telnet and serial tabs again instead of waiting for consent, and a connection lost mid-session redials at 2s, 5s and 15s before falling back to the existing *press any key to reconnect*.

The retry rules are deliberately conservative, so nothing hammers a host that cannot be reached:

- a shell that exits cleanly never redials;
- a failed dial continues a chain that a real drop started, but never starts one;
- an interactive auth prompt suppresses the automatic redial rather than re-prompting someone who walked away;
- 30 seconds of stable uptime counts as a new incident and restores the full attempt budget, so a host that drops once an hour never runs out.

Turning the switch off restores the previous behaviour, which is still the better default for a large layout of 2FA-protected hosts.

## Terminal history

Each terminal serializes its recent buffer (~1000 lines, colours included) into a new `terminal_snapshots` table. On restore it is replayed above a dim `[end of restored output]` divider, and the new session continues below it. Reconnects hand the buffer over in memory, so the screen no longer blanks on a redial.

Snapshots are written 1.5 seconds after output goes quiet, every 10 seconds while output keeps arriving, and on window close. The close path is the interesting one: a normal request is cancelled by the closing window, so it uses `keepalive`, which browsers cap at 64 KiB — and JSON encoding expands every escape byte sixfold, so the encoded body is measured and the depth stepped down (1000 → 400 → 150 → 50 → 10 lines) until it fits.

Snapshots are pruned once no stored workspace references their tab, checked at server start and on every workspace save and delete, with an hour of grace so a fresh tab is not reaped before its first layout autosave. They live in the same local SQLite database as workspaces and never leave the machine; with the switch off, nothing is written at all.

## Incidental fix

Terminals now run with xterm's `scrollOnEraseInDisplay`. Shells and prompts that clear the screen on login would otherwise erase the history that was just replayed. As a side effect, a manual `clear` no longer discards scrollback either.

## Verification

476 unit tests pass, plus typecheck and lint. Two end-to-end runs against the `hack/demo-env.mjs` sandbox cover the flows that unit tests cannot reach:

- restore and redial: a session is restored and reconnects, the backend is then killed mid-session and the tab is watched through a failed attempt until it recovers once the backend returns;
- history: a command is run and the window closed **immediately**, then reopened, for a local shell and for SSH.

That second one matters. An earlier version of this branch passed its tests while being broken in practice, because the test waited 12 seconds before closing and the periodic autosave always fired. The current tests close with no wait, and were confirmed to fail against the unfixed code.

Known limits, all documented: a hard crash can lose up to 10 seconds of output, closing in the same instant output appears can clip the last line, and restore never resumes a remote process — tmux or screen are still the answer there.
