### PR TITLE
Add SSH connection multiplexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ electron/build/
 electron/release/
 .env
 .DS_Store
+promo/
 
 # Zensical docs build output & cache
 site/

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -75,13 +75,27 @@ stdin/stdout, which supports tools such as `cloudflared access ssh` and corporat
 Forwards declared on the block (`LocalForward`, `RemoteForward`, `DynamicForward`) start
 with the session, and `ForwardAgent` applies when an agent is present.
 
-## Connection leases
+## One connection per host
 
-Connections are leased. Splitting a pane, opening a second tab on the same host, the file
-browser, the remote editor and an ad-hoc forward all use the same SSH transport:
+Connections are multiplexed, the way OpenSSH `ControlMaster` sharing works. A session whose
+resolved dial plan — every hop's user, host and port, plus any `ProxyCommand` — matches a
+live connection opens a new channel on it instead of a new TCP connection. Splitting a
+pane, opening a second tab on the same host, the file browser, the remote editor, tunnels
+and ad-hoc forwards all share one SSH transport:
 
 - no second login and no second 2FA prompt;
-- closing one tab does not affect the others;
+- servers that cap connections per user (`MaxStartups`, firewall rules) see one connection,
+  no matter how many panes are open;
+- sessions started together, such as a restored workspace, collapse into a single dial with
+  a single authentication round-trip.
+
+Sharing is safe by construction: a connection whose keepalives have gone quiet is not
+reused, and if the server refuses another channel on a shared connection (`MaxSessions`),
+Muxus silently dials a dedicated connection for that pane instead.
+
+Each consumer holds its own lease on the transport:
+
+- closing one tab does not affect the others; the connection closes with its last consumer;
 - a [tunnel](tunnels.md) holds its own lease, so closing every terminal leaves it running.
 
 ## Connection loss

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -78,10 +78,10 @@ with the session, and `ForwardAgent` applies when an agent is present.
 ## One connection per host
 
 Connections are multiplexed, the way OpenSSH `ControlMaster` sharing works. A session whose
-resolved dial plan — every hop's user, host and port, plus any `ProxyCommand` — matches a
-live connection opens a new channel on it instead of a new TCP connection. Splitting a
-pane, opening a second tab on the same host, the file browser, the remote editor, tunnels
-and ad-hoc forwards all share one SSH transport:
+resolved dial plan — every hop's user, host, port and agent-forwarding policy, plus any
+expanded `ProxyCommand` — matches a live connection opens a new channel on it instead of a
+new TCP connection. Splitting a pane, opening a second tab on the same host, the file
+browser, the remote editor, tunnels and ad-hoc forwards all share one SSH transport:
 
 - no second login and no second 2FA prompt;
 - servers that cap connections per user (`MaxStartups`, firewall rules) see one connection,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,15 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      '@types/ssh2':
+        specifier: ^1.15.5
+        version: 1.15.5
       '@vitest/coverage-v8':
         specifier: ^4.0.5
         version: 4.1.10(vitest@4.1.10)
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
       typescript:
         specifier: ^7.0.2
         version: 7.0.2

--- a/server/src/forwards/forward-manager.ts
+++ b/server/src/forwards/forward-manager.ts
@@ -17,6 +17,8 @@ interface ActiveForward {
  */
 export class ForwardManager {
   private readonly forwards = new Map<string, ActiveForward>();
+  /** Config forwards currently being created, keyed by connection and rule. */
+  private readonly pendingConfigStarts = new Map<string, Promise<ForwardInfo>>();
   /** Connections whose remote 'tcp connection' dispatcher is installed. */
   private readonly remoteDispatch = new Map<string, Map<number, ForwardInfo>>();
 
@@ -76,6 +78,34 @@ export class ForwardManager {
     this.forwards.set(info.id, { info, stop });
     unsubscribe = conn.onClose(() => this.stop(info.id));
     return info;
+  }
+
+  /**
+   * Start an ssh-config forward once per connection and rule. Every terminal
+   * on a multiplexed transport runs its resolved config through this method,
+   * so aliases can add distinct rules while repeated/concurrent sessions do
+   * not race into duplicate listener binds.
+   */
+  async startConfig(req: ForwardRequest): Promise<{ info: ForwardInfo; started: boolean }> {
+    const key = configForwardKey(req);
+    const existing = [...this.forwards.values()].find(
+      (active) =>
+        active.info.origin === 'config' &&
+        active.info.lifecycle === 'session' &&
+        configForwardKey(active.info) === key,
+    );
+    if (existing) return { info: existing.info, started: false };
+
+    const pending = this.pendingConfigStarts.get(key);
+    if (pending) return { info: await pending, started: false };
+
+    const start = this.start(req, 'config');
+    this.pendingConfigStarts.set(key, start);
+    try {
+      return { info: await start, started: true };
+    } finally {
+      if (this.pendingConfigStarts.get(key) === start) this.pendingConfigStarts.delete(key);
+    }
   }
 
   stop(id: string): void {
@@ -181,6 +211,18 @@ export class ForwardManager {
     await listen(server, info.bindPort);
     return () => server.close();
   }
+}
+
+function configForwardKey(
+  forward: Pick<ForwardRequest, 'connId' | 'type' | 'bindPort' | 'targetHost' | 'targetPort'>,
+): string {
+  return JSON.stringify([
+    forward.connId,
+    forward.type,
+    forward.bindPort,
+    forward.targetHost,
+    forward.targetPort,
+  ]);
 }
 
 function listen(server: net.Server, port: number): Promise<void> {

--- a/server/src/ssh/connection-leases.ts
+++ b/server/src/ssh/connection-leases.ts
@@ -50,6 +50,16 @@ export class ConnectionLeaseRegistry<T extends LeaseableConnection> {
     return [...this.records.values()].filter((record) => !record.closing).map((record) => record.connection);
   }
 
+  /** Live leases on `id`, optionally counting only the given owner kinds. */
+  leaseCount(id: string, owners?: readonly ConnectionLeaseOwner[]): number {
+    const record = this.records.get(id);
+    if (!record || record.closing) return 0;
+    if (!owners) return record.leases.size;
+    let count = 0;
+    for (const owner of record.leases.values()) if (owners.includes(owner)) count += 1;
+    return count;
+  }
+
   acquire(id: string, owner: ConnectionLeaseOwner): TransportLease<T> | undefined {
     const record = this.records.get(id);
     if (!record || record.closing) return undefined;

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -69,10 +69,14 @@ export interface ManagedConnection {
   host: string;
   port: number;
   user: string;
+  /** Dial-plan identity for connection sharing; see {@link muxKey}. */
+  muxKey: string;
   /** Concrete OpenSSH alias eligible for Muxus-owned recent-use metadata. */
   metadataAlias?: string;
   /** *Forward lines resolved from ssh config — auto-started once the session is up. */
   configForwards: ConfigForward[];
+  /** Current passive keepalive health of the transport. */
+  health(): SshTransportHealth;
   shell(cols: number, rows: number, term: string): Promise<ClientChannel>;
   sftp(): Promise<SFTPWrapper>;
   /** Subscribe to passive keepalive health; returns an unsubscribe function. */
@@ -85,6 +89,23 @@ export interface ManagedConnection {
 
 export type ConnectionLease = TransportLease<ManagedConnection>;
 export type SshTransportHealth = 'healthy' | 'suspect';
+
+export interface MuxedConnectionLease extends TransportLease<ManagedConnection> {
+  /** True when this lease multiplexes onto a pre-existing transport instead of a fresh dial. */
+  reused: boolean;
+}
+
+export interface TerminalShell {
+  lease: MuxedConnectionLease;
+  stream: ClientChannel;
+  /**
+   * 'new' — fresh transport, this session owns starting its config forwards;
+   * 'shared' — multiplexed onto a live transport that already has them;
+   * 'overflow' — dedicated transport dialed because the shared one refused
+   * another session; its sibling still owns the config forwards.
+   */
+  transport: 'new' | 'shared' | 'overflow';
+}
 
 const MAX_JUMP_DEPTH = 8;
 const MAX_PASSWORD_ATTEMPTS = 3;
@@ -160,13 +181,27 @@ export interface ChainHop {
 export class SshConnectionManager {
   private readonly connections = new ConnectionLeaseRegistry<ManagedConnection>();
   private readonly closeReasons = new WeakMap<Client, string>();
-  readonly knownHosts = new KnownHostsStore();
+  /** In-flight dials by mux key, so simultaneous sessions share one TCP connection and one auth round-trip. */
+  private readonly pendingDials = new Map<string, Promise<ManagedConnection>>();
+  private readonly loadConfig: () => ConfigDocument;
+  readonly knownHosts: KnownHostsStore;
 
-  constructor(private readonly log: FastifyBaseLogger) {}
+  constructor(
+    private readonly log: FastifyBaseLogger,
+    options: { knownHosts?: KnownHostsStore; loadConfig?: () => ConfigDocument } = {},
+  ) {
+    this.knownHosts = options.knownHosts ?? new KnownHostsStore();
+    this.loadConfig = options.loadConfig ?? (() => loadConfigDocument());
+  }
 
   /** Acquire an independent consumer lease on an existing SSH transport. */
   acquire(id: string, owner: ConnectionLeaseOwner): ConnectionLease | undefined {
     return this.connections.acquire(id, owner);
+  }
+
+  /** Live lease count on a connection, optionally restricted to owner kinds. */
+  leaseCount(id: string, owners?: readonly ConnectionLeaseOwner[]): number {
+    return this.connections.leaseCount(id, owners);
   }
 
   /** Live transports (forwarding panel, connection reuse when starting tunnels). */
@@ -181,10 +216,115 @@ export class SshConnectionManager {
     }));
   }
 
-  async connect(profile: SshProfile, io: ConnectIo, owner: ConnectionLeaseOwner = 'terminal'): Promise<ConnectionLease> {
-    const doc = loadConfigDocument();
+  /**
+   * Connect with OpenSSH-ControlMaster-style multiplexing: a session whose
+   * dial plan matches a live, healthy transport attaches to it as a new
+   * lease instead of opening another TCP connection — split panes, SFTP,
+   * tunnels and repeated connects to one host share a single SSH connection,
+   * which also keeps Muxus inside server-side connection caps (MaxStartups,
+   * per-user limits). Concurrent dials to the same plan (workspace restore)
+   * collapse into one connection and one auth round-trip.
+   */
+  async connect(
+    profile: SshProfile,
+    io: ConnectIo,
+    owner: ConnectionLeaseOwner = 'terminal',
+    opts: { freshTransport?: boolean } = {},
+  ): Promise<MuxedConnectionLease> {
+    const doc = this.loadConfig();
     const chain = buildChain(doc, profile);
+    const key = muxKey(chain);
+    const target = chain[chain.length - 1]!;
+    const label = `${target.user}@${target.resolved.hostname}:${target.port}`;
 
+    if (!opts.freshTransport) {
+      const shared = this.acquireShared(key, owner);
+      if (shared) {
+        io.status(`Reusing the SSH connection to ${label} (multiplexed).`, { transient: true });
+        return shared;
+      }
+      const pending = this.pendingDials.get(key);
+      if (pending) {
+        io.status(`Waiting for the SSH connection to ${label} …`, { transient: true });
+        // A failed dial fails every session waiting on it — auth prompts and
+        // errors surface on the session that started the dial.
+        const conn = await pending;
+        const lease = this.connections.acquire(conn.id, owner);
+        if (lease) return { ...lease, reused: true };
+        // The transport died between ready and acquire; dial our own below.
+      }
+    }
+
+    const dial = this.dialChain(doc, chain, profile, io, owner, key);
+    const tracked = dial.then((lease) => lease.connection);
+    tracked.catch(() => undefined); // waiters observe the rejection through their own await
+    this.pendingDials.set(key, tracked);
+    try {
+      const lease = await dial;
+      return { ...lease, reused: false };
+    } finally {
+      if (this.pendingDials.get(key) === tracked) this.pendingDials.delete(key);
+    }
+  }
+
+  /** Least-busy live, healthy transport with the same dial plan, if any. */
+  private acquireShared(key: string, owner: ConnectionLeaseOwner): MuxedConnectionLease | undefined {
+    const candidates = this.connections
+      .list()
+      .filter((conn) => conn.muxKey === key && conn.health() === 'healthy')
+      .sort((a, b) => this.connections.leaseCount(a.id) - this.connections.leaseCount(b.id));
+    for (const conn of candidates) {
+      const lease = this.connections.acquire(conn.id, owner);
+      if (lease) return { ...lease, reused: true };
+    }
+    return undefined;
+  }
+
+  /**
+   * Terminal entry point: connect (sharing a transport when possible) and
+   * open the shell channel. When a shared transport refuses another session
+   * channel (sshd MaxSessions and similar per-connection caps), falls back
+   * to a dedicated transport — a new pane never fails just because the
+   * multiplexed connection is full.
+   */
+  async connectShell(
+    profile: SshProfile,
+    io: ConnectIo,
+    cols: number,
+    rows: number,
+    term: string,
+  ): Promise<TerminalShell> {
+    const lease = await this.connect(profile, io);
+    try {
+      const stream = await lease.connection.shell(cols, rows, term);
+      return { lease, stream, transport: lease.reused ? 'shared' : 'new' };
+    } catch (err) {
+      lease.release();
+      if (!lease.reused) throw err;
+      this.log.info(
+        { host: lease.connection.host, err: String(err) },
+        'shared ssh transport refused a session; dialing a dedicated connection',
+      );
+      io.status('The shared SSH connection refused another session — opening a dedicated one …', { transient: true });
+      const dedicated = await this.connect(profile, io, 'terminal', { freshTransport: true });
+      try {
+        const stream = await dedicated.connection.shell(cols, rows, term);
+        return { lease: dedicated, stream, transport: 'overflow' };
+      } catch (retryErr) {
+        dedicated.release();
+        throw retryErr;
+      }
+    }
+  }
+
+  private async dialChain(
+    doc: ConfigDocument,
+    chain: ChainHop[],
+    profile: SshProfile,
+    io: ConnectIo,
+    owner: ConnectionLeaseOwner,
+    key: string,
+  ): Promise<ConnectionLease> {
     const clients: Client[] = [];
     const healthListeners = new Set<(state: SshTransportHealth) => void>();
     const hopHealth = new Map<number, SshTransportHealth>();
@@ -270,7 +410,9 @@ export class SshConnectionManager {
       host: target.resolved.hostname,
       port: target.port,
       user: target.user,
+      muxKey: key,
       metadataAlias,
+      health: () => transportHealth,
       configForwards: target.resolved.forwards,
       shell: async (cols, rows, term) => {
         const pty = terminalPtyOptions(cols, rows, term);
@@ -419,6 +561,19 @@ export class SshConnectionManager {
 // ---------------------------------------------------------------------------
 // Dial plan
 // ---------------------------------------------------------------------------
+
+/**
+ * Identity of a dial plan for connection sharing: the resolved hop sequence
+ * (user@hostname:port each) plus the ProxyCommand transport when one applies.
+ * Sessions whose plans agree may share one SSH transport. Auth settings are
+ * deliberately absent — they matter while establishing a transport, not for
+ * attaching to an established one.
+ */
+export function muxKey(chain: ChainHop[]): string {
+  const hops = chain.map((hop) => `${hop.user}@${hop.resolved.hostname}:${hop.port}`);
+  const proxy = chain[0]?.resolved.proxyCommand;
+  return (proxy ? [`proxy(${proxy})`, ...hops] : hops).join(' -> ');
+}
 
 /**
  * Expand a profile into the ordered list of hosts to dial: every ProxyJump

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -235,11 +235,16 @@ export class SshConnectionManager {
     const chain = buildChain(doc, profile);
     const key = muxKey(chain);
     const target = chain[chain.length - 1]!;
+    const configForwards = target.resolved.forwards;
     const label = `${target.user}@${target.resolved.hostname}:${target.port}`;
 
     if (!opts.freshTransport) {
       const shared = this.acquireShared(key, owner);
       if (shared) {
+        shared.connection.configForwards = mergeConfigForwards(
+          shared.connection.configForwards,
+          configForwards,
+        );
         io.status(`Reusing the SSH connection to ${label} (multiplexed).`, { transient: true });
         return shared;
       }
@@ -250,7 +255,10 @@ export class SshConnectionManager {
         // errors surface on the session that started the dial.
         const conn = await pending;
         const lease = this.connections.acquire(conn.id, owner);
-        if (lease) return { ...lease, reused: true };
+        if (lease) {
+          conn.configForwards = mergeConfigForwards(conn.configForwards, configForwards);
+          return { ...lease, reused: true };
+        }
         // The transport died between ready and acquire; dial our own below.
       }
     }
@@ -481,16 +489,7 @@ export class SshConnectionManager {
     const agent = agentSocket();
     const auth = new AuthLadder(hop, io);
     const proxySocket =
-      !sock && hop.resolved.proxyCommand
-        ? openProxyCommand(
-            expandProxyCommand(hop.resolved.proxyCommand, {
-              hostname: hop.resolved.hostname,
-              originalHost: hop.spec.host,
-              port: hop.port,
-              user: hop.user,
-            }),
-          )
-        : undefined;
+      !sock && hop.resolved.proxyCommand ? openProxyCommand(expandedProxyCommand(hop)!) : undefined;
     const transport = sock ?? proxySocket;
     const config: ConnectConfig = {
       username: hop.user,
@@ -564,15 +563,40 @@ export class SshConnectionManager {
 
 /**
  * Identity of a dial plan for connection sharing: the resolved hop sequence
- * (user@hostname:port each) plus the ProxyCommand transport when one applies.
- * Sessions whose plans agree may share one SSH transport. Auth settings are
+ * (user@hostname:port and agent-forwarding policy for each hop) plus the
+ * expanded ProxyCommand transport when one applies. Other auth settings are
  * deliberately absent — they matter while establishing a transport, not for
  * attaching to an established one.
  */
 export function muxKey(chain: ChainHop[]): string {
-  const hops = chain.map((hop) => `${hop.user}@${hop.resolved.hostname}:${hop.port}`);
-  const proxy = chain[0]?.resolved.proxyCommand;
+  const hops = chain.map(
+    (hop) =>
+      `${hop.user}@${hop.resolved.hostname}:${hop.port};agentForward=${hop.resolved.forwardAgent ? 'yes' : 'no'}`,
+  );
+  const first = chain[0];
+  const proxy = first?.resolved.proxyCommand ? expandedProxyCommand(first) : undefined;
   return (proxy ? [`proxy(${proxy})`, ...hops] : hops).join(' -> ');
+}
+
+function mergeConfigForwards(
+  current: readonly ConfigForward[],
+  requested: readonly ConfigForward[],
+): ConfigForward[] {
+  const merged = [...current];
+  for (const forward of requested) {
+    if (
+      !merged.some(
+        (existing) =>
+          existing.type === forward.type &&
+          existing.bindPort === forward.bindPort &&
+          existing.targetHost === forward.targetHost &&
+          existing.targetPort === forward.targetPort,
+      )
+    ) {
+      merged.push(forward);
+    }
+  }
+  return merged;
 }
 
 /**
@@ -657,6 +681,16 @@ export function expandProxyCommand(
       default:
         return tokens.user;
     }
+  });
+}
+
+function expandedProxyCommand(hop: ChainHop): string | undefined {
+  if (!hop.resolved.proxyCommand) return undefined;
+  return expandProxyCommand(hop.resolved.proxyCommand, {
+    hostname: hop.resolved.hostname,
+    originalHost: hop.spec.host,
+    port: hop.port,
+    user: hop.user,
   });
 }
 

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -155,7 +155,7 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
       socket.close();
     });
     socket.once('close', () => unsubscribeDialClose());
-    app.log.info({ target: connectMsg.profile.target, host: conn.host, user: conn.user, connId: conn.id }, 'ssh transport dialed');
+    app.log.info({ target: connectMsg.profile.target, host: conn.host, user: conn.user, connId: conn.id, reused: dialLease.reused }, 'ssh transport dialed');
     if (conn.metadataAlias) {
       try {
         ctx.database.recordOpenSshConnection(conn.metadataAlias);
@@ -268,49 +268,64 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
   }
 
   // --- SSH ---
-  const terminalLease = await ctx.connections.connect(profile, io);
+  const { lease: terminalLease, stream, transport } = await ctx.connections.connectShell(profile, io, cols, rows, DEFAULT_TERM);
   const conn = terminalLease.connection;
+  // Session forwards belong to the terminal sessions using this transport;
+  // stop them when the last terminal/dial lease leaves. Saved/manual tunnels
+  // are marked independent and keep their own leases.
+  const releaseSession = () => {
+    // On a shared transport the connection (and the remote shell with it)
+    // outlives this tab, so the channel must be closed explicitly.
+    stream.close();
+    terminalLease.release();
+    if (ctx.connections.leaseCount(conn.id, ['terminal', 'dial']) === 0) {
+      ctx.forwards.stopSessionForConnection(conn.id);
+    }
+  };
+  if (!socketOpen) {
+    releaseSession();
+    return;
+  }
+  socket.once('close', releaseSession);
   const unsubscribeHealth = conn.onHealth((state) =>
     sendControl(socket, { op: 'connection-health', state }),
   );
   socket.once('close', () => unsubscribeHealth());
-  // Config and ad-hoc forwards started on this terminal's connection belong
-  // to the terminal. Saved/manual tunnels are marked independent and keep
-  // their own lease when this socket closes.
-  socket.once('close', () => ctx.forwards.stopSessionForConnection(conn.id));
 
-  // Forwards declared on the host in ssh config start with the session,
+  // Forwards declared on the host in ssh config start with the transport,
   // exactly like `ssh` honoring LocalForward/RemoteForward/DynamicForward.
+  // A session multiplexed onto a live transport — or overflowing next to
+  // one — finds them already bound; starting them again would only collide.
   const configForwardIds: string[] = [];
-  for (const fwd of conn.configForwards) {
-    if (!socketOpen) break;
-    try {
-      const started = await ctx.forwards.start(
-        {
-          connId: conn.id,
-          type: fwd.type,
-          bindPort: fwd.bindPort,
-          targetHost: fwd.targetHost,
-          targetPort: fwd.targetPort,
-        },
-        'config',
-      );
-      configForwardIds.push(started.id);
-    } catch (err) {
-      sendControl(socket, { op: 'status', message: `forward -${fwd.type[0]?.toUpperCase()} ${fwd.bindPort} failed: ${err instanceof Error ? err.message : String(err)}` });
+  if (transport === 'new') {
+    for (const fwd of conn.configForwards) {
+      if (!socketOpen) break;
+      try {
+        const started = await ctx.forwards.start(
+          {
+            connId: conn.id,
+            type: fwd.type,
+            bindPort: fwd.bindPort,
+            targetHost: fwd.targetHost,
+            targetPort: fwd.targetPort,
+          },
+          'config',
+        );
+        configForwardIds.push(started.id);
+      } catch (err) {
+        sendControl(socket, { op: 'status', message: `forward -${fwd.type[0]?.toUpperCase()} ${fwd.bindPort} failed: ${err instanceof Error ? err.message : String(err)}` });
+      }
     }
   }
 
   if (!socketOpen) {
     // The tab disappeared before setup reached `ready`; do not leave
     // half-created config forwards running with no visible owning session.
+    // releaseSession already ran via the close handler.
     for (const id of configForwardIds) ctx.forwards.stop(id);
-    terminalLease.release();
     return;
   }
-  socket.once('close', () => terminalLease.release());
 
-  const stream = await conn.shell(cols, rows, DEFAULT_TERM);
   writeInput = (data) => stream.write(data);
   control.onMessage = (msg) => {
     if (handleLoggingControl(msg)) return;
@@ -372,7 +387,7 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
     unsubscribeClose();
   });
 
-  app.log.info({ target: profile.target, host: conn.host, user: conn.user, connId: conn.id }, 'ssh session established');
+  app.log.info({ target: profile.target, host: conn.host, user: conn.user, connId: conn.id, transport }, 'ssh session established');
   if (conn.metadataAlias) {
     try {
       ctx.database.recordOpenSshConnection(conn.metadataAlias);

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -292,29 +292,23 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
   );
   socket.once('close', () => unsubscribeHealth());
 
-  // Forwards declared on the host in ssh config start with the transport,
-  // exactly like `ssh` honoring LocalForward/RemoteForward/DynamicForward.
-  // A session multiplexed onto a live transport — or overflowing next to
-  // one — finds them already bound; starting them again would only collide.
+  // Every multiplexed alias contributes its resolved *Forward rules to the
+  // shared transport. startConfig deduplicates rules already started by a
+  // sibling session and collapses concurrent attempts for the same listener.
   const configForwardIds: string[] = [];
-  if (transport === 'new') {
-    for (const fwd of conn.configForwards) {
-      if (!socketOpen) break;
-      try {
-        const started = await ctx.forwards.start(
-          {
-            connId: conn.id,
-            type: fwd.type,
-            bindPort: fwd.bindPort,
-            targetHost: fwd.targetHost,
-            targetPort: fwd.targetPort,
-          },
-          'config',
-        );
-        configForwardIds.push(started.id);
-      } catch (err) {
-        sendControl(socket, { op: 'status', message: `forward -${fwd.type[0]?.toUpperCase()} ${fwd.bindPort} failed: ${err instanceof Error ? err.message : String(err)}` });
-      }
+  for (const fwd of conn.configForwards) {
+    if (!socketOpen) break;
+    try {
+      const started = await ctx.forwards.startConfig({
+        connId: conn.id,
+        type: fwd.type,
+        bindPort: fwd.bindPort,
+        targetHost: fwd.targetHost,
+        targetPort: fwd.targetPort,
+      });
+      if (started.started) configForwardIds.push(started.info.id);
+    } catch (err) {
+      sendControl(socket, { op: 'status', message: `forward -${fwd.type[0]?.toUpperCase()} ${fwd.bindPort} failed: ${err instanceof Error ? err.message : String(err)}` });
     }
   }
 
@@ -322,7 +316,9 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
     // The tab disappeared before setup reached `ready`; do not leave
     // half-created config forwards running with no visible owning session.
     // releaseSession already ran via the close handler.
-    for (const id of configForwardIds) ctx.forwards.stop(id);
+    if (ctx.connections.leaseCount(conn.id, ['terminal', 'dial']) === 0) {
+      for (const id of configForwardIds) ctx.forwards.stop(id);
+    }
     return;
   }
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,9 @@
   "devDependencies": {
     "@muxus/shared": "workspace:*",
     "@types/node": "^24.13.3",
+    "@types/ssh2": "^1.15.5",
     "@vitest/coverage-v8": "^4.0.5",
+    "ssh2": "^1.17.0",
     "typescript": "^7.0.2",
     "vitest": "^4.0.5",
     "zod": "^4.4.3"

--- a/tests/unit/server/chain.test.ts
+++ b/tests/unit/server/chain.test.ts
@@ -7,6 +7,7 @@ import {
   buildChain,
   expandProxyCommand,
   findMetadataAlias,
+  muxKey,
   observeSshTransportHealth,
   terminalPtyOptions,
 } from '../../../server/src/ssh/connection-manager.js';
@@ -212,5 +213,54 @@ describe('passive SSH transport health', () => {
     vi.advanceTimersByTime(120_000);
     expect(listener).not.toHaveBeenCalled();
     transport.destroy();
+  });
+});
+
+describe('muxKey', () => {
+  it('matches when different targets resolve to the same dial plan', () => {
+    const doc = docOf(
+      [
+        'Host web web-alias',
+        '  HostName web.example.com',
+        '  User deploy',
+        '  Port 2222',
+      ].join('\n'),
+    );
+    const direct = muxKey(buildChain(doc, { target: 'web' }));
+    const aliased = muxKey(buildChain(doc, { target: 'web-alias' }));
+    expect(direct).toBe('deploy@web.example.com:2222');
+    expect(aliased).toBe(direct);
+  });
+
+  it('separates plans that differ in user, port, or jump chain', () => {
+    const doc = docOf(
+      [
+        'Host app',
+        '  HostName app.internal',
+        '  ProxyJump bastion',
+        '',
+        'Host bastion',
+        '  HostName bastion.example.com',
+      ].join('\n'),
+    );
+    const viaJump = muxKey(buildChain(doc, { target: 'app' }));
+    const otherUser = muxKey(buildChain(doc, { target: 'app', user: 'admin' }));
+    const otherPort = muxKey(buildChain(doc, { target: 'app', port: 2200 }));
+    expect(viaJump).toContain('bastion.example.com:22 -> ');
+    expect(new Set([viaJump, otherUser, otherPort]).size).toBe(3);
+  });
+
+  it('includes the ProxyCommand transport in the plan identity', () => {
+    const doc = docOf(
+      [
+        'Host tunneled',
+        '  HostName inner.example.com',
+        '  ProxyCommand nc -x proxy:1080 %h %p',
+      ].join('\n'),
+    );
+    const plain = muxKey(buildChain(docOf('Host tunneled\n  HostName inner.example.com'), { target: 'tunneled' }));
+    const proxied = muxKey(buildChain(doc, { target: 'tunneled' }));
+    expect(proxied).toContain('proxy(nc -x proxy:1080 %h %p)');
+    expect(proxied).not.toBe(plain);
   });
 });

--- a/tests/unit/server/chain.test.ts
+++ b/tests/unit/server/chain.test.ts
@@ -228,7 +228,7 @@ describe('muxKey', () => {
     );
     const direct = muxKey(buildChain(doc, { target: 'web' }));
     const aliased = muxKey(buildChain(doc, { target: 'web-alias' }));
-    expect(direct).toBe('deploy@web.example.com:2222');
+    expect(direct).toBe('deploy@web.example.com:2222;agentForward=no');
     expect(aliased).toBe(direct);
   });
 
@@ -246,21 +246,42 @@ describe('muxKey', () => {
     const viaJump = muxKey(buildChain(doc, { target: 'app' }));
     const otherUser = muxKey(buildChain(doc, { target: 'app', user: 'admin' }));
     const otherPort = muxKey(buildChain(doc, { target: 'app', port: 2200 }));
-    expect(viaJump).toContain('bastion.example.com:22 -> ');
+    expect(viaJump).toContain('bastion.example.com:22;agentForward=no -> ');
     expect(new Set([viaJump, otherUser, otherPort]).size).toBe(3);
   });
 
-  it('includes the ProxyCommand transport in the plan identity', () => {
+  it('includes the expanded ProxyCommand transport in the plan identity', () => {
     const doc = docOf(
       [
-        'Host tunneled',
+        'Host tunneled tunneled-alias',
         '  HostName inner.example.com',
-        '  ProxyCommand nc -x proxy:1080 %h %p',
+        '  ProxyCommand route --alias %n --host %h --port %p',
       ].join('\n'),
     );
     const plain = muxKey(buildChain(docOf('Host tunneled\n  HostName inner.example.com'), { target: 'tunneled' }));
     const proxied = muxKey(buildChain(doc, { target: 'tunneled' }));
-    expect(proxied).toContain('proxy(nc -x proxy:1080 %h %p)');
+    const aliased = muxKey(buildChain(doc, { target: 'tunneled-alias' }));
+    expect(proxied).toContain('proxy(route --alias tunneled --host inner.example.com --port 22)');
     expect(proxied).not.toBe(plain);
+    expect(aliased).not.toBe(proxied);
+  });
+
+  it('separates plans by effective agent-forwarding policy', () => {
+    const doc = docOf(
+      [
+        'Host no-agent',
+        '  HostName app.example.com',
+        '  ForwardAgent no',
+        '',
+        'Host with-agent',
+        '  HostName app.example.com',
+        '  ForwardAgent yes',
+      ].join('\n'),
+    );
+    const noAgent = muxKey(buildChain(doc, { target: 'no-agent' }));
+    const withAgent = muxKey(buildChain(doc, { target: 'with-agent' }));
+    expect(noAgent).toContain('agentForward=no');
+    expect(withAgent).toContain('agentForward=yes');
+    expect(withAgent).not.toBe(noAgent);
   });
 });

--- a/tests/unit/server/connection-leases.test.ts
+++ b/tests/unit/server/connection-leases.test.ts
@@ -57,6 +57,26 @@ describe('ConnectionLeaseRegistry', () => {
     expect(registry.list()).toEqual([]);
   });
 
+  it('counts live leases, optionally by owner kind', () => {
+    const registry = new ConnectionLeaseRegistry<ReturnType<typeof connection>>();
+    const transport = connection();
+    const terminal = registry.register(transport, 'terminal');
+    registry.acquire(transport.id, 'terminal');
+    const forward = registry.acquire(transport.id, 'forward')!;
+
+    expect(registry.leaseCount(transport.id)).toBe(3);
+    expect(registry.leaseCount(transport.id, ['terminal', 'dial'])).toBe(2);
+    expect(registry.leaseCount(transport.id, ['sftp'])).toBe(0);
+    expect(registry.leaseCount('missing')).toBe(0);
+
+    terminal.release();
+    expect(registry.leaseCount(transport.id, ['terminal', 'dial'])).toBe(1);
+
+    registry.markClosed(transport);
+    expect(registry.leaseCount(transport.id)).toBe(0);
+    forward.release();
+  });
+
   it('force-closes every registered transport during application shutdown', () => {
     const registry = new ConnectionLeaseRegistry<ReturnType<typeof connection>>();
     const first = connection('first');

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -87,14 +87,14 @@ function startServer(opts: { maxShellsPerConnection?: number } = {}): Promise<{
 }
 
 let knownHostsCounter = 0;
-function makeManager(): SshConnectionManager {
+function makeManager(configFile = emptyConfig): SshConnectionManager {
   const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
   return new SshConnectionManager(log as never, {
     knownHosts: new KnownHostsStore(
       path.join(tmp, `known_hosts-${knownHostsCounter++}`),
       path.join(tmp, 'no-global-known-hosts'),
     ),
-    loadConfig: () => loadConfigDocument(emptyConfig),
+    loadConfig: () => loadConfigDocument(configFile),
   });
 }
 
@@ -157,6 +157,51 @@ describe('SSH connection multiplexing', () => {
     a.stream.close();
     a.lease.release();
     await vi.waitFor(() => expect(manager!.list()).toHaveLength(0));
+  }, 15_000);
+
+  it('adds config forwards requested by another alias on a shared transport', async () => {
+    const started = await startServer();
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-forwards-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host first',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  DynamicForward 1080',
+        '',
+        'Host second',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  DynamicForward 1081',
+      ].join('\n'),
+    );
+    manager = makeManager(configFile);
+
+    const a = await manager.connectShell(
+      { kind: 'ssh', target: 'first', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+    const b = await manager.connectShell(
+      { kind: 'ssh', target: 'second', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(b.transport).toBe('shared');
+    expect(b.lease.connection.id).toBe(a.lease.connection.id);
+    expect(b.lease.connection.configForwards).toEqual([
+      { type: 'dynamic', bindPort: 1080 },
+      { type: 'dynamic', bindPort: 1081 },
+    ]);
   }, 15_000);
 
   it('collapses concurrent dials into one connection and one auth round-trip', async () => {

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -1,0 +1,217 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import type net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { Server } from 'ssh2';
+import { afterEach, afterAll, describe, expect, it, vi } from 'vitest';
+import type { SshProfile } from '@muxus/shared/ws-protocol';
+import { SshConnectionManager, type ConnectIo } from '../../../server/src/ssh/connection-manager.js';
+import { KnownHostsStore } from '../../../server/src/ssh/known-hosts.js';
+import { loadConfigDocument } from '../../../server/src/ssh/ssh-config.js';
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-mux-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+const PASSWORD = 'secret';
+
+// One host key for every fake server in the suite; generating RSA keys is the
+// slow part of setup.
+const HOST_KEY = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+}).privateKey;
+
+const emptyConfig = path.join(tmp, 'ssh_config');
+writeFileSync(emptyConfig, '');
+
+interface ServerStats {
+  connections: number;
+  auths: number;
+  shells: number;
+}
+
+/**
+ * Minimal sshd stand-in: password auth, PTY + shell sessions with an optional
+ * per-connection shell cap (the MaxSessions failure mode), and rejected
+ * exec/sftp probes so the manager falls back to plain shells.
+ */
+function startServer(opts: { maxShellsPerConnection?: number } = {}): Promise<{
+  server: Server;
+  port: number;
+  stats: ServerStats;
+}> {
+  const stats: ServerStats = { connections: 0, auths: 0, shells: 0 };
+  const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
+    stats.connections += 1;
+    let shells = 0;
+    conn.on('error', () => undefined);
+    conn.on('authentication', (authCtx) => {
+      if (authCtx.method === 'password' && authCtx.password === PASSWORD) {
+        stats.auths += 1;
+        authCtx.accept();
+      } else {
+        authCtx.reject(['password']);
+      }
+    });
+    conn.on('ready', () => {
+      conn.on('session', (acceptSession) => {
+        const session = acceptSession();
+        session.on('pty', (acceptPty) => acceptPty?.());
+        // Empty probe output means "no integrated shell" — the manager then
+        // opens a plain shell, which is what these tests exercise.
+        session.on('exec', (acceptExec) => {
+          const stream = acceptExec();
+          stream.exit(0);
+          stream.end();
+        });
+        session.on('sftp', (_acceptSftp, rejectSftp) => rejectSftp?.());
+        session.on('shell', (acceptShell, rejectShell) => {
+          if (shells >= (opts.maxShellsPerConnection ?? Number.POSITIVE_INFINITY)) {
+            rejectShell?.();
+            return;
+          }
+          shells += 1;
+          stats.shells += 1;
+          acceptShell().write('ready\n');
+        });
+      });
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as net.AddressInfo).port, stats });
+    });
+  });
+}
+
+let knownHostsCounter = 0;
+function makeManager(): SshConnectionManager {
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return new SshConnectionManager(log as never, {
+    knownHosts: new KnownHostsStore(
+      path.join(tmp, `known_hosts-${knownHostsCounter++}`),
+      path.join(tmp, 'no-global-known-hosts'),
+    ),
+    loadConfig: () => loadConfigDocument(emptyConfig),
+  });
+}
+
+function makeIo(): { io: ConnectIo; prompts: string[]; hostKeyAsks: number[] } {
+  const prompts: string[] = [];
+  const hostKeyAsks: number[] = [];
+  const io: ConnectIo = {
+    status: () => undefined,
+    prompt: (info) => {
+      prompts.push(...info.prompts.map((p) => p.prompt));
+      return Promise.resolve(info.prompts.map(() => PASSWORD));
+    },
+    hostKey: (challenge) => {
+      hostKeyAsks.push(challenge.port);
+      return Promise.resolve(true);
+    },
+  };
+  return { io, prompts, hostKeyAsks };
+}
+
+function profile(port: number): SshProfile {
+  return { kind: 'ssh', target: '127.0.0.1', user: 'tester', port, passwordOnly: true, useConfig: false };
+}
+
+describe('SSH connection multiplexing', () => {
+  let manager: SshConnectionManager | undefined;
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    manager?.closeAll();
+    manager = undefined;
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  it('multiplexes a second terminal onto the existing transport', async () => {
+    const started = await startServer();
+    server = started.server;
+    manager = makeManager();
+
+    const first = makeIo();
+    const a = await manager.connectShell(profile(started.port), first.io, 80, 24, 'xterm-256color');
+    const second = makeIo();
+    const b = await manager.connectShell(profile(started.port), second.io, 80, 24, 'xterm-256color');
+
+    expect(a.transport).toBe('new');
+    expect(b.transport).toBe('shared');
+    expect(b.lease.connection.id).toBe(a.lease.connection.id);
+    expect(started.stats).toMatchObject({ connections: 1, auths: 1, shells: 2 });
+    // Attaching to an established transport needs no auth or host-key round-trips.
+    expect(second.prompts).toHaveLength(0);
+    expect(second.hostKeyAsks).toHaveLength(0);
+
+    // The transport survives its first session and closes with its last one.
+    b.stream.close();
+    b.lease.release();
+    expect(manager.list()).toHaveLength(1);
+    a.stream.close();
+    a.lease.release();
+    await vi.waitFor(() => expect(manager!.list()).toHaveLength(0));
+  }, 15_000);
+
+  it('collapses concurrent dials into one connection and one auth round-trip', async () => {
+    const started = await startServer();
+    server = started.server;
+    manager = makeManager();
+
+    const first = makeIo();
+    const second = makeIo();
+    const [a, b] = await Promise.all([
+      manager.connectShell(profile(started.port), first.io, 80, 24, 'xterm-256color'),
+      manager.connectShell(profile(started.port), second.io, 80, 24, 'xterm-256color'),
+    ]);
+
+    expect(started.stats).toMatchObject({ connections: 1, auths: 1, shells: 2 });
+    expect([a.transport, b.transport].sort()).toEqual(['new', 'shared']);
+    expect(b.lease.connection.id).toBe(a.lease.connection.id);
+    // Only the session that started the dial answered prompts.
+    expect(first.prompts.length + second.prompts.length).toBe(1);
+  }, 15_000);
+
+  it('falls back to a dedicated transport when the shared one refuses another session', async () => {
+    const started = await startServer({ maxShellsPerConnection: 1 });
+    server = started.server;
+    manager = makeManager();
+
+    const first = makeIo();
+    const a = await manager.connectShell(profile(started.port), first.io, 80, 24, 'xterm-256color');
+    const second = makeIo();
+    const b = await manager.connectShell(profile(started.port), second.io, 80, 24, 'xterm-256color');
+
+    expect(a.transport).toBe('new');
+    expect(b.transport).toBe('overflow');
+    expect(b.lease.connection.id).not.toBe(a.lease.connection.id);
+    expect(started.stats).toMatchObject({ connections: 2, shells: 2 });
+    // A third pane multiplexes onto the overflow transport instead of dialing again.
+    const third = makeIo();
+    const c = await manager.connectShell(profile(started.port), third.io, 80, 24, 'xterm-256color');
+    expect(c.transport).toBe('overflow');
+    expect(started.stats.connections).toBe(3);
+  }, 15_000);
+
+  it('honors the freshTransport escape hatch', async () => {
+    const started = await startServer();
+    server = started.server;
+    manager = makeManager();
+
+    const first = makeIo();
+    const a = await manager.connect(profile(started.port), first.io);
+    const second = makeIo();
+    const b = await manager.connect(profile(started.port), second.io, 'terminal', { freshTransport: true });
+
+    expect(a.reused).toBe(false);
+    expect(b.reused).toBe(false);
+    expect(b.connection.id).not.toBe(a.connection.id);
+    expect(started.stats.connections).toBe(2);
+  }, 15_000);
+});

--- a/tests/unit/server/forward-manager.test.ts
+++ b/tests/unit/server/forward-manager.test.ts
@@ -57,4 +57,29 @@ describe('ForwardManager lifecycle', () => {
     ]);
     expect(release).not.toHaveBeenCalled();
   });
+
+  it('deduplicates concurrent config forwards on a multiplexed connection', async () => {
+    const release = vi.fn();
+    const connection = {
+      id: 'connection-1',
+      client: {},
+      onClose: () => () => undefined,
+    } as unknown as ManagedConnection;
+    const acquire = vi.fn(() => ({ connection, owner: 'forward' as const, release }));
+    manager = new ForwardManager({ acquire } as never, { warn: vi.fn() } as never);
+    const request = { connId: connection.id, type: 'dynamic' as const, bindPort: 0 };
+
+    const [first, second] = await Promise.all([
+      manager.startConfig(request),
+      manager.startConfig(request),
+    ]);
+
+    expect(new Set([first.started, second.started])).toEqual(new Set([false, true]));
+    expect(first.info.id).toBe(second.info.id);
+    expect(manager.list()).toEqual([first.info]);
+    expect(acquire).toHaveBeenCalledTimes(1);
+
+    manager.stop(first.info.id);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

- reuse live, healthy SSH transports when resolved dial plans match
- collapse concurrent connection attempts into one authentication round-trip
- fall back to a dedicated transport when a shared connection reaches its session-channel limit
- keep connection leases and session-owned forwards alive for exactly as long as their consumers need them
- document the behavior and add unit and integration coverage

## Why

Each terminal session previously opened its own TCP and SSH connection. Opening several panes or restoring a workspace could therefore repeat authentication prompts and exceed server-side connection limits.

This change lets compatible sessions open independent channels on one transport while preserving isolation and lifecycle safety.

## Impact

Multiple panes and other consumers targeting the same resolved host path can share a connection. Unhealthy transports are excluded from reuse, and channel-capacity failures transparently open another connection.

## Validation

- `pnpm test` — 495 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`