### PR TITLE
Bump Muxus to v0.2.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -46,7 +46,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.2.0',
+      currentVersion: '0.2.1',
       latestVersion: '0.3.0',
       releaseName: 'Muxus 0.3',
       releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.3.0',
@@ -56,7 +56,7 @@ describe('app routes', () => {
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.2.0' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.2.1' },
     });
   });
 
@@ -83,7 +83,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.2.0',
+      currentVersion: '0.2.1',
       latestVersion: '0.3.0',
       reason: 'missing-release-url',
     });


### PR DESCRIPTION
## Summary

- bump the root package and all workspace packages from 0.2.0 to 0.2.1
- update the app update-check expectations to reflect the new runtime version

## Impact

Builds from this revision report Muxus version 0.2.1 consistently across the root, client, server, shared, Electron, and test packages.

## Validation

- `pnpm --filter @muxus/tests test -- unit/server/app-routes.test.ts` — 498 tests passed
- `pnpm lint` — reaches an existing `typescript(no-redundant-type-constituents)` error in untouched `electron/src/main.ts:47`
