### PR TITLE
Add update checks and release notifications

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "docs/**"
       - "zensical.toml"
+      - "hack/write-latest-manifest.mjs"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -30,11 +31,24 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - run: pip install zensical
       - run: zensical build --clean --strict
+      - name: Write update manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if gh release view --repo "$GH_REPO" --json tagName,name,url,publishedAt > /tmp/muxus-latest-release.json; then
+            node hack/write-latest-manifest.mjs /tmp/muxus-latest-release.json site/latest.json
+          else
+            echo "No release published yet; skipping update manifest."
+          fi
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      actions: write
       contents: write
     steps:
       - name: Download installers
@@ -129,3 +130,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+
+      # The docs deploy writes site/latest.json from the latest GitHub release,
+      # which powers the in-app update check for all installed versions.
+      - name: Refresh Pages update manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docs.yml --ref main --repo "$GITHUB_REPOSITORY"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import { DialogHost } from './components/DialogHost.js';
 import { ErrorBoundary } from './components/ErrorBoundary.js';
 import { ToastHost } from './components/ToastHost.js';
 import { BackendStatusBanner } from './components/BackendStatusBanner.js';
+import { UpdateNotification } from './components/UpdateNotification.js';
 import {
   loadHostEditorDialog,
   loadFolderDialog,
@@ -111,6 +112,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
       <DialogHost />
       <ToastHost />
       <BackendStatusBanner />
+      {!launch ? <UpdateNotification /> : null}
     </ThemeProvider>
   );
 }

--- a/client/src/api/app.ts
+++ b/client/src/api/app.ts
@@ -1,0 +1,8 @@
+import type { UpdateCheckResult } from '@muxus/shared';
+import { apiFetch } from './http.js';
+
+export async function checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult> {
+  const desktop = window.muxusDesktop;
+  if (desktop) return desktop.checkForUpdate(options);
+  return apiFetch<UpdateCheckResult>(`/api/app/update-check${options?.force ? '?force=true' : ''}`);
+}

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -3,6 +3,7 @@ import Autocomplete from '@mui/material/Autocomplete';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import Divider from '@mui/material/Divider';
@@ -14,6 +15,7 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import ListSubheader from '@mui/material/ListSubheader';
+import Link from '@mui/material/Link';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Slider from '@mui/material/Slider';
@@ -25,6 +27,8 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import HighlightOutlinedIcon from '@mui/icons-material/HighlightOutlined';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import KeyboardOutlinedIcon from '@mui/icons-material/KeyboardOutlined';
@@ -32,6 +36,8 @@ import BackupOutlinedIcon from '@mui/icons-material/BackupOutlined';
 import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
+import type { UpdateCheckResult } from '@muxus/shared';
+import { checkForUpdate } from '../api/app.js';
 import {
   useSaveSessionHistorySettings,
   useSaveSessionLoggingPolicy,
@@ -896,18 +902,92 @@ function HighlightingSection() {
   );
 }
 
+function updateReasonLabel(reason?: string): string {
+  switch (reason) {
+    case 'timeout':
+      return 'The update check timed out.';
+    case 'network':
+      return 'The update check could not reach GitHub.';
+    case 'no-release':
+      return 'No published release was found.';
+    case 'missing-version':
+    case 'missing-release-url':
+      return 'The latest release metadata is incomplete.';
+    default:
+      return reason?.startsWith('manifest-')
+        ? `The update manifest returned ${reason.replace('manifest-', '')}.`
+        : 'The update check could not be completed.';
+  }
+}
+
 function AboutSection() {
   const { data: info } = useAppInfo();
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<UpdateCheckResult | null>(null);
+
+  const checkForUpdates = () => {
+    setChecking(true);
+    setResult(null);
+    void checkForUpdate({ force: true })
+      .then(setResult)
+      .catch(() => setResult({ available: false, currentVersion: info?.version ?? '', reason: 'network' }))
+      .finally(() => setChecking(false));
+  };
+
+  const updatesAvailable = result?.available === true;
+
   return (
-    <Stack spacing={1}>
-      <SectionTitle>About</SectionTitle>
-      <Typography variant="body2">
-        Muxus {info?.version ?? ''} · {String(info?.platform ?? '')}
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane workspaces,
-        SFTP and terminal-independent port forwarding.
-      </Typography>
+    <Stack spacing={3}>
+      <Box>
+        <SectionTitle>About</SectionTitle>
+        <Stack spacing={1.25}>
+          <Typography variant="body2">
+            Muxus {info?.version ?? ''} · {String(info?.platform ?? '')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane
+            workspaces, SFTP and terminal-independent port forwarding.
+          </Typography>
+          <Link href="https://github.com/FloSch62/muxus" target="_blank" rel="noreferrer">
+            github.com/FloSch62/muxus
+          </Link>
+        </Stack>
+      </Box>
+      <Box>
+        <SectionTitle>Updates</SectionTitle>
+        <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+            <Button
+              variant="contained"
+              startIcon={checking ? <CircularProgress color="inherit" size={16} /> : <CachedOutlinedIcon />}
+              disabled={checking}
+              onClick={checkForUpdates}
+            >
+              Check for updates
+            </Button>
+            {updatesAvailable ? (
+              <Button startIcon={<DownloadOutlinedIcon />} href={result.releaseUrl} target="_blank" rel="noreferrer">
+                Download
+              </Button>
+            ) : null}
+          </Stack>
+          {result?.available === false && result.latestVersion ? (
+            <Alert severity="success" variant="outlined">
+              Muxus is up to date. Latest release: {result.latestVersion}.
+            </Alert>
+          ) : null}
+          {result?.available === false && !result.latestVersion ? (
+            <Alert severity="warning" variant="outlined">
+              {updateReasonLabel(result.reason)}
+            </Alert>
+          ) : null}
+          {updatesAvailable ? (
+            <Alert severity="info" variant="outlined">
+              Muxus {result.latestVersion} is available. You are running {result.currentVersion}.
+            </Alert>
+          ) : null}
+        </Stack>
+      </Box>
     </Stack>
   );
 }

--- a/client/src/components/UpdateNotification.tsx
+++ b/client/src/components/UpdateNotification.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Snackbar from '@mui/material/Snackbar';
+import Stack from '@mui/material/Stack';
+import type { UpdateCheckResult } from '@muxus/shared';
+import { checkForUpdate as checkForAppUpdate } from '../api/app.js';
+
+const DISMISSED_UPDATE_KEY = 'muxus-dismissed-update-version';
+
+let updateCheck: Promise<UpdateCheckResult> | undefined;
+
+function readDismissedVersion(): string | null {
+  try {
+    return window.localStorage.getItem(DISMISSED_UPDATE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function dismissVersion(version: string): void {
+  try {
+    window.localStorage.setItem(DISMISSED_UPDATE_KEY, version);
+  } catch {
+    /* Dismissal is a nicety; ignore blocked storage. */
+  }
+}
+
+function checkForUpdate(): Promise<UpdateCheckResult> {
+  updateCheck ??= checkForAppUpdate();
+  return updateCheck;
+}
+
+export function UpdateNotification() {
+  const [update, setUpdate] = useState<Extract<UpdateCheckResult, { available: true }> | null>(null);
+
+  useEffect(() => {
+    const check = checkForUpdate();
+
+    let cancelled = false;
+    void check
+      .then((result) => {
+        if (cancelled || !result.available) return;
+        if (readDismissedVersion() === result.latestVersion) return;
+        setUpdate(result);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const dismiss = () => {
+    if (update) dismissVersion(update.latestVersion);
+    setUpdate(null);
+  };
+
+  return (
+    <Snackbar open={!!update} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+      <Alert
+        severity="info"
+        variant="filled"
+        onClose={dismiss}
+        action={
+          update ? (
+            <Stack direction="row" spacing={0.5}>
+              <Button color="inherit" size="small" href={update.releaseUrl} target="_blank" rel="noreferrer" onClick={dismiss}>
+                Download
+              </Button>
+              <Button color="inherit" size="small" onClick={dismiss}>
+                Later
+              </Button>
+            </Stack>
+          ) : undefined
+        }
+      >
+        Muxus {update?.latestVersion} is available. You are running {update?.currentVersion}.
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/client/src/components/UpdateNotification.tsx
+++ b/client/src/components/UpdateNotification.tsx
@@ -5,22 +5,23 @@ import Snackbar from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
 import type { UpdateCheckResult } from '@muxus/shared';
 import { checkForUpdate as checkForAppUpdate } from '../api/app.js';
+import { muxusStateStorage } from '../state/persist-storage.js';
 
 const DISMISSED_UPDATE_KEY = 'muxus-dismissed-update-version';
 
 let updateCheck: Promise<UpdateCheckResult> | undefined;
 
-function readDismissedVersion(): string | null {
+async function readDismissedVersion(): Promise<string | null> {
   try {
-    return window.localStorage.getItem(DISMISSED_UPDATE_KEY);
+    return await muxusStateStorage.getItem(DISMISSED_UPDATE_KEY);
   } catch {
     return null;
   }
 }
 
-function dismissVersion(version: string): void {
+async function dismissVersion(version: string): Promise<void> {
   try {
-    window.localStorage.setItem(DISMISSED_UPDATE_KEY, version);
+    await muxusStateStorage.setItem(DISMISSED_UPDATE_KEY, version);
   } catch {
     /* Dismissal is a nicety; ignore blocked storage. */
   }
@@ -39,9 +40,10 @@ export function UpdateNotification() {
 
     let cancelled = false;
     void check
-      .then((result) => {
-        if (cancelled || !result.available) return;
-        if (readDismissedVersion() === result.latestVersion) return;
+      .then(async (result) => {
+        if (!result.available) return;
+        const dismissedVersion = await readDismissedVersion();
+        if (cancelled || dismissedVersion === result.latestVersion) return;
         setUpdate(result);
       })
       .catch(() => undefined);
@@ -52,7 +54,7 @@ export function UpdateNotification() {
   }, []);
 
   const dismiss = () => {
-    if (update) dismissVersion(update.latestVersion);
+    if (update) void dismissVersion(update.latestVersion);
     setUpdate(null);
   };
 

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -1,4 +1,4 @@
-import type { AppInfo, AppWindowLaunch } from '@muxus/shared';
+import type { AppInfo, AppWindowLaunch, UpdateCheckResult } from '@muxus/shared';
 
 declare global {
   /** Bridge exposed by the Electron preload (absent in regular browsers). */
@@ -19,6 +19,7 @@ declare global {
       /** Scale the whole window natively (the interface zoom preference). */
       setZoomFactor(factor: number): void;
       getAppInfo(): Promise<AppInfo | undefined>;
+      checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult>;
       /** Choose an SSH private key with the operating system's file picker. */
       selectPrivateKey(): Promise<string | undefined>;
       /** Open a secondary native application window. */

--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -70,6 +70,11 @@ make all    # everything electron-builder is configured for
 
 Artifacts are written to `electron/release/`.
 
+Publishing a GitHub release runs the installer workflow. After the installers are
+attached, that workflow redeploys the documentation site with a `latest.json` generated
+from the newest release. The desktop app and browser-hosted UI use that manifest for
+their update checks.
+
 ## Serial devices on Linux
 
 Serial ports usually require group membership:

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -107,4 +107,6 @@ client. Muxus-only settings remain in the backup.
 
 ## About
 
-Version and build information, and the location of the application data on this machine.
+Version and platform information, a link to the source repository, and a manual update
+check. When a newer release exists, Muxus links to its GitHub release so the appropriate
+installer can be downloaded.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -91,7 +91,10 @@ the window loads is served from the local server.
 
 ## What Muxus does not do
 
-- It does not phone home, check for updates in the background, or collect telemetry.
+- It does not collect telemetry. Its only background request is a version check against
+  the static `latest.json` on the Muxus documentation site; the request contains the
+  installed version in its user agent and can only direct downloads to the Muxus GitHub
+  releases page.
 - It does not proxy traffic through anything.
 - It does not store passwords.
 - It does not run as a service or accept connections from other machines.

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -15,7 +15,7 @@ import {
 } from 'electron';
 import fixPath from 'fix-path';
 import { startServer, type RunningServer } from '@muxus/server';
-import type { AppWindowLaunch } from '@muxus/shared';
+import type { AppWindowLaunch, UpdateCheckResult } from '@muxus/shared';
 
 // GUI apps on macOS/Linux don't inherit the shell PATH; ssh-agent sockets
 // and the user's login shell tooling need it.
@@ -36,6 +36,8 @@ const EXTERNAL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
 
 // Must match the client TopBar height: its toolbar doubles as the titlebar.
 const TITLEBAR_HEIGHT = 52;
+const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/muxus/latest.json';
+const UPDATE_CHECK_TIMEOUT_MS = 10_000;
 
 let primaryWindow: BrowserWindow | undefined;
 let appUrl: string | undefined;
@@ -43,6 +45,7 @@ const managedWindows = new Set<BrowserWindow>();
 const windowLaunches = new Map<number, AppWindowLaunch>();
 let server: RunningServer | undefined;
 let closing: Promise<void> | undefined;
+let updateCheck: Promise<UpdateCheckResult> | undefined;
 
 interface WindowState {
   width: number;
@@ -55,6 +58,13 @@ interface WindowState {
 interface AppInfo {
   name: string;
   version: string;
+}
+
+interface UpdateManifest {
+  version?: unknown;
+  releaseName?: unknown;
+  releaseUrl?: unknown;
+  publishedAt?: unknown;
 }
 
 const windowStateFile = () => path.join(app.getPath('userData'), 'window-state.json');
@@ -167,6 +177,92 @@ function openAllowedExternalUrl(rawUrl: string): void {
     void shell.openExternal(parsed.toString()).catch(() => undefined);
   } catch {
     /* malformed or relative URLs are never handed to the OS */
+  }
+}
+
+function versionParts(version: string): [number, number, number] | undefined {
+  const match = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(version.trim());
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)];
+}
+
+function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+function isNewerVersion(candidate: string, current: string): boolean {
+  const next = versionParts(candidate);
+  const installed = versionParts(current);
+  if (!next || !installed) return false;
+  const [nextMajor, nextMinor, nextPatch] = next;
+  const [installedMajor, installedMinor, installedPatch] = installed;
+  const pairs = [
+    [nextMajor, installedMajor],
+    [nextMinor, installedMinor],
+    [nextPatch, installedPatch],
+  ] as const;
+  for (const [nextPart, installedPart] of pairs) {
+    if (nextPart > installedPart) return true;
+    if (nextPart < installedPart) return false;
+  }
+  return false;
+}
+
+function releaseUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:' || url.hostname !== 'github.com') return undefined;
+    if (!url.pathname.startsWith('/FloSch62/muxus/releases/')) return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+async function checkForUpdate(force = false): Promise<UpdateCheckResult> {
+  const currentVersion = app.getVersion();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPDATE_CHECK_TIMEOUT_MS);
+  try {
+    const url = new URL(UPDATE_MANIFEST_URL);
+    if (force) url.searchParams.set('t', String(Date.now()));
+    const response = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': `Muxus/${currentVersion}`,
+      },
+      signal: controller.signal,
+    });
+    if (response.status === 404) return { available: false, currentVersion, reason: 'no-release' };
+    if (!response.ok) return { available: false, currentVersion, reason: `manifest-${response.status}` };
+
+    const manifest = (await response.json()) as UpdateManifest;
+    const version = typeof manifest.version === 'string' ? manifest.version : undefined;
+    if (!version) return { available: false, currentVersion, reason: 'missing-version' };
+
+    const latestVersion = normalizeVersion(version);
+    if (!isNewerVersion(latestVersion, currentVersion)) return { available: false, currentVersion, latestVersion };
+
+    const downloadUrl = releaseUrl(manifest.releaseUrl);
+    if (!downloadUrl) return { available: false, currentVersion, latestVersion, reason: 'missing-release-url' };
+
+    return {
+      available: true,
+      currentVersion,
+      latestVersion,
+      releaseName: typeof manifest.releaseName === 'string' && manifest.releaseName ? manifest.releaseName : undefined,
+      releaseUrl: downloadUrl,
+      publishedAt: typeof manifest.publishedAt === 'string' ? manifest.publishedAt : undefined,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      currentVersion,
+      reason: err instanceof Error && err.name === 'AbortError' ? 'timeout' : 'network',
+    };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -388,6 +484,15 @@ ipcMain.on('muxus:state:remove-item', (event, name: unknown) => {
 ipcMain.handle('muxus:get-app-info', (event): AppInfo | undefined => {
   if (!isManagedWindowSender(event)) return undefined;
   return { name: app.getName(), version: app.getVersion() };
+});
+
+ipcMain.handle('muxus:check-for-update', async (event, options?: { force?: unknown }): Promise<UpdateCheckResult> => {
+  if (!isManagedWindowSender(event)) {
+    return { available: false, currentVersion: app.getVersion(), reason: 'invalid-sender' };
+  }
+  if (options?.force === true) updateCheck = checkForUpdate(true);
+  updateCheck ??= checkForUpdate();
+  return updateCheck;
 });
 
 ipcMain.handle('muxus:select-private-key', async (event): Promise<string | undefined> => {

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -15,6 +15,7 @@ import {
 } from 'electron';
 import fixPath from 'fix-path';
 import { startServer, type RunningServer } from '@muxus/server';
+import { isNewerVersion } from '@muxus/shared';
 import type { AppWindowLaunch, UpdateCheckResult } from '@muxus/shared';
 
 // GUI apps on macOS/Linux don't inherit the shell PATH; ssh-agent sockets
@@ -180,32 +181,8 @@ function openAllowedExternalUrl(rawUrl: string): void {
   }
 }
 
-function versionParts(version: string): [number, number, number] | undefined {
-  const match = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(version.trim());
-  if (!match) return undefined;
-  return [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)];
-}
-
 function normalizeVersion(version: string): string {
   return version.trim().replace(/^v/i, '');
-}
-
-function isNewerVersion(candidate: string, current: string): boolean {
-  const next = versionParts(candidate);
-  const installed = versionParts(current);
-  if (!next || !installed) return false;
-  const [nextMajor, nextMinor, nextPatch] = next;
-  const [installedMajor, installedMinor, installedPatch] = installed;
-  const pairs = [
-    [nextMajor, installedMajor],
-    [nextMinor, installedMinor],
-    [nextPatch, installedPatch],
-  ] as const;
-  for (const [nextPart, installedPart] of pairs) {
-    if (nextPart > installedPart) return true;
-    if (nextPart < installedPart) return false;
-  }
-  return false;
 }
 
 function releaseUrl(value: unknown): string | undefined {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -72,6 +72,9 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   getAppInfo() {
     return ipcRenderer.invoke('muxus:get-app-info');
   },
+  checkForUpdate(options?: { force?: boolean }) {
+    return ipcRenderer.invoke('muxus:check-for-update', options);
+  },
   /** Open a native single-file picker and return only the user-selected path. */
   selectPrivateKey(): Promise<string | undefined> {
     return ipcRenderer.invoke('muxus:select-private-key');

--- a/hack/write-latest-manifest.mjs
+++ b/hack/write-latest-manifest.mjs
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [sourcePath = '', outPath = 'site/latest.json'] = process.argv.slice(2);
+
+function readJson(file) {
+  if (!file) return undefined;
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function normalizeVersion(tag) {
+  return tag.trim().replace(/^v/i, '');
+}
+
+const source = readJson(sourcePath) ?? {};
+const tag = firstString(process.env.RELEASE_TAG, source.tagName, source.tag_name, source.tag);
+const releaseName = firstString(process.env.RELEASE_NAME, source.name, tag);
+const releaseUrl = firstString(process.env.RELEASE_URL, source.url, source.html_url);
+const publishedAt = firstString(process.env.RELEASE_PUBLISHED_AT, source.publishedAt, source.published_at);
+
+if (!tag) fail('Release metadata must include tagName, tag_name, tag, or RELEASE_TAG.');
+if (!releaseUrl) fail('Release metadata must include url, html_url, or RELEASE_URL.');
+if (!publishedAt) fail('Release metadata must include publishedAt, published_at, or RELEASE_PUBLISHED_AT.');
+
+const version = normalizeVersion(tag);
+if (!version) fail('Release metadata resolved to an empty version.');
+
+const manifest = {
+  version,
+  releaseName,
+  releaseUrl,
+  publishedAt,
+};
+
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`wrote ${outPath} for ${manifest.version}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/src/routes/app.ts
+++ b/server/src/routes/app.ts
@@ -1,9 +1,21 @@
 import os from 'node:os';
 import { readFileSync } from 'node:fs';
 import type { FastifyInstance } from 'fastify';
-import type { AppInfo } from '@muxus/shared';
+import type { AppInfo, UpdateCheckResult } from '@muxus/shared';
 import type { AppContext } from '../app.js';
 import { defaultShell } from '../local/pty-manager.js';
+
+const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/muxus/latest.json';
+const UPDATE_CHECK_TIMEOUT_MS = 10_000;
+
+interface UpdateManifest {
+  version?: unknown;
+  releaseName?: unknown;
+  releaseUrl?: unknown;
+  publishedAt?: unknown;
+}
+
+let updateCheck: Promise<UpdateCheckResult> | undefined;
 
 function serverVersion(): string {
   try {
@@ -15,14 +27,107 @@ function serverVersion(): string {
   }
 }
 
-export function registerAppRoutes(app: FastifyInstance, _ctx: AppContext): void {
-  app.get('/api/app/info', (): AppInfo => {
+function versionParts(version: string): [number, number, number] | undefined {
+  const match = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(version.trim());
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)];
+}
+
+function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+function isNewerVersion(candidate: string, current: string): boolean {
+  const next = versionParts(candidate);
+  const installed = versionParts(current);
+  if (!next || !installed) return false;
+  const [nextMajor, nextMinor, nextPatch] = next;
+  const [installedMajor, installedMinor, installedPatch] = installed;
+  const pairs = [
+    [nextMajor, installedMajor],
+    [nextMinor, installedMinor],
+    [nextPatch, installedPatch],
+  ] as const;
+  for (const [nextPart, installedPart] of pairs) {
+    if (nextPart > installedPart) return true;
+    if (nextPart < installedPart) return false;
+  }
+  return false;
+}
+
+function releaseUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:' || url.hostname !== 'github.com') return undefined;
+    if (!url.pathname.startsWith('/FloSch62/muxus/releases/')) return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function appInfo(): AppInfo {
+  return {
+    name: 'Muxus',
+    version: serverVersion(),
+    platform: process.platform,
+    homeDir: os.homedir(),
+    defaultShell: defaultShell(),
+  };
+}
+
+async function checkForUpdate(force = false): Promise<UpdateCheckResult> {
+  const currentVersion = appInfo().version;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPDATE_CHECK_TIMEOUT_MS);
+  try {
+    const url = new URL(UPDATE_MANIFEST_URL);
+    if (force) url.searchParams.set('t', String(Date.now()));
+    const response = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': `Muxus/${currentVersion}`,
+      },
+      signal: controller.signal,
+    });
+    if (response.status === 404) return { available: false, currentVersion, reason: 'no-release' };
+    if (!response.ok) return { available: false, currentVersion, reason: `manifest-${response.status}` };
+
+    const manifest = (await response.json()) as UpdateManifest;
+    const version = typeof manifest.version === 'string' ? manifest.version : undefined;
+    if (!version) return { available: false, currentVersion, reason: 'missing-version' };
+
+    const latestVersion = normalizeVersion(version);
+    if (!isNewerVersion(latestVersion, currentVersion)) return { available: false, currentVersion, latestVersion };
+
+    const downloadUrl = releaseUrl(manifest.releaseUrl);
+    if (!downloadUrl) return { available: false, currentVersion, latestVersion, reason: 'missing-release-url' };
+
     return {
-      name: 'Muxus',
-      version: serverVersion(),
-      platform: process.platform,
-      homeDir: os.homedir(),
-      defaultShell: defaultShell(),
+      available: true,
+      currentVersion,
+      latestVersion,
+      releaseName: typeof manifest.releaseName === 'string' && manifest.releaseName ? manifest.releaseName : undefined,
+      releaseUrl: downloadUrl,
+      publishedAt: typeof manifest.publishedAt === 'string' ? manifest.publishedAt : undefined,
     };
+  } catch (err) {
+    return {
+      available: false,
+      currentVersion,
+      reason: err instanceof Error && err.name === 'AbortError' ? 'timeout' : 'network',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function registerAppRoutes(app: FastifyInstance, _ctx: AppContext): void {
+  app.get('/api/app/info', async () => appInfo());
+  app.get<{ Querystring: { force?: string } }>('/api/app/update-check', async (req) => {
+    if (req.query.force === 'true') updateCheck = checkForUpdate(true);
+    updateCheck ??= checkForUpdate();
+    return updateCheck;
   });
 }

--- a/server/src/routes/app.ts
+++ b/server/src/routes/app.ts
@@ -1,6 +1,7 @@
 import os from 'node:os';
 import { readFileSync } from 'node:fs';
 import type { FastifyInstance } from 'fastify';
+import { isNewerVersion } from '@muxus/shared';
 import type { AppInfo, UpdateCheckResult } from '@muxus/shared';
 import type { AppContext } from '../app.js';
 import { defaultShell } from '../local/pty-manager.js';
@@ -27,32 +28,8 @@ function serverVersion(): string {
   }
 }
 
-function versionParts(version: string): [number, number, number] | undefined {
-  const match = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(version.trim());
-  if (!match) return undefined;
-  return [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)];
-}
-
 function normalizeVersion(version: string): string {
   return version.trim().replace(/^v/i, '');
-}
-
-function isNewerVersion(candidate: string, current: string): boolean {
-  const next = versionParts(candidate);
-  const installed = versionParts(current);
-  if (!next || !installed) return false;
-  const [nextMajor, nextMinor, nextPatch] = next;
-  const [installedMajor, installedMinor, installedPatch] = installed;
-  const pairs = [
-    [nextMajor, installedMajor],
-    [nextMinor, installedMinor],
-    [nextPatch, installedPatch],
-  ] as const;
-  for (const [nextPart, installedPart] of pairs) {
-    if (nextPart > installedPart) return true;
-    if (nextPart < installedPart) return false;
-  }
-  return false;
 }
 
 function releaseUrl(value: unknown): string | undefined {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -15,6 +15,22 @@ export interface AppInfo {
   defaultShell: string;
 }
 
+export type UpdateCheckResult =
+  | {
+      available: true;
+      currentVersion: string;
+      latestVersion: string;
+      releaseName?: string;
+      releaseUrl: string;
+      publishedAt?: string;
+    }
+  | {
+      available: false;
+      currentVersion: string;
+      latestVersion?: string;
+      reason?: string;
+    };
+
 /** Effective retention and privacy policy for one host (or "*" for defaults). */
 export interface SessionLoggingPolicy {
   profileKey: string;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './api-types.js';
+export * from './update-version.js';
 // Type-only so zod (a server-side runtime concern) stays out of the client
 // bundle; runtime schemas import from '@muxus/shared/ws-protocol' directly.
 export type * from './ws-protocol.js';

--- a/shared/src/update-version.ts
+++ b/shared/src/update-version.ts
@@ -1,0 +1,69 @@
+interface ParsedVersion {
+  core: [string, string, string];
+  prerelease: string[];
+}
+
+const SEMVER =
+  /^[vV]?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function parseVersion(version: string): ParsedVersion | undefined {
+  const match = SEMVER.exec(version.trim());
+  if (!match) return undefined;
+
+  const prerelease = match[4]?.split('.') ?? [];
+  if (prerelease.some((identifier) => /^\d+$/.test(identifier) && identifier.length > 1 && identifier.startsWith('0'))) {
+    return undefined;
+  }
+
+  return {
+    core: [match[1]!, match[2]!, match[3]!],
+    prerelease,
+  };
+}
+
+function compareNumeric(candidate: string, current: string): number {
+  if (candidate.length !== current.length) return candidate.length > current.length ? 1 : -1;
+  if (candidate === current) return 0;
+  return candidate > current ? 1 : -1;
+}
+
+function comparePrerelease(candidate: string[], current: string[]): number {
+  if (candidate.length === 0 || current.length === 0) {
+    if (candidate.length === current.length) return 0;
+    return candidate.length === 0 ? 1 : -1;
+  }
+
+  const length = Math.max(candidate.length, current.length);
+  for (let index = 0; index < length; index++) {
+    const next = candidate[index];
+    const installed = current[index];
+    if (next === undefined || installed === undefined) {
+      if (next === installed) return 0;
+      return next === undefined ? -1 : 1;
+    }
+    if (next === installed) continue;
+
+    const nextNumeric = /^\d+$/.test(next);
+    const installedNumeric = /^\d+$/.test(installed);
+    if (nextNumeric && installedNumeric) return compareNumeric(next, installed);
+    if (nextNumeric !== installedNumeric) return nextNumeric ? -1 : 1;
+    return next > installed ? 1 : -1;
+  }
+  return 0;
+}
+
+/** True when candidate has higher SemVer precedence than current. */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const next = parseVersion(candidate);
+  const installed = parseVersion(current);
+  if (!next || !installed) return false;
+
+  for (let index = 0; index < next.core.length; index++) {
+    const nextPart = next.core[index]!;
+    const installedPart = installed.core[index]!;
+    const precedence = compareNumeric(nextPart, installedPart);
+    if (precedence !== 0) return precedence > 0;
+  }
+
+  return comparePrerelease(next.prerelease, installed.prerelease) > 0;
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildApp } from '../../../server/src/app.js';
+import { resolveConfig } from '../../../server/src/config.js';
+
+const TOKEN = 'app-route-test-token';
+let app: Awaited<ReturnType<typeof buildApp>>['app'];
+
+beforeEach(async () => {
+  ({ app } = await buildApp(
+    resolveConfig({
+      token: TOKEN,
+      databasePath: ':memory:',
+      openBrowser: false,
+      prettyLogs: false,
+      staticRoot: '/path/that/does/not/exist',
+    }),
+  ));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await app.close();
+});
+
+describe('app routes', () => {
+  it('validates update manifests and reports a newer trusted release', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          version: 'v0.2.0',
+          releaseName: 'Muxus 0.2',
+          releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.2.0',
+          publishedAt: '2026-07-26T08:00:00Z',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/app/update-check?force=true',
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      available: true,
+      currentVersion: '0.1.1',
+      latestVersion: '0.2.0',
+      releaseName: 'Muxus 0.2',
+      releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.2.0',
+      publishedAt: '2026-07-26T08:00:00Z',
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
+      /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.1.1' },
+    });
+  });
+
+  it('rejects an update manifest that points outside the Muxus releases page', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            version: '0.3.0',
+            releaseUrl: 'https://attacker.example/FloSch62/muxus/releases/tag/v0.3.0',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/app/update-check?force=true',
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      available: false,
+      currentVersion: '0.1.1',
+      latestVersion: '0.3.0',
+      reason: 'missing-release-url',
+    });
+  });
+});

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -27,9 +27,9 @@ describe('app routes', () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          version: 'v0.2.0',
-          releaseName: 'Muxus 0.2',
-          releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.2.0',
+          version: 'v0.3.0',
+          releaseName: 'Muxus 0.3',
+          releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.3.0',
           publishedAt: '2026-07-26T08:00:00Z',
         }),
         { status: 200, headers: { 'content-type': 'application/json' } },
@@ -46,17 +46,17 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.1.1',
-      latestVersion: '0.2.0',
-      releaseName: 'Muxus 0.2',
-      releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.2.0',
+      currentVersion: '0.2.0',
+      latestVersion: '0.3.0',
+      releaseName: 'Muxus 0.3',
+      releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.3.0',
       publishedAt: '2026-07-26T08:00:00Z',
     });
     expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.1.1' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.2.0' },
     });
   });
 
@@ -83,7 +83,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.1.1',
+      currentVersion: '0.2.0',
       latestVersion: '0.3.0',
       reason: 'missing-release-url',
     });

--- a/tests/unit/shared/update-version.test.ts
+++ b/tests/unit/shared/update-version.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { isNewerVersion } from '@muxus/shared';
+
+describe('update version precedence', () => {
+  it('compares stable core versions', () => {
+    expect(isNewerVersion('0.2.0', '0.1.1')).toBe(true);
+    expect(isNewerVersion('V10.0.0', 'v9.999.999')).toBe(true);
+    expect(isNewerVersion('0.1.1', '0.1.1')).toBe(false);
+    expect(isNewerVersion('0.1.0', '0.1.1')).toBe(false);
+  });
+
+  it('offers the final release to prerelease users', () => {
+    expect(isNewerVersion('0.2.0', '0.2.0-beta.1')).toBe(true);
+    expect(isNewerVersion('0.2.0-beta.1', '0.2.0')).toBe(false);
+  });
+
+  it('uses SemVer prerelease precedence and ignores build metadata', () => {
+    expect(isNewerVersion('1.0.0-beta.11', '1.0.0-beta.2')).toBe(true);
+    expect(isNewerVersion('1.0.0-rc.1', '1.0.0-beta.11')).toBe(true);
+    expect(isNewerVersion('1.0.0+build.2', '1.0.0+build.1')).toBe(false);
+  });
+
+  it('rejects malformed versions', () => {
+    expect(isNewerVersion('1.0', '0.9.0')).toBe(false);
+    expect(isNewerVersion('1.0.0-beta.01', '1.0.0-beta.1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add trusted latest-release checks for both the Electron app and browser-hosted UI
- show a dismissible startup notification in the primary window and a manual check in Settings → About
- publish `latest.json` from GitHub release metadata and refresh it after release assets are uploaded
- document the network request, release flow, and user-facing update behavior
- cover newer-release detection and untrusted release URL rejection

## Why

Muxus previously had no way to tell users that a newer release was available. This adds a lightweight manifest-based flow that preserves the existing manual installer model while restricting download links to the Muxus GitHub releases page.

## User impact

Users receive one notification per available version and can download the appropriate installer from GitHub. They can also trigger a fresh check from the About settings. Detached SFTP windows do not display duplicate notifications.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 483 tests passed
- `pnpm check:bundle`
- update manifest generation check
- workflow YAML parsing