### PR TITLE
Honor ssh_config algorithm and dial-time options

### DIFF
--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -1,17 +1,26 @@
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import SettingsEthernetIcon from '@mui/icons-material/SettingsEthernet';
+import { DIAL_TIME_KEYWORDS } from '@muxus/shared';
+import { useAppInfo } from '../../api/queries.js';
+import { LEGACY_ALGORITHM_PRESET, unsupportedEntries } from './advanced-options.js';
 import type { HostDraft } from './draft.js';
 
 /**
- * Everything ssh_config knows that Muxus doesn't model: free-form option
- * rows (kept verbatim through edits), plus the live preview of the exact
- * block text a save writes — rendered by the server so it can't drift.
+ * Everything ssh_config knows that Muxus doesn't model as a field: free-form
+ * option rows (kept verbatim through edits), plus the live preview of the
+ * exact block text a save writes — rendered by the server so it can't drift.
+ * Rows are badged by whether the dialer applies the keyword or merely
+ * preserves it for OpenSSH, and algorithm values the SSH engine can't offer
+ * are flagged as they are typed instead of at connect time.
  */
 export function AdvancedSection({
   draft,
@@ -24,32 +33,75 @@ export function AdvancedSection({
   preview: string;
   previewError: string | null;
 }) {
+  const sshAlgorithms = useAppInfo().data?.sshAlgorithms;
+
   const update = (i: number, patch: Partial<{ keyword: string; value: string }>) =>
     set({ extras: draft.extras.map((e, j) => (j === i ? { ...e, ...patch } : e)) });
+
+  const missingLegacy = LEGACY_ALGORITHM_PRESET.filter(
+    (row) => !draft.extras.some((e) => e.keyword.trim().toLowerCase() === row.keyword.toLowerCase()),
+  );
 
   return (
     <Stack spacing={2}>
       <Stack spacing={1}>
         <Typography variant="body2" color="text.secondary">
-          Extra ssh_config options written into the block as-is (Compression, ServerAliveInterval, RequestTTY, …).
+          Extra ssh_config options written into the block as-is. Rows marked{' '}
+          <em>applied</em> are honoured by Muxus when connecting; the rest are kept for OpenSSH.
         </Typography>
-        {draft.extras.map((e, i) => (
-          <Stack key={i} direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <TextField label="Option" value={e.keyword} onChange={(ev) => update(i, { keyword: ev.target.value })} sx={{ width: 220 }} />
-            <TextField label="Value" value={e.value} onChange={(ev) => update(i, { value: ev.target.value })} fullWidth />
-            <IconButton size="small" aria-label="Remove option" onClick={() => set({ extras: draft.extras.filter((_, j) => j !== i) })}>
-              <DeleteOutlineIcon fontSize="small" />
-            </IconButton>
-          </Stack>
-        ))}
-        <Button
-          size="small"
-          startIcon={<AddIcon />}
-          onClick={() => set({ extras: [...draft.extras, { keyword: '', value: '' }] })}
-          sx={{ alignSelf: 'flex-start' }}
-        >
-          Add option
-        </Button>
+        {draft.extras.map((e, i) => {
+          const keyword = e.keyword.trim().toLowerCase();
+          const unsupported = unsupportedEntries(e.keyword, e.value, sshAlgorithms);
+          return (
+            <Stack key={i} direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+              <TextField label="Option" value={e.keyword} onChange={(ev) => update(i, { keyword: ev.target.value })} sx={{ width: 220 }} />
+              <TextField
+                label="Value"
+                value={e.value}
+                onChange={(ev) => update(i, { value: ev.target.value })}
+                fullWidth
+                error={unsupported.length > 0}
+                helperText={
+                  unsupported.length
+                    ? `Skipped when connecting — not supported by the SSH engine: ${unsupported.join(', ')}`
+                    : undefined
+                }
+              />
+              <Box sx={{ width: 62, flexShrink: 0, display: 'flex', justifyContent: 'center', pt: 1.25 }}>
+                {keyword &&
+                  (DIAL_TIME_KEYWORDS.has(keyword) ? (
+                    <Tooltip title="Muxus applies this option when connecting.">
+                      <Chip size="small" label="applied" color="success" variant="outlined" sx={{ height: 18, fontSize: 10 }} />
+                    </Tooltip>
+                  ) : (
+                    <Tooltip title="Kept in the config for OpenSSH — Muxus does not use this option.">
+                      <Chip size="small" label="kept" variant="outlined" sx={{ height: 18, fontSize: 10, color: 'text.secondary' }} />
+                    </Tooltip>
+                  ))}
+              </Box>
+              <IconButton size="small" aria-label="Remove option" sx={{ mt: 0.75 }} onClick={() => set({ extras: draft.extras.filter((_, j) => j !== i) })}>
+                <DeleteOutlineIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+          );
+        })}
+        <Stack direction="row" spacing={1}>
+          <Button size="small" startIcon={<AddIcon />} onClick={() => set({ extras: [...draft.extras, { keyword: '', value: '' }] })}>
+            Add option
+          </Button>
+          <Tooltip title="Adds the key exchange, host key and cipher options old console servers and network gear need. Appended to the modern defaults, so current hosts keep working.">
+            <span>
+              <Button
+                size="small"
+                startIcon={<SettingsEthernetIcon />}
+                disabled={missingLegacy.length === 0}
+                onClick={() => set({ extras: [...draft.extras, ...missingLegacy] })}
+              >
+                Legacy device algorithms
+              </Button>
+            </span>
+          </Tooltip>
+        </Stack>
       </Stack>
 
       <Stack spacing={0.75}>

--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -11,7 +11,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import SettingsEthernetIcon from '@mui/icons-material/SettingsEthernet';
 import { DIAL_TIME_KEYWORDS } from '@muxus/shared';
 import { useAppInfo } from '../../api/queries.js';
-import { LEGACY_ALGORITHM_PRESET, unsupportedEntries } from './advanced-options.js';
+import { applyLegacyPreset, legacyPresetState, unsupportedEntries } from './advanced-options.js';
 import type { HostDraft } from './draft.js';
 
 /**
@@ -34,27 +34,34 @@ export function AdvancedSection({
   previewError: string | null;
 }) {
   const sshAlgorithms = useAppInfo().data?.sshAlgorithms;
+  const legacyState = legacyPresetState(draft.extras);
 
   const update = (i: number, patch: Partial<{ keyword: string; value: string }>) =>
     set({ extras: draft.extras.map((e, j) => (j === i ? { ...e, ...patch } : e)) });
-
-  const missingLegacy = LEGACY_ALGORITHM_PRESET.filter(
-    (row) => !draft.extras.some((e) => e.keyword.trim().toLowerCase() === row.keyword.toLowerCase()),
-  );
 
   return (
     <Stack spacing={2}>
       <Stack spacing={1}>
         <Typography variant="body2" color="text.secondary">
-          Extra ssh_config options written into the block as-is. Rows marked{' '}
-          <em>applied</em> are honoured by Muxus when connecting; the rest are kept for OpenSSH.
+          Raw ssh_config options for algorithm policies, environment variables, known-hosts files,
+          keepalives, and other expert settings. Rows marked <em>applied</em> are honoured by Muxus;
+          the rest are kept for OpenSSH.
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          Agent selection and host-key security have dedicated controls in Authentication;
+          startup commands and TTY behavior are in General.
         </Typography>
         {draft.extras.map((e, i) => {
           const keyword = e.keyword.trim().toLowerCase();
           const unsupported = unsupportedEntries(e.keyword, e.value, sshAlgorithms);
           return (
             <Stack key={i} direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
-              <TextField label="Option" value={e.keyword} onChange={(ev) => update(i, { keyword: ev.target.value })} sx={{ width: 220 }} />
+              <TextField
+                label="Option"
+                value={e.keyword}
+                onChange={(ev) => update(i, { keyword: ev.target.value })}
+                sx={{ width: 180, flexShrink: 0 }}
+              />
               <TextField
                 label="Value"
                 value={e.value}
@@ -89,13 +96,19 @@ export function AdvancedSection({
           <Button size="small" startIcon={<AddIcon />} onClick={() => set({ extras: [...draft.extras, { keyword: '', value: '' }] })}>
             Add option
           </Button>
-          <Tooltip title="Adds the key exchange, host key and cipher options old console servers and network gear need. Appended to the modern defaults, so current hosts keep working.">
+          <Tooltip
+            title={
+              legacyState === 'conflict'
+                ? 'An algorithm list uses a removal (-) policy the preset will not rewrite. Adjust the lists manually.'
+                : 'Adds the key exchange, host key and cipher options old console servers and network gear need. Merged into the modern defaults, so current hosts keep working.'
+            }
+          >
             <span>
               <Button
                 size="small"
                 startIcon={<SettingsEthernetIcon />}
-                disabled={missingLegacy.length === 0}
-                onClick={() => set({ extras: [...draft.extras, ...missingLegacy] })}
+                disabled={legacyState === 'enabled' || legacyState === 'conflict'}
+                onClick={() => set({ extras: applyLegacyPreset(draft.extras) })}
               >
                 Legacy device algorithms
               </Button>

--- a/client/src/components/host-editor/AuthSection.tsx
+++ b/client/src/components/host-editor/AuthSection.tsx
@@ -3,8 +3,10 @@ import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import Stack from '@mui/material/Stack';
@@ -20,7 +22,7 @@ import KeyOutlinedIcon from '@mui/icons-material/KeyOutlined';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VerifiedUserOutlinedIcon from '@mui/icons-material/VerifiedUserOutlined';
 import type { SshKeysResponse } from '@muxus/shared';
-import type { HostDraft } from './draft.js';
+import type { HostDraft, IdentityAgentMode, StrictHostKeyCheckingMode } from './draft.js';
 
 /**
  * How to authenticate: OpenSSH default order (agent, then id_* keys), a
@@ -206,20 +208,123 @@ export function AuthSection({
         </Stack>
       )}
 
-      <FormControlLabel
-        control={<Switch size="small" checked={draft.forwardAgent} onChange={(e) => set({ forwardAgent: e.target.checked })} />}
-        label={<Labeled title="Forward agent" sub="Lets the remote host use your local SSH agent (ForwardAgent yes)" />}
-      />
+      <Divider />
 
-      <Typography variant="caption" color="text.secondary">
-        {keys
-          ? keys.agentAvailable
-            ? `SSH agent detected — ${keys.agentKeys.length} key${keys.agentKeys.length === 1 ? '' : 's'} loaded.`
-            : 'No SSH agent detected (SSH_AUTH_SOCK is not set).'
-          : ''}
-      </Typography>
+      <Stack spacing={1.5}>
+        <Box>
+          <Typography variant="subtitle2">SSH agent</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Choose which local agent supplies keys for this host.
+          </Typography>
+        </Box>
+        <TextField
+          select
+          label="Agent source"
+          value={draft.identityAgentMode}
+          onChange={(e) => {
+            const identityAgentMode = e.target.value as IdentityAgentMode;
+            set({
+              identityAgentMode,
+              ...(identityAgentMode === 'none' ? { forwardAgent: false } : {}),
+            });
+          }}
+          helperText={agentSourceHelp(draft.identityAgentMode)}
+          fullWidth
+        >
+          <MenuItem value="default">Use SSH configuration</MenuItem>
+          <MenuItem value="environment">SSH_AUTH_SOCK environment agent</MenuItem>
+          <MenuItem value="custom">Custom socket or environment variable</MenuItem>
+          <MenuItem value="none">Do not use an agent</MenuItem>
+        </TextField>
+        {draft.identityAgentMode === 'custom' ? (
+          <TextField
+            label="Agent socket"
+            value={draft.identityAgent}
+            onChange={(e) => set({ identityAgent: e.target.value })}
+            placeholder="~/.1password/agent.sock or ${CUSTOM_SOCK}"
+            helperText="Accepts a socket path, $VAR, or ${VAR}."
+            fullWidth
+          />
+        ) : null}
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={draft.forwardAgent}
+              disabled={draft.identityAgentMode === 'none'}
+              onChange={(e) => set({ forwardAgent: e.target.checked })}
+            />
+          }
+          label={<Labeled title="Forward agent" sub="Lets the remote host use your selected local SSH agent" />}
+        />
+
+        <Typography variant="caption" color="text.secondary">
+          {keys
+            ? keys.agentAvailable
+              ? `Agent detected — ${keys.agentKeys.length} key${keys.agentKeys.length === 1 ? '' : 's'} loaded.`
+              : 'No agent detected in SSH_AUTH_SOCK. A custom agent may still be available.'
+            : ''}
+        </Typography>
+      </Stack>
+
+      <Divider />
+
+      <Stack spacing={1.5}>
+        <Box>
+          <Typography variant="subtitle2">Host-key security</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Control what happens when a server has not been seen before.
+          </Typography>
+        </Box>
+        <TextField
+          select
+          label="Host verification"
+          value={draft.strictHostKeyChecking}
+          onChange={(e) =>
+            set({
+              strictHostKeyChecking: e.target.value as StrictHostKeyCheckingMode,
+            })
+          }
+          helperText={hostVerificationHelp(draft.strictHostKeyChecking)}
+          fullWidth
+        >
+          <MenuItem value="inherit">Use SSH configuration</MenuItem>
+          <MenuItem value="ask">Ask before trusting a new host</MenuItem>
+          <MenuItem value="accept-new">Trust new hosts automatically</MenuItem>
+          <MenuItem value="yes">Require a saved host key</MenuItem>
+          <MenuItem value="no">Disable strict checking (no)</MenuItem>
+        </TextField>
+      </Stack>
     </Stack>
   );
+}
+
+function hostVerificationHelp(value: StrictHostKeyCheckingMode): string {
+  switch (value) {
+    case 'yes':
+      return 'Refuses hosts whose key is not already saved.';
+    case 'accept-new':
+      return 'Saves first-contact keys silently, but still warns if a saved key changes.';
+    case 'no':
+      return 'Accepts first-contact keys. Muxus still warns if a saved key changes.';
+    case 'ask':
+      return 'Prompts before saving a first-contact key and whenever a saved key changes.';
+    default:
+      return 'Inherits StrictHostKeyChecking; the normal default is to ask.';
+  }
+}
+
+function agentSourceHelp(mode: IdentityAgentMode): string {
+  switch (mode) {
+    case 'environment':
+      return 'Overrides inherited agent settings and reads SSH_AUTH_SOCK when connecting.';
+    case 'custom':
+      return 'Use a 1Password, Secretive, or other agent socket for this host.';
+    case 'none':
+      return 'Disables agent authentication and agent forwarding for this host.';
+    default:
+      return 'Inherits the normal SSH configuration and environment.';
+  }
 }
 
 function Labeled({ title, sub }: { title: string; sub: string }) {

--- a/client/src/components/host-editor/EditorShell.tsx
+++ b/client/src/components/host-editor/EditorShell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import DialogActions from '@mui/material/DialogActions';
@@ -17,7 +17,7 @@ export type ConnectionKind = 'ssh' | 'telnet' | 'serial';
 export interface EditorSectionDef<S extends string> {
   value: S;
   label: string;
-  icon: ReactNode;
+  icon: ReactElement;
   /** Shown as "Label (n)" when > 0, matching the SSH editor's rail. */
   count?: number;
 }
@@ -110,7 +110,7 @@ export function EditorShell<S extends string>({
               <Tab
                 key={def.value}
                 value={def.value}
-                icon={<>{def.icon}</>}
+                icon={def.icon}
                 iconPosition="start"
                 label={tabLabel(def.label, def.count)}
               />

--- a/client/src/components/host-editor/GeneralSection.tsx
+++ b/client/src/components/host-editor/GeneralSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
@@ -7,7 +8,7 @@ import Typography from '@mui/material/Typography';
 import type { SshConfigResponse } from '@muxus/shared';
 import { FolderPathField } from '../FolderPathField.js';
 import { HostColorPicker } from '../HostColorPicker.js';
-import type { HostDraft } from './draft.js';
+import type { HostDraft, RemoteCommandMode, RequestTtyMode } from './draft.js';
 import { draftAliases } from './draft.js';
 
 const NEW_FILE = '__new__';
@@ -122,6 +123,52 @@ export function GeneralSection({
       </Stack>
 
       <Divider />
+      <Stack spacing={1.5}>
+        <Box>
+          <Typography variant="subtitle2">Startup behavior</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Choose what opens after authentication and whether the server should allocate a terminal.
+          </Typography>
+        </Box>
+        <TextField
+          select
+          label="After connecting"
+          value={draft.remoteCommandMode}
+          onChange={(e) => set({ remoteCommandMode: e.target.value as RemoteCommandMode })}
+          helperText={remoteCommandHelp(draft.remoteCommandMode)}
+          fullWidth
+        >
+          <MenuItem value="inherit">Use SSH configuration</MenuItem>
+          <MenuItem value="shell">Open a login shell</MenuItem>
+          <MenuItem value="command">Run a startup command</MenuItem>
+        </TextField>
+        {draft.remoteCommandMode === 'command' ? (
+          <TextField
+            label="Startup command"
+            value={draft.remoteCommand}
+            onChange={(e) => set({ remoteCommand: e.target.value })}
+            placeholder="tmux new -A -s main"
+            helperText="Runs on the remote host instead of its login shell."
+            fullWidth
+          />
+        ) : null}
+        <TextField
+          select
+          label="Terminal allocation (TTY)"
+          value={draft.requestTty}
+          onChange={(e) => set({ requestTty: e.target.value as RequestTtyMode })}
+          helperText={requestTtyHelp(draft.requestTty, draft.remoteCommandMode)}
+          fullWidth
+        >
+          <MenuItem value="inherit">Use SSH configuration</MenuItem>
+          <MenuItem value="auto">Automatic</MenuItem>
+          <MenuItem value="yes">Always allocate a terminal</MenuItem>
+          <MenuItem value="no">Do not allocate a terminal</MenuItem>
+          <MenuItem value="force">Force terminal allocation</MenuItem>
+        </TextField>
+      </Stack>
+
+      <Divider />
       <Typography variant="caption" color="text.secondary">
         Display name, group and color are local to Muxus — they never touch your
         ssh config.
@@ -142,4 +189,34 @@ export function GeneralSection({
       <HostColorPicker value={draft.color} onChange={(color) => set({ color })} />
     </Stack>
   );
+}
+
+function remoteCommandHelp(mode: RemoteCommandMode): string {
+  switch (mode) {
+    case 'shell':
+      return 'Explicitly disables an inherited RemoteCommand and opens the normal shell.';
+    case 'command':
+      return 'Runs one command after authentication instead of opening the normal shell.';
+    default:
+      return 'Uses any RemoteCommand inherited from matching SSH configuration.';
+  }
+}
+
+function requestTtyHelp(value: RequestTtyMode, commandMode: RemoteCommandMode): string {
+  switch (value) {
+    case 'auto':
+      return commandMode === 'command'
+        ? 'A startup command runs without a terminal; choose “Always” for interactive tools such as tmux.'
+        : 'Allocates a terminal for a login shell.';
+    case 'yes':
+      return 'Allocates a terminal for both login shells and startup commands.';
+    case 'force':
+      return 'Forces a terminal even when the local session is not interactive.';
+    case 'no':
+      return 'Runs without a terminal.';
+    default:
+      return commandMode === 'command'
+        ? 'Inherits RequestTTY; SSH normally runs startup commands without a terminal.'
+        : 'Inherits RequestTTY; SSH normally allocates a terminal for a login shell.';
+  }
 }

--- a/client/src/components/host-editor/advanced-options.ts
+++ b/client/src/components/host-editor/advanced-options.ts
@@ -1,0 +1,31 @@
+/**
+ * The algorithm lines an old console server or switch typically needs —
+ * append forms, so modern hosts matched by the same block keep working.
+ */
+export const LEGACY_ALGORITHM_PRESET = [
+  { keyword: 'KexAlgorithms', value: '+diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1' },
+  { keyword: 'HostKeyAlgorithms', value: '+ssh-rsa' },
+  { keyword: 'Ciphers', value: '+aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc' },
+];
+
+/**
+ * Entries of an algorithm-list option the dialer would have to skip: not
+ * `*`/`?` patterns, and absent from the SSH engine's supported table for the
+ * keyword. Non-algorithm keywords and a missing table return [].
+ */
+export function unsupportedEntries(
+  keyword: string,
+  value: string,
+  tables: Record<string, string[]> | undefined,
+): string[] {
+  if (!tables) return [];
+  const canonical = Object.keys(tables).find((k) => k.toLowerCase() === keyword.trim().toLowerCase());
+  if (!canonical) return [];
+  const supported = tables[canonical]!;
+  return value
+    .replace(/^[+^-]/, '')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((entry) => !/[*?]/.test(entry) && !supported.includes(entry));
+}

--- a/client/src/components/host-editor/advanced-options.ts
+++ b/client/src/components/host-editor/advanced-options.ts
@@ -6,7 +6,72 @@ export const LEGACY_ALGORITHM_PRESET = [
   { keyword: 'KexAlgorithms', value: '+diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1' },
   { keyword: 'HostKeyAlgorithms', value: '+ssh-rsa' },
   { keyword: 'Ciphers', value: '+aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc' },
-];
+] as const;
+
+type ExtraOption = { keyword: string; value: string };
+
+export type LegacyPresetState = 'missing' | 'partial' | 'enabled' | 'conflict';
+
+/** Whether the raw algorithm rows already provide the legacy-device preset. */
+export function legacyPresetState(extras: readonly ExtraOption[]): LegacyPresetState {
+  let configured = 0;
+  let required = 0;
+  let customPolicy = false;
+  let conflict = false;
+
+  for (const preset of LEGACY_ALGORITHM_PRESET) {
+    const row = extras.find(
+      (extra) => extra.keyword.trim().toLowerCase() === preset.keyword.toLowerCase(),
+    );
+    const requiredNames = algorithmNames(preset.value);
+    required += requiredNames.length;
+    if (!row) continue;
+    customPolicy = true;
+    if (row.value.trim().startsWith('-')) {
+      conflict = true;
+      continue;
+    }
+    const current = new Set(algorithmNames(row.value));
+    configured += requiredNames.filter((name) => current.has(name)).length;
+  }
+
+  if (configured === required) return 'enabled';
+  if (conflict) return 'conflict';
+  return configured > 0 || customPolicy ? 'partial' : 'missing';
+}
+
+/**
+ * Add the legacy names without replacing a user's existing exact, append, or
+ * prepend policy. Removal policies are left untouched because rewriting one
+ * would silently discard the user's exclusions.
+ */
+export function applyLegacyPreset(extras: readonly ExtraOption[]): ExtraOption[] {
+  const next = extras.map((extra) => ({ ...extra }));
+  for (const preset of LEGACY_ALGORITHM_PRESET) {
+    const index = next.findIndex(
+      (extra) => extra.keyword.trim().toLowerCase() === preset.keyword.toLowerCase(),
+    );
+    if (index < 0) {
+      next.push({ ...preset });
+      continue;
+    }
+    const row = next[index]!;
+    const value = row.value.trim();
+    if (value.startsWith('-')) continue;
+    const prefix = /^[+^]/.test(value) ? value[0]! : '';
+    const currentNames = algorithmNames(value);
+    const seen = new Set(currentNames);
+    const missing = algorithmNames(preset.value).filter((name) => !seen.has(name));
+    if (!missing.length) continue;
+    next[index] = {
+      ...row,
+      value: currentNames.length
+        ? `${prefix}${[...currentNames, ...missing].join(',')}`
+        : preset.value,
+    };
+  }
+  return next;
+}
 
 /**
  * Entries of an algorithm-list option the dialer would have to skip: not
@@ -28,4 +93,13 @@ export function unsupportedEntries(
     .map((entry) => entry.trim().toLowerCase())
     .filter(Boolean)
     .filter((entry) => !/[*?]/.test(entry) && !supported.includes(entry));
+}
+
+function algorithmNames(value: string): string[] {
+  return value
+    .trim()
+    .replace(/^[+^-]/, '')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
 }

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -10,6 +10,11 @@ import {
 } from '../../session-logging-policy.js';
 import { parseHostTarget } from './native-draft.js';
 
+export type IdentityAgentMode = 'default' | 'environment' | 'custom' | 'none';
+export type RemoteCommandMode = 'inherit' | 'shell' | 'command';
+export type RequestTtyMode = 'inherit' | 'no' | 'yes' | 'force' | 'auto';
+export type StrictHostKeyCheckingMode = 'inherit' | 'yes' | 'no' | 'accept-new' | 'ask';
+
 /** Everything the editor form holds, in form-friendly shapes (ports as text). */
 export interface HostDraft {
   /** Space-separated aliases for the Host line (usually one). */
@@ -28,11 +33,18 @@ export interface HostDraft {
   identityFiles: string[];
   certificateFiles: string[];
   identitiesOnly: boolean;
+  identityAgentMode: IdentityAgentMode;
+  /** Custom agent socket path or environment indirection. */
+  identityAgent: string;
   forwardAgent: boolean;
   routeMode: 'direct' | 'jump' | 'command';
   proxyJump: string[];
   proxyCommand: string;
   forwards: ConfigForward[];
+  remoteCommandMode: RemoteCommandMode;
+  remoteCommand: string;
+  requestTty: RequestTtyMode;
+  strictHostKeyChecking: StrictHostKeyCheckingMode;
   extras: Array<{ keyword: string; value: string }>;
   keywordHighlights: HostKeywordHighlightConfig;
   sessionLogging: HostSessionLoggingDraft;
@@ -57,11 +69,17 @@ export function blankDraft(prefillTarget = ''): HostDraft {
     identityFiles: [],
     certificateFiles: [],
     identitiesOnly: false,
+    identityAgentMode: 'default',
+    identityAgent: '',
     forwardAgent: false,
     routeMode: 'direct',
     proxyJump: [],
     proxyCommand: '',
     forwards: [],
+    remoteCommandMode: 'inherit',
+    remoteCommand: '',
+    requestTty: 'inherit',
+    strictHostKeyChecking: 'inherit',
     extras: [],
     keywordHighlights: { inheritGlobal: true, rules: [] },
     sessionLogging: blankHostSessionLoggingDraft(),
@@ -71,6 +89,8 @@ export function blankDraft(prefillTarget = ''): HostDraft {
 /** Build the form state from a listed entry's own block options. */
 export function draftFromEntry(entry: SshHostEntry, duplicate: boolean): HostDraft {
   const o = entry.options;
+  const identityAgent = identityAgentDraft(o.identityAgent);
+  const remoteCommand = remoteCommandDraft(o.remoteCommand);
   return {
     aliasText: duplicate ? `${entry.alias}-copy` : entry.aliases.join(' '),
     description: entry.description ?? '',
@@ -90,6 +110,8 @@ export function draftFromEntry(entry: SshHostEntry, duplicate: boolean): HostDra
     identityFiles: o.identityFiles ?? [],
     certificateFiles: o.certificateFiles ?? [],
     identitiesOnly: o.identitiesOnly ?? false,
+    identityAgentMode: identityAgent.mode,
+    identityAgent: identityAgent.value,
     forwardAgent: o.forwardAgent ?? false,
     routeMode: o.proxyCommand
       ? 'command'
@@ -99,6 +121,10 @@ export function draftFromEntry(entry: SshHostEntry, duplicate: boolean): HostDra
     proxyJump: o.proxyJump ?? [],
     proxyCommand: o.proxyCommand ?? '',
     forwards: o.forwards ?? [],
+    remoteCommandMode: remoteCommand.mode,
+    remoteCommand: remoteCommand.value,
+    requestTty: o.requestTty ?? 'inherit',
+    strictHostKeyChecking: o.strictHostKeyChecking ?? 'inherit',
     extras: o.extras ?? [],
     keywordHighlights: entry.metadata?.keywordHighlights ?? {
       inheritGlobal: true,
@@ -122,8 +148,14 @@ export function draftProblem(draft: HostDraft): string | null {
   }
   if (draft.port && !portOk(draft.port)) return 'Port must be 1–65535.';
   if (draft.authMode === 'key' && !draft.identityFiles.some((f) => f.trim())) return 'Pick at least one key file, or switch the auth mode.';
+  if (draft.identityAgentMode === 'custom' && !draft.identityAgent.trim()) {
+    return 'Enter an agent socket path or choose another agent source.';
+  }
   if (draft.routeMode === 'command' && !draft.proxyCommand.trim()) {
     return 'Proxy command is required when ProxyCommand routing is selected.';
+  }
+  if (draft.remoteCommandMode === 'command' && !draft.remoteCommand.trim()) {
+    return 'Enter a startup command or choose a login shell.';
   }
   for (const f of draft.forwards) {
     if (!portOk(String(f.bindPort))) return 'Every forward needs a listen port (1–65535).';
@@ -160,6 +192,14 @@ export function draftToRequest(draft: HostDraft, previousAlias?: string): HostUp
           ? draft.certificateFiles.map((f) => f.trim()).filter(Boolean)
           : undefined,
       identitiesOnly: draft.authMode === 'key' && draft.identitiesOnly ? true : undefined,
+      identityAgent:
+        draft.identityAgentMode === 'environment'
+          ? 'SSH_AUTH_SOCK'
+          : draft.identityAgentMode === 'none'
+            ? 'none'
+            : draft.identityAgentMode === 'custom'
+              ? text(draft.identityAgent)
+              : undefined,
       forwardAgent: draft.forwardAgent ? true : undefined,
       proxyJump:
         draft.routeMode === 'jump' && draft.proxyJump.length
@@ -169,7 +209,37 @@ export function draftToRequest(draft: HostDraft, previousAlias?: string): HostUp
         draft.routeMode === 'command' ? text(draft.proxyCommand) : undefined,
       forwards: draft.forwards.length ? draft.forwards : undefined,
       passwordOnly: draft.authMode === 'password' ? true : undefined,
+      remoteCommand:
+        draft.remoteCommandMode === 'shell'
+          ? 'none'
+          : draft.remoteCommandMode === 'command'
+            ? text(draft.remoteCommand)
+            : undefined,
+      requestTty: draft.requestTty === 'inherit' ? undefined : draft.requestTty,
+      strictHostKeyChecking:
+        draft.strictHostKeyChecking === 'inherit'
+          ? undefined
+          : draft.strictHostKeyChecking,
       extras: draft.extras.length ? draft.extras : undefined,
     },
   };
+}
+
+function identityAgentDraft(value: string | undefined): {
+  mode: IdentityAgentMode;
+  value: string;
+} {
+  if (value === undefined) return { mode: 'default', value: '' };
+  if (value === 'SSH_AUTH_SOCK') return { mode: 'environment', value: '' };
+  if (value.toLowerCase() === 'none') return { mode: 'none', value: '' };
+  return { mode: 'custom', value };
+}
+
+function remoteCommandDraft(value: string | undefined): {
+  mode: RemoteCommandMode;
+  value: string;
+} {
+  if (value === undefined) return { mode: 'inherit', value: '' };
+  if (value.toLowerCase() === 'none') return { mode: 'shell', value: '' };
+  return { mode: 'command', value };
 }

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -55,18 +55,31 @@ These keywords are modelled as fields. They appear as controls in the
 | `PubkeyAuthentication no` | The editor's "password / interactive" mode |
 | `PreferredAuthentications keyboard-interactive,password` | Written alongside the above |
 
-These keywords never become editor fields — they are edited under **Advanced** — but the
-dialler still applies them the way `ssh` would:
+These keywords never become editor fields — they are edited under **Advanced**, where the
+editor badges them **applied** — but the dialler still applies them the way `ssh` would:
 
 | Keyword | Used for |
 | --- | --- |
-| `Ciphers`, `KexAlgorithms`, `HostKeyAlgorithms`, `MACs` | Algorithm negotiation, including the `+`/`^`/`-` list syntax and `*` patterns. Entries the SSH engine does not implement are skipped with a notice, so a config shared with OpenSSH keeps working. |
+| `Ciphers`, `KexAlgorithms`, `HostKeyAlgorithms`, `MACs` | Algorithm negotiation, including the `+`/`^`/`-` list syntax and `*` patterns. Entries the SSH engine does not implement are skipped with a notice, so a config shared with OpenSSH keeps working — and the editor flags them while you type. |
+| `Compression` | `yes` prefers zlib like `ssh -C` |
 | `ConnectTimeout` | Dial timeout; defaults to 20 seconds |
 | `ServerAliveInterval`, `ServerAliveCountMax` | Keepalives; default 15 seconds / 3 missed replies |
+| `IdentityAgent` | Agent socket override — a path (1Password, Secretive, …), `$VAR`, `SSH_AUTH_SOCK`, or `none` |
+| `PasswordAuthentication no`, `KbdInteractiveAuthentication no` | Removes that rung from the auth ladder (the legacy `ChallengeResponseAuthentication` spelling works too) |
+| `UserKnownHostsFile`, `GlobalKnownHostsFile` | Host keys verify against these files instead; new keys are recorded into the first user file, `none` disables |
+| `StrictHostKeyChecking` | `accept-new`/`no` accept first-contact keys silently; `yes` refuses unknown or changed keys. A **changed** key always asks, even under `no` — silently trusting a swapped key is a footgun Muxus does not reproduce |
+| `SetEnv`, `SendEnv` | Session environment, with `-pattern` removals and SetEnv overriding |
+| `RemoteCommand` | Runs instead of the login shell (`tmux new -A` workflows) |
+| `RequestTTY` | `ssh(1)` semantics: `auto` allocates a tty only for plain shells, so a `RemoteCommand` needs `RequestTTY yes` — the same pairing OpenSSH requires |
+
+The editor's **Advanced** section shows a badge per row: **applied** for the keywords above,
+**kept** for everything Muxus preserves but does not use. A one-click **Legacy device
+algorithms** button adds the `KexAlgorithms`/`HostKeyAlgorithms`/`Ciphers` lines old console
+servers and network appliances need.
 
 **Everything else is preserved.** Unmodelled keywords are kept verbatim and shown in the
 editor's **Advanced** section, so keywords Muxus does not model survive an edit untouched:
-`Compression`, `StrictHostKeyChecking`, and any site-specific options.
+`HashKnownHosts`, `ControlMaster`, `ForwardX11`, and any site-specific options.
 
 ## How edits are written
 

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -55,10 +55,18 @@ These keywords are modelled as fields. They appear as controls in the
 | `PubkeyAuthentication no` | The editor's "password / interactive" mode |
 | `PreferredAuthentications keyboard-interactive,password` | Written alongside the above |
 
+These keywords never become editor fields — they are edited under **Advanced** — but the
+dialler still applies them the way `ssh` would:
+
+| Keyword | Used for |
+| --- | --- |
+| `Ciphers`, `KexAlgorithms`, `HostKeyAlgorithms`, `MACs` | Algorithm negotiation, including the `+`/`^`/`-` list syntax and `*` patterns. Entries the SSH engine does not implement are skipped with a notice, so a config shared with OpenSSH keeps working. |
+| `ConnectTimeout` | Dial timeout; defaults to 20 seconds |
+| `ServerAliveInterval`, `ServerAliveCountMax` | Keepalives; default 15 seconds / 3 missed replies |
+
 **Everything else is preserved.** Unmodelled keywords are kept verbatim and shown in the
 editor's **Advanced** section, so keywords Muxus does not model survive an edit untouched:
-`Compression`, `ServerAliveInterval`, `StrictHostKeyChecking`, and any site-specific
-options.
+`Compression`, `StrictHostKeyChecking`, and any site-specific options.
 
 ## How edits are written
 

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -64,9 +64,9 @@ editor badges them **applied** — but the dialler still applies them the way `s
 | `Compression` | `yes` prefers zlib like `ssh -C` |
 | `ConnectTimeout` | Dial timeout; defaults to 20 seconds |
 | `ServerAliveInterval`, `ServerAliveCountMax` | Keepalives; default 15 seconds / 3 missed replies |
-| `IdentityAgent` | Agent socket override — a path (1Password, Secretive, …), `$VAR`, `SSH_AUTH_SOCK`, or `none` |
+| `IdentityAgent` | Agent socket override — a path (1Password, Secretive, …), `$VAR`/`${VAR}`, `SSH_AUTH_SOCK`, or `none` |
 | `PasswordAuthentication no`, `KbdInteractiveAuthentication no` | Removes that rung from the auth ladder (the legacy `ChallengeResponseAuthentication` spelling works too) |
-| `UserKnownHostsFile`, `GlobalKnownHostsFile` | Host keys verify against these files instead; new keys are recorded into the first user file, `none` disables |
+| `UserKnownHostsFile`, `GlobalKnownHostsFile` | Host keys verify against these files instead; new keys are recorded into the first user file, `none` disables, and user-file path tokens such as `%h`, `%n`, and `%p` expand per connection |
 | `StrictHostKeyChecking` | `accept-new`/`no` accept first-contact keys silently; `yes` refuses unknown or changed keys. A **changed** key always asks, even under `no` — silently trusting a swapped key is a footgun Muxus does not reproduce |
 | `SetEnv`, `SendEnv` | Session environment, with `-pattern` removals and SetEnv overriding |
 | `RemoteCommand` | Runs instead of the login shell (`tmux new -A` workflows) |

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -48,15 +48,19 @@ These keywords are modelled as fields. They appear as controls in the
 | `IdentityFile` | Keys offered, in order |
 | `CertificateFile` | User certificates, paired with their key |
 | `IdentitiesOnly` | Restricts authentication to the listed identities |
+| `IdentityAgent` | Agent source — inherited, `SSH_AUTH_SOCK`, custom socket/variable, or disabled |
 | `ForwardAgent` | Agent forwarding, when an agent is present |
 | `ProxyJump` | Jump chain, comma-separated and nestable |
 | `ProxyCommand` | External transport command (`%h`, `%p`, `%r` expand at dial time) |
 | `LocalForward`, `RemoteForward`, `DynamicForward` | Forwards started with the session |
 | `PubkeyAuthentication no` | The editor's "password / interactive" mode |
 | `PreferredAuthentications keyboard-interactive,password` | Written alongside the above |
+| `StrictHostKeyChecking` | Host-key verification policy |
+| `RemoteCommand` | Login shell or a command to run after connecting |
+| `RequestTTY` | Terminal allocation for shells and startup commands |
 
-These keywords never become editor fields — they are edited under **Advanced**, where the
-editor badges them **applied** — but the dialler still applies them the way `ssh` would:
+These expert policies remain under **Advanced**, where the editor badges them **applied**,
+but the dialler still applies them the way `ssh` would:
 
 | Keyword | Used for |
 | --- | --- |
@@ -64,18 +68,14 @@ editor badges them **applied** — but the dialler still applies them the way `s
 | `Compression` | `yes` prefers zlib like `ssh -C` |
 | `ConnectTimeout` | Dial timeout; defaults to 20 seconds |
 | `ServerAliveInterval`, `ServerAliveCountMax` | Keepalives; default 15 seconds / 3 missed replies |
-| `IdentityAgent` | Agent socket override — a path (1Password, Secretive, …), `$VAR`/`${VAR}`, `SSH_AUTH_SOCK`, or `none` |
 | `PasswordAuthentication no`, `KbdInteractiveAuthentication no` | Removes that rung from the auth ladder (the legacy `ChallengeResponseAuthentication` spelling works too) |
 | `UserKnownHostsFile`, `GlobalKnownHostsFile` | Host keys verify against these files instead; new keys are recorded into the first user file, `none` disables, and user-file path tokens such as `%h`, `%n`, and `%p` expand per connection |
-| `StrictHostKeyChecking` | `accept-new`/`no` accept first-contact keys silently; `yes` refuses unknown or changed keys. A **changed** key always asks, even under `no` — silently trusting a swapped key is a footgun Muxus does not reproduce |
 | `SetEnv`, `SendEnv` | Session environment, with `-pattern` removals and SetEnv overriding |
-| `RemoteCommand` | Runs instead of the login shell (`tmux new -A` workflows) |
-| `RequestTTY` | `ssh(1)` semantics: `auto` allocates a tty only for plain shells, so a `RemoteCommand` needs `RequestTTY yes` — the same pairing OpenSSH requires |
 
 The editor's **Advanced** section shows a badge per row: **applied** for the keywords above,
 **kept** for everything Muxus preserves but does not use. A one-click **Legacy device
 algorithms** button adds the `KexAlgorithms`/`HostKeyAlgorithms`/`Ciphers` lines old console
-servers and network appliances need.
+servers and network appliances need, merging them into any algorithm lists already present.
 
 **Everything else is preserved.** Unmodelled keywords are kept verbatim and shown in the
 editor's **Advanced** section, so keywords Muxus does not model survive an edit untouched:

--- a/server/src/routes/app.ts
+++ b/server/src/routes/app.ts
@@ -5,6 +5,7 @@ import { isNewerVersion } from '@muxus/shared';
 import type { AppInfo, UpdateCheckResult } from '@muxus/shared';
 import type { AppContext } from '../app.js';
 import { defaultShell } from '../local/pty-manager.js';
+import { supportedAlgorithms } from '../ssh/algorithms.js';
 
 const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/muxus/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
@@ -51,6 +52,7 @@ function appInfo(): AppInfo {
     platform: process.platform,
     homeDir: os.homedir(),
     defaultShell: defaultShell(),
+    sshAlgorithms: supportedAlgorithms(),
   };
 }
 

--- a/server/src/ssh/algorithms.ts
+++ b/server/src/ssh/algorithms.ts
@@ -1,6 +1,6 @@
-import { createRequire } from 'node:module';
 import type { Algorithms } from 'ssh2';
 import type { ResolvedTarget } from './ssh-config.js';
+import ssh2Constants from './ssh2-internals.js';
 
 /**
  * Translate the ssh_config algorithm lists (Ciphers, KexAlgorithms,
@@ -20,14 +20,6 @@ import type { ResolvedTarget } from './ssh-config.js';
 // ssh2 publishes no API for its algorithm tables; read them from the same
 // module instance the Client uses so this filter can never disagree with the
 // handshake.
-const requireFromHere = createRequire(import.meta.url);
-const ssh2Constants = requireFromHere('ssh2/lib/protocol/constants.js') as {
-  SUPPORTED_KEX: string[];
-  SUPPORTED_CIPHER: string[];
-  SUPPORTED_SERVER_HOST_KEY: string[];
-  SUPPORTED_MAC: string[];
-};
-
 const CATEGORIES = [
   { option: 'ciphers', keyword: 'Ciphers', ssh2Key: 'cipher', supported: ssh2Constants.SUPPORTED_CIPHER },
   { option: 'kexAlgorithms', keyword: 'KexAlgorithms', ssh2Key: 'kex', supported: ssh2Constants.SUPPORTED_KEX },
@@ -44,9 +36,14 @@ export interface ConnectionAlgorithms {
   notes: string[];
 }
 
+/** Per-keyword algorithm names ssh2 can negotiate (edit-time validation). */
+export function supportedAlgorithms(): Record<string, string[]> {
+  return Object.fromEntries(CATEGORIES.map((c) => [c.keyword, [...c.supported]]));
+}
+
 /** Throws when an exact list leaves no algorithm ssh2 could offer at all. */
 export function connectionAlgorithms(
-  resolved: Pick<ResolvedTarget, 'ciphers' | 'kexAlgorithms' | 'hostKeyAlgorithms' | 'macs'>,
+  resolved: Pick<ResolvedTarget, 'ciphers' | 'kexAlgorithms' | 'hostKeyAlgorithms' | 'macs' | 'compression'>,
 ): ConnectionAlgorithms {
   const out: Record<string, TranslatedList> = {};
   const notes: string[] = [];
@@ -55,6 +52,11 @@ export function connectionAlgorithms(
     if (!value) continue;
     const translated = translateList(value, category.keyword, category.supported, notes);
     if (translated) out[category.ssh2Key] = translated;
+  }
+  if (resolved.compression !== undefined) {
+    // `Compression yes` prefers zlib the way `ssh -C` does; `no` pins the
+    // ssh2 default of none but stops a zlib-preferring server from winning.
+    out.compress = resolved.compression ? ['zlib@openssh.com', 'zlib', 'none'] : ['none'];
   }
   return {
     // Every name was filtered against ssh2's own supported tables above, so

--- a/server/src/ssh/algorithms.ts
+++ b/server/src/ssh/algorithms.ts
@@ -1,0 +1,103 @@
+import { createRequire } from 'node:module';
+import type { Algorithms } from 'ssh2';
+import type { ResolvedTarget } from './ssh-config.js';
+
+/**
+ * Translate the ssh_config algorithm lists (Ciphers, KexAlgorithms,
+ * HostKeyAlgorithms, MACs) into ssh2's `algorithms` connect option.
+ *
+ * OpenSSH list syntax: a leading `+` appends to the default set, `^` moves to
+ * its head, `-` removes from it, and a bare list replaces it entirely.
+ * Entries may be `*`/`?` patterns; they expand against the supported table.
+ *
+ * The config file is usually shared with OpenSSH, which implements algorithms
+ * ssh2 lacks (sntrup761x25519, mlkem768, …). Such entries are dropped and
+ * reported instead of failing the dial — ssh2 throws on any name outside its
+ * supported set, and an extra algorithm OpenSSH would offer must not break a
+ * host Muxus could otherwise reach.
+ */
+
+// ssh2 publishes no API for its algorithm tables; read them from the same
+// module instance the Client uses so this filter can never disagree with the
+// handshake.
+const requireFromHere = createRequire(import.meta.url);
+const ssh2Constants = requireFromHere('ssh2/lib/protocol/constants.js') as {
+  SUPPORTED_KEX: string[];
+  SUPPORTED_CIPHER: string[];
+  SUPPORTED_SERVER_HOST_KEY: string[];
+  SUPPORTED_MAC: string[];
+};
+
+const CATEGORIES = [
+  { option: 'ciphers', keyword: 'Ciphers', ssh2Key: 'cipher', supported: ssh2Constants.SUPPORTED_CIPHER },
+  { option: 'kexAlgorithms', keyword: 'KexAlgorithms', ssh2Key: 'kex', supported: ssh2Constants.SUPPORTED_KEX },
+  { option: 'hostKeyAlgorithms', keyword: 'HostKeyAlgorithms', ssh2Key: 'serverHostKey', supported: ssh2Constants.SUPPORTED_SERVER_HOST_KEY },
+  { option: 'macs', keyword: 'MACs', ssh2Key: 'hmac', supported: ssh2Constants.SUPPORTED_MAC },
+] as const;
+
+type TranslatedList = string[] | Partial<Record<'append' | 'prepend' | 'remove', string[]>>;
+
+export interface ConnectionAlgorithms {
+  /** ssh2 connect option; undefined when the config requests nothing usable. */
+  algorithms?: Algorithms;
+  /** User-facing notices about config entries that had to be skipped. */
+  notes: string[];
+}
+
+/** Throws when an exact list leaves no algorithm ssh2 could offer at all. */
+export function connectionAlgorithms(
+  resolved: Pick<ResolvedTarget, 'ciphers' | 'kexAlgorithms' | 'hostKeyAlgorithms' | 'macs'>,
+): ConnectionAlgorithms {
+  const out: Record<string, TranslatedList> = {};
+  const notes: string[] = [];
+  for (const category of CATEGORIES) {
+    const value = resolved[category.option];
+    if (!value) continue;
+    const translated = translateList(value, category.keyword, category.supported, notes);
+    if (translated) out[category.ssh2Key] = translated;
+  }
+  return {
+    // Every name was filtered against ssh2's own supported tables above, so
+    // the plain string lists satisfy the literal unions @types/ssh2 declares.
+    algorithms: Object.keys(out).length ? (out as Algorithms) : undefined,
+    notes,
+  };
+}
+
+function translateList(
+  value: string,
+  keyword: string,
+  supported: readonly string[],
+  notes: string[],
+): TranslatedList | undefined {
+  const first = value[0];
+  const mode = first === '+' ? 'append' : first === '^' ? 'prepend' : first === '-' ? 'remove' : 'exact';
+  const list = mode === 'exact' ? value : value.slice(1);
+  const names: string[] = [];
+  const dropped: string[] = [];
+  for (const token of list.split(',').map((t) => t.trim().toLowerCase()).filter(Boolean)) {
+    const matches = expandEntry(token, supported);
+    // Removing an algorithm ssh2 never offers is a no-op, not a surprise.
+    if (!matches.length && mode !== 'remove') dropped.push(token);
+    for (const name of matches) if (!names.includes(name)) names.push(name);
+  }
+  if (dropped.length) {
+    notes.push(`${keyword}: skipping ${dropped.join(', ')} — not supported by the SSH engine.`);
+  }
+  if (mode === 'exact') {
+    if (!names.length) {
+      throw new Error(`none of the ${keyword} in the ssh config ("${value}") are supported by the SSH engine`);
+    }
+    return names;
+  }
+  return names.length ? { [mode]: names } : undefined;
+}
+
+/** Expand one list entry against the supported table: exact name or `*`/`?` pattern. */
+function expandEntry(token: string, supported: readonly string[]): string[] {
+  if (!/[*?]/.test(token)) return supported.includes(token) ? [token] : [];
+  const rx = new RegExp(
+    `^${token.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.')}$`,
+  );
+  return supported.filter((name) => rx.test(name));
+}

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -31,6 +31,7 @@ import {
   type ConnectionLeaseOwner,
   type TransportLease,
 } from './connection-leases.js';
+import { connectionAlgorithms } from './algorithms.js';
 import { openIntegratedRemoteShell } from './remote-shell-integration.js';
 import {
   expandIdentityPath,
@@ -488,6 +489,8 @@ export class SshConnectionManager {
   private dial(hop: ChainHop, sock: Duplex | undefined, io: ConnectIo): Promise<Client> {
     const agent = agentSocket();
     const auth = new AuthLadder(hop, io);
+    const { algorithms, notes } = connectionAlgorithms(hop.resolved);
+    for (const note of notes) io.status(note);
     const proxySocket =
       !sock && hop.resolved.proxyCommand ? openProxyCommand(expandedProxyCommand(hop)!) : undefined;
     const transport = sock ?? proxySocket;
@@ -495,7 +498,8 @@ export class SshConnectionManager {
       username: hop.user,
       readyTimeout: (hop.resolved.connectTimeout ?? 20) * 1000,
       keepaliveInterval: (hop.resolved.serverAliveInterval ?? 15) * 1000,
-      keepaliveCountMax: 3,
+      keepaliveCountMax: hop.resolved.serverAliveCountMax ?? 3,
+      ...(algorithms ? { algorithms } : {}),
       hostVerifier: (key: Buffer, verify: (valid: boolean) => void) => {
         void this.verifyHostKey(hop, key, io).then(verify);
       },
@@ -1006,5 +1010,10 @@ function friendlyConnectError(err: Error, hop: ChainHop): Error {
   if (/ENOTFOUND|EAI_AGAIN/.test(msg)) return new Error(`could not resolve host ${hop.resolved.hostname}`);
   if (/ETIMEDOUT|Timed out/i.test(msg)) return new Error(`connection to ${where} timed out`);
   if (/All configured authentication methods failed/.test(msg)) return new Error(`authentication to ${where} failed`);
+  if (/Handshake failed: no matching/i.test(msg)) {
+    return new Error(
+      `${msg} — if ${where} only speaks legacy algorithms, add KexAlgorithms/Ciphers/HostKeyAlgorithms lines to this host's ssh config (Advanced options in the host editor)`,
+    );
+  }
   return err;
 }

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -25,7 +25,7 @@ import {
   type OpenSshCertificate,
 } from './certificates.js';
 import { KnownHostsStore, fingerprintSha256, hostKeyType } from './known-hosts.js';
-import { agentSocket } from './key-scan.js';
+import { resolveAgentSocket } from './key-scan.js';
 import {
   ConnectionLeaseRegistry,
   type ConnectionLeaseOwner,
@@ -39,6 +39,7 @@ import {
   loadConfigDocument,
   parseHostSpec,
   resolveHost,
+  sessionEnvironment,
   type ConfigDocument,
   type ResolvedTarget,
 } from './ssh-config.js';
@@ -63,6 +64,32 @@ export interface ConnectIo {
   hostKey(challenge: HostKeyChallenge): Promise<boolean>;
 }
 
+/**
+ * Per-session channel settings from ssh config. Resolved per connect call —
+ * two aliases multiplexed onto one transport keep their own environment and
+ * RemoteCommand, the way each `ssh` invocation does under ControlMaster.
+ */
+export interface SessionSettings {
+  env?: Record<string, string>;
+  remoteCommand?: string;
+  requestTty?: ResolvedTarget['requestTty'];
+}
+
+export function sessionSettings(resolved: ResolvedTarget): SessionSettings {
+  return {
+    env: sessionEnvironment(resolved),
+    remoteCommand: resolved.remoteCommand,
+    requestTty: resolved.requestTty,
+  };
+}
+
+/** RequestTTY the way ssh(1) treats it: auto ⇒ a tty only for plain shells. */
+function wantsPty(requestTty: ResolvedTarget['requestTty'], hasCommand: boolean): boolean {
+  if (requestTty === 'no') return false;
+  if (requestTty === 'yes' || requestTty === 'force') return true;
+  return !hasCommand;
+}
+
 export interface ManagedConnection {
   id: string;
   client: Client;
@@ -78,7 +105,8 @@ export interface ManagedConnection {
   configForwards: ConfigForward[];
   /** Current passive keepalive health of the transport. */
   health(): SshTransportHealth;
-  shell(cols: number, rows: number, term: string): Promise<ClientChannel>;
+  /** Session defaults come from the dialed target when none are passed. */
+  shell(cols: number, rows: number, term: string, session?: SessionSettings): Promise<ClientChannel>;
   sftp(): Promise<SFTPWrapper>;
   /** Subscribe to passive keepalive health; returns an unsubscribe function. */
   onHealth(listener: (state: SshTransportHealth) => void): () => void;
@@ -94,6 +122,9 @@ export type SshTransportHealth = 'healthy' | 'suspect';
 export interface MuxedConnectionLease extends TransportLease<ManagedConnection> {
   /** True when this lease multiplexes onto a pre-existing transport instead of a fresh dial. */
   reused: boolean;
+  /** This connect call's resolved final hop (not the dialing call's) — the
+   *  source for per-alias session settings on a shared transport. */
+  target: ChainHop;
 }
 
 export interface TerminalShell {
@@ -240,7 +271,7 @@ export class SshConnectionManager {
     const label = `${target.user}@${target.resolved.hostname}:${target.port}`;
 
     if (!opts.freshTransport) {
-      const shared = this.acquireShared(key, owner);
+      const shared = this.acquireShared(key, owner, target);
       if (shared) {
         shared.connection.configForwards = mergeConfigForwards(
           shared.connection.configForwards,
@@ -258,7 +289,7 @@ export class SshConnectionManager {
         const lease = this.connections.acquire(conn.id, owner);
         if (lease) {
           conn.configForwards = mergeConfigForwards(conn.configForwards, configForwards);
-          return { ...lease, reused: true };
+          return { ...lease, reused: true, target };
         }
         // The transport died between ready and acquire; dial our own below.
       }
@@ -270,21 +301,25 @@ export class SshConnectionManager {
     this.pendingDials.set(key, tracked);
     try {
       const lease = await dial;
-      return { ...lease, reused: false };
+      return { ...lease, reused: false, target };
     } finally {
       if (this.pendingDials.get(key) === tracked) this.pendingDials.delete(key);
     }
   }
 
   /** Least-busy live, healthy transport with the same dial plan, if any. */
-  private acquireShared(key: string, owner: ConnectionLeaseOwner): MuxedConnectionLease | undefined {
+  private acquireShared(
+    key: string,
+    owner: ConnectionLeaseOwner,
+    target: ChainHop,
+  ): MuxedConnectionLease | undefined {
     const candidates = this.connections
       .list()
       .filter((conn) => conn.muxKey === key && conn.health() === 'healthy')
       .sort((a, b) => this.connections.leaseCount(a.id) - this.connections.leaseCount(b.id));
     for (const conn of candidates) {
       const lease = this.connections.acquire(conn.id, owner);
-      if (lease) return { ...lease, reused: true };
+      if (lease) return { ...lease, reused: true, target };
     }
     return undefined;
   }
@@ -305,7 +340,7 @@ export class SshConnectionManager {
   ): Promise<TerminalShell> {
     const lease = await this.connect(profile, io);
     try {
-      const stream = await lease.connection.shell(cols, rows, term);
+      const stream = await lease.connection.shell(cols, rows, term, sessionSettings(lease.target.resolved));
       return { lease, stream, transport: lease.reused ? 'shared' : 'new' };
     } catch (err) {
       lease.release();
@@ -317,7 +352,7 @@ export class SshConnectionManager {
       io.status('The shared SSH connection refused another session — opening a dedicated one …', { transient: true });
       const dedicated = await this.connect(profile, io, 'terminal', { freshTransport: true });
       try {
-        const stream = await dedicated.connection.shell(cols, rows, term);
+        const stream = await dedicated.connection.shell(cols, rows, term, sessionSettings(dedicated.target.resolved));
         return { lease: dedicated, stream, transport: 'overflow' };
       } catch (retryErr) {
         dedicated.release();
@@ -423,12 +458,21 @@ export class SshConnectionManager {
       metadataAlias,
       health: () => transportHealth,
       configForwards: target.resolved.forwards,
-      shell: async (cols, rows, term) => {
-        const pty = terminalPtyOptions(cols, rows, term);
-        const integrated = await openIntegratedRemoteShell(client, getSftp, pty);
-        if (integrated) return integrated;
+      shell: async (cols, rows, term, session = sessionSettings(target.resolved)) => {
+        const pty = wantsPty(session.requestTty, !!session.remoteCommand)
+          ? terminalPtyOptions(cols, rows, term)
+          : undefined;
+        if (session.remoteCommand) {
+          return openSessionExec(client, session.remoteCommand, pty, session.env);
+        }
+        if (pty) {
+          const integrated = await openIntegratedRemoteShell(client, getSftp, pty, session.env);
+          if (integrated) return integrated;
+        }
         return new Promise((resolve, reject) => {
-          client.shell(pty, (err, stream) => (err ? reject(err) : resolve(stream)));
+          client.shell(pty ?? false, { env: session.env }, (err, stream) =>
+            err ? reject(err) : resolve(stream),
+          );
         });
       },
       // One SFTP channel per connection, shared by every file operation.
@@ -487,7 +531,7 @@ export class SshConnectionManager {
   }
 
   private dial(hop: ChainHop, sock: Duplex | undefined, io: ConnectIo): Promise<Client> {
-    const agent = agentSocket();
+    const agent = resolveAgentSocket(hop.resolved.identityAgent);
     const auth = new AuthLadder(hop, io);
     const { algorithms, notes } = connectionAlgorithms(hop.resolved);
     for (const note of notes) io.status(note);
@@ -536,14 +580,38 @@ export class SshConnectionManager {
     });
   }
 
+  /** The default store, or a per-host one when the config redirects the files. */
+  private knownHostsFor(hop: ChainHop): KnownHostsStore {
+    const { userKnownHostsFiles, globalKnownHostsFiles } = hop.resolved;
+    if (!userKnownHostsFiles && !globalKnownHostsFiles) return this.knownHosts;
+    return new KnownHostsStore(userKnownHostsFiles, globalKnownHostsFiles);
+  }
+
   private async verifyHostKey(hop: ChainHop, key: Buffer, io: ConnectIo): Promise<boolean> {
     const host = hop.resolved.hostname;
     const port = hop.port;
-    const verdict = this.knownHosts.verify(host, port, key);
+    const store = this.knownHostsFor(hop);
+    const verdict = store.verify(host, port, key);
     if (verdict.state === 'ok') return true;
     if (verdict.state === 'revoked') {
       io.status(`HOST KEY REVOKED for ${host} — remove the @revoked entry from known_hosts if this is intentional.`);
       return false;
+    }
+    const strict = hop.resolved.strictHostKeyChecking ?? 'ask';
+    if (strict === 'yes') {
+      io.status(
+        verdict.state === 'changed'
+          ? `HOST KEY CHANGED for ${host} and StrictHostKeyChecking is yes — refusing to connect.`
+          : `No ${hostKeyType(key)} host key for ${host} in known_hosts and StrictHostKeyChecking is yes — refusing to connect.`,
+      );
+      return false;
+    }
+    // `no` on a *changed* key still asks below: silently trusting a swapped
+    // key is a footgun OpenSSH's degraded continue-mode doesn't map to.
+    if (verdict.state === 'unknown' && (strict === 'accept-new' || strict === 'no')) {
+      store.record(host, port, key);
+      io.status(`Automatically accepted the new host key for ${host} (${fingerprintSha256(key)}).`);
+      return true;
     }
     const accepted = await io
       .hostKey({
@@ -556,7 +624,7 @@ export class SshConnectionManager {
         hop: hop.hopLabel,
       })
       .catch(() => false);
-    if (accepted) this.knownHosts.record(host, port, key);
+    if (accepted) store.record(host, port, key);
     return accepted;
   }
 }
@@ -664,6 +732,8 @@ function directSettings(hostname: string): ResolvedTarget {
     proxyJump: [],
     forwards: [],
     passwordOnly: false,
+    setEnv: {},
+    sendEnv: [],
   };
 }
 
@@ -813,7 +883,7 @@ class AuthLadder {
     const { resolved, user, hopLabel } = this.hop;
     const label = hopLabel ?? this.hop.spec.host;
     const attempts: AuthAttempt[] = [{ type: 'none', get: () => Promise.resolve({ type: 'none', username: user }) }];
-    const agent = agentSocket();
+    const agent = resolveAgentSocket(resolved.identityAgent);
 
     if (!resolved.passwordOnly) {
       if (agent && !resolved.identitiesOnly) {
@@ -859,40 +929,44 @@ class AuthLadder {
       }
     }
 
-    attempts.push({
-      type: 'keyboard-interactive',
-      get: () =>
-        Promise.resolve({
-          type: 'keyboard-interactive',
-          username: user,
-          prompt: (name, instructions, _lang, prompts, finish) => {
-            this.io
-              .prompt({
-                name: name || undefined,
-                instructions: instructions || undefined,
-                host: label,
-                prompts: prompts.map((p) => ({ prompt: p.prompt, echo: p.echo !== false })),
-              })
-              .then(finish)
-              .catch(() => {
-                this.cancelled = true;
-                finish(prompts.map(() => ''));
-              });
-          },
-        }),
-    });
-
-    for (let attempt = 1; attempt <= MAX_PASSWORD_ATTEMPTS; attempt++) {
+    if (resolved.kbdInteractiveAuthentication !== false) {
       attempts.push({
-        type: 'password',
-        get: async () => {
-          const [password] = await this.io.prompt({
-            host: label,
-            prompts: [{ prompt: attempt === 1 ? `${user}@${label}'s password` : 'Permission denied, please try again. Password', echo: false }],
-          });
-          return { type: 'password', username: user, password: password ?? '' };
-        },
+        type: 'keyboard-interactive',
+        get: () =>
+          Promise.resolve({
+            type: 'keyboard-interactive',
+            username: user,
+            prompt: (name, instructions, _lang, prompts, finish) => {
+              this.io
+                .prompt({
+                  name: name || undefined,
+                  instructions: instructions || undefined,
+                  host: label,
+                  prompts: prompts.map((p) => ({ prompt: p.prompt, echo: p.echo !== false })),
+                })
+                .then(finish)
+                .catch(() => {
+                  this.cancelled = true;
+                  finish(prompts.map(() => ''));
+                });
+            },
+          }),
       });
+    }
+
+    if (resolved.passwordAuthentication !== false) {
+      for (let attempt = 1; attempt <= MAX_PASSWORD_ATTEMPTS; attempt++) {
+        attempts.push({
+          type: 'password',
+          get: async () => {
+            const [password] = await this.io.prompt({
+              host: label,
+              prompts: [{ prompt: attempt === 1 ? `${user}@${label}'s password` : 'Permission denied, please try again. Password', echo: false }],
+            });
+            return { type: 'password', username: user, password: password ?? '' };
+          },
+        });
+      }
     }
     return attempts;
   }
@@ -1000,6 +1074,20 @@ class AuthLadder {
 function defaultIdentityFiles(): string[] {
   const dir = path.join(os.homedir(), '.ssh');
   return DEFAULT_IDENTITY_NAMES.map((name) => path.join(dir, name)).filter((p) => fs.existsSync(p));
+}
+
+/** RemoteCommand session: exec instead of a shell, tty per RequestTTY. */
+function openSessionExec(
+  client: Client,
+  command: string,
+  pty: PseudoTtyOptions | undefined,
+  env?: Record<string, string>,
+): Promise<ClientChannel> {
+  return new Promise((resolve, reject) => {
+    client.exec(command, { ...(pty ? { pty } : {}), ...(env ? { env } : {}) }, (err, stream) =>
+      err ? reject(err) : resolve(stream),
+    );
+  });
 }
 
 /** Translate the common ssh2 failure modes into user-actionable messages. */

--- a/server/src/ssh/key-scan.ts
+++ b/server/src/ssh/key-scan.ts
@@ -38,14 +38,18 @@ export function agentSocket(): string | undefined {
 
 /**
  * The agent socket for one host: the IdentityAgent override when set
- * (`none`, `$VAR`, the literal `SSH_AUTH_SOCK`, or a path — 1Password and
- * friends), otherwise the environment default.
+ * (`none`, `$VAR`/`${VAR}`, the literal `SSH_AUTH_SOCK`, or a path —
+ * 1Password and friends), otherwise the environment default.
  */
 export function resolveAgentSocket(identityAgent?: string): string | undefined {
   if (identityAgent === undefined) return agentSocket();
   if (identityAgent.toLowerCase() === 'none') return undefined;
   if (identityAgent === 'SSH_AUTH_SOCK') return process.env.SSH_AUTH_SOCK || undefined;
-  if (identityAgent.startsWith('$')) return process.env[identityAgent.slice(1)] || undefined;
+  if (identityAgent.startsWith('$')) {
+    const braced = /^\$\{([^{}]+)\}$/.exec(identityAgent);
+    const name = braced?.[1] ?? identityAgent.slice(1);
+    return process.env[name] || undefined;
+  }
   return identityAgent;
 }
 

--- a/server/src/ssh/key-scan.ts
+++ b/server/src/ssh/key-scan.ts
@@ -36,6 +36,19 @@ export function agentSocket(): string | undefined {
   return process.platform === 'win32' ? '\\\\.\\pipe\\openssh-ssh-agent' : undefined;
 }
 
+/**
+ * The agent socket for one host: the IdentityAgent override when set
+ * (`none`, `$VAR`, the literal `SSH_AUTH_SOCK`, or a path — 1Password and
+ * friends), otherwise the environment default.
+ */
+export function resolveAgentSocket(identityAgent?: string): string | undefined {
+  if (identityAgent === undefined) return agentSocket();
+  if (identityAgent.toLowerCase() === 'none') return undefined;
+  if (identityAgent === 'SSH_AUTH_SOCK') return process.env.SSH_AUTH_SOCK || undefined;
+  if (identityAgent.startsWith('$')) return process.env[identityAgent.slice(1)] || undefined;
+  return identityAgent;
+}
+
 export async function listAgentKeys(): Promise<SshAgentKey[]> {
   const sock = agentSocket();
   if (!sock) return [];

--- a/server/src/ssh/known-hosts.ts
+++ b/server/src/ssh/known-hosts.ts
@@ -48,10 +48,18 @@ export function hostKeyType(key: Buffer): string {
 }
 
 export class KnownHostsStore {
+  /** New entries land in the first user file; the rest are read-only. */
+  private readonly userFiles: string[];
+  private readonly globalFiles: string[];
+
+  /** Arrays follow UserKnownHostsFile/GlobalKnownHostsFile: [] means `none`. */
   constructor(
-    private readonly userFile = defaultKnownHostsPath(),
-    private readonly globalFile = GLOBAL_KNOWN_HOSTS,
-  ) {}
+    userFiles: string | string[] = defaultKnownHostsPath(),
+    globalFiles: string | string[] = GLOBAL_KNOWN_HOSTS,
+  ) {
+    this.userFiles = Array.isArray(userFiles) ? userFiles : [userFiles];
+    this.globalFiles = Array.isArray(globalFiles) ? globalFiles : [globalFiles];
+  }
 
   verify(host: string, port: number, key: Buffer): KnownHostVerdict {
     const names = hostNames(host, port);
@@ -59,7 +67,7 @@ export class KnownHostsStore {
     const keyB64 = key.toString('base64');
     let previous: string | undefined;
 
-    for (const file of [this.userFile, this.globalFile]) {
+    for (const file of [...this.userFiles, ...this.globalFiles]) {
       for (const entry of readEntries(file)) {
         if (entry.marker === 'cert-authority') continue; // CA validation is out of scope
         if (entry.keyType !== keyType || !entryMatches(entry.hosts, names)) continue;
@@ -78,14 +86,16 @@ export class KnownHostsStore {
    * `ssh-keygen -R` part, backing up to known_hosts.old), then append.
    */
   record(host: string, port: number, key: Buffer): void {
+    const target = this.userFiles[0];
+    if (!target) return; // UserKnownHostsFile none — nowhere to remember it
     const names = hostNames(host, port);
     const keyType = hostKeyType(key);
-    fs.mkdirSync(path.dirname(this.userFile), { recursive: true, mode: 0o700 });
+    fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
 
     let lines: string[] = [];
     try {
-      const text = fs.readFileSync(this.userFile, 'utf8');
-      fs.writeFileSync(`${this.userFile}.old`, text, { mode: 0o600 });
+      const text = fs.readFileSync(target, 'utf8');
+      fs.writeFileSync(`${target}.old`, text, { mode: 0o600 });
       lines = text.split(/\r?\n/);
       while (lines.length && lines[lines.length - 1] === '') lines.pop();
     } catch {
@@ -98,9 +108,9 @@ export class KnownHostsStore {
     });
     kept.push(`${names[0]} ${keyType} ${key.toString('base64')}`);
 
-    const tmp = `${this.userFile}.muxus.tmp`;
+    const tmp = `${target}.muxus.tmp`;
     fs.writeFileSync(tmp, `${kept.join('\n')}\n`, { mode: 0o600 });
-    fs.renameSync(tmp, this.userFile);
+    fs.renameSync(tmp, target);
   }
 }
 

--- a/server/src/ssh/remote-shell-integration.ts
+++ b/server/src/ssh/remote-shell-integration.ts
@@ -66,6 +66,7 @@ export async function openIntegratedRemoteShell(
   client: Client,
   getSftp: () => Promise<SFTPWrapper>,
   pty: PseudoTtyOptions,
+  env?: Record<string, string>,
 ): Promise<ClientChannel | undefined> {
   try {
     // Shell detection and SFTP channel setup are independent network
@@ -73,7 +74,7 @@ export async function openIntegratedRemoteShell(
     const [shell, sftp] = await Promise.all([probeShell(client), getSftp()]);
     if (!shell) return undefined;
     const root = await installIntegration(sftp, shell);
-    return await openExec(client, remoteShellCommand(shell, root), { pty });
+    return await openExec(client, remoteShellCommand(shell, root), { pty, ...(env ? { env } : {}) });
   } catch {
     return undefined;
   }
@@ -187,7 +188,7 @@ function writeFile(sftp: SFTPWrapper, remotePath: string, content: string): Prom
 function openExec(
   client: Client,
   command: string,
-  options?: { pty: PseudoTtyOptions },
+  options?: { pty: PseudoTtyOptions; env?: Record<string, string> },
 ): Promise<ClientChannel> {
   return new Promise((resolve, reject) => {
     const callback = (error: Error | undefined, channel: ClientChannel) =>

--- a/server/src/ssh/ssh-config-edit.ts
+++ b/server/src/ssh/ssh-config-edit.ts
@@ -106,6 +106,7 @@ function validateUpsert(req: HostUpsertRequest): void {
   for (const v of [
     o.hostname,
     o.user,
+    o.identityAgent,
     ...(o.identityFiles ?? []),
     ...(o.certificateFiles ?? []),
   ]) {
@@ -121,6 +122,9 @@ function validateUpsert(req: HostUpsertRequest): void {
   }
   if (o.proxyCommand !== undefined && o.proxyJump !== undefined) {
     bad('ProxyJump and ProxyCommand are mutually exclusive');
+  }
+  if (o.remoteCommand !== undefined && (!o.remoteCommand.trim() || /[\r\n]/.test(o.remoteCommand))) {
+    bad('RemoteCommand must be non-empty single-line text');
   }
   for (const f of o.forwards ?? []) validateForward(f);
   for (const extra of o.extras ?? []) {
@@ -170,6 +174,7 @@ export function renderHostBlock(req: HostUpsertRequest, indent: string, extraPat
   for (const file of o.identityFiles ?? []) opt('IdentityFile', singleToken(file));
   for (const file of o.certificateFiles ?? []) opt('CertificateFile', singleToken(file));
   if (o.identitiesOnly !== undefined) opt('IdentitiesOnly', o.identitiesOnly ? 'yes' : 'no');
+  opt('IdentityAgent', singleToken(o.identityAgent));
   if (o.proxyJump !== undefined) opt('ProxyJump', o.proxyJump.length ? o.proxyJump.join(',') : 'none');
   opt('ProxyCommand', o.proxyCommand?.trim());
   if (o.forwardAgent !== undefined) opt('ForwardAgent', o.forwardAgent ? 'yes' : 'no');
@@ -181,6 +186,9 @@ export function renderHostBlock(req: HostUpsertRequest, indent: string, extraPat
     if (f.type === 'dynamic') opt('DynamicForward', String(f.bindPort));
     else opt(f.type === 'local' ? 'LocalForward' : 'RemoteForward', `${f.bindPort} ${forwardTarget(f.targetHost!, f.targetPort!)}`);
   }
+  opt('StrictHostKeyChecking', o.strictHostKeyChecking);
+  opt('RemoteCommand', o.remoteCommand?.trim());
+  opt('RequestTTY', o.requestTty);
   for (const extra of o.extras ?? []) opt(extra.keyword, extra.value.trim());
   return lines;
 }

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -26,7 +27,6 @@ const MAX_INCLUDE_DEPTH = 8;
 
 const CONFIG_LINE_RE = /^([A-Za-z][A-Za-z0-9]*)\s*(?:=|\s)\s*(.*?)\s*$/;
 const WILDCARD_RE = /[*?]/;
-const ARG_TOKEN_RE = /"([^"]*)"|(\S+)/g;
 
 /** ~/.ssh/config — the OpenSSH per-user config location on macOS, Linux and Windows. */
 export function defaultSshConfigPath(): string {
@@ -209,11 +209,27 @@ function preludeText(lines: string[], commentStart: number, hostLine: number): s
   return text || undefined;
 }
 
-/** Split a config value into tokens, honoring double quotes. */
+/** Split a config value into tokens, honoring double quotes anywhere in a token. */
 export function splitArgs(value: string): string[] {
   const out: string[] = [];
-  ARG_TOKEN_RE.lastIndex = 0;
-  for (let m = ARG_TOKEN_RE.exec(value); m; m = ARG_TOKEN_RE.exec(value)) out.push(m[1] ?? m[2] ?? '');
+  let token = '';
+  let quoted = false;
+  let started = false;
+  for (const char of value) {
+    if (char === '"') {
+      quoted = !quoted;
+      started = true;
+    } else if (/\s/.test(char) && !quoted) {
+      if (!started) continue;
+      out.push(token);
+      token = '';
+      started = false;
+    } else {
+      token += char;
+      started = true;
+    }
+  }
+  if (started) out.push(token);
   return out;
 }
 
@@ -267,7 +283,7 @@ export interface ResolvedTarget extends ResolvedHostSettings {
   hostKeyAlgorithms?: string;
   macs?: string;
   compression?: boolean;
-  /** Agent socket override: a path, `$VAR`, `SSH_AUTH_SOCK`, or `none`. */
+  /** Agent socket override: a path, `$VAR`/`${VAR}`, `SSH_AUTH_SOCK`, or `none`. */
   identityAgent?: string;
   /** false ⇒ never try this method (`PasswordAuthentication no`). */
   passwordAuthentication?: boolean;
@@ -303,6 +319,10 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
   for (const entry of doc.sequence) {
     if (entry.patterns && !hostPatternsMatch(entry.patterns, host)) continue;
     for (const opt of entry.options) {
+      // OpenSSH treats ChallengeResponseAuthentication as an exact alias, so
+      // both spellings share one first-obtained slot.
+      const resolvedKey =
+        opt.key === 'challengeresponseauthentication' ? 'kbdinteractiveauthentication' : opt.key;
       switch (opt.key) {
         case 'identityfile': {
           const file = opt.args[0];
@@ -339,7 +359,9 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
           break;
         }
         default:
-          if (RESOLVED_KEYS.has(opt.key) && !first.has(opt.key) && opt.value) first.set(opt.key, opt.value);
+          if (RESOLVED_KEYS.has(resolvedKey) && !first.has(resolvedKey) && opt.value) {
+            first.set(resolvedKey, opt.value);
+          }
       }
     }
   }
@@ -348,14 +370,24 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
   const user = first.get('user');
   const port = parsePort(first.get('port')) ?? 22;
   const preferred = first.get('preferredauthentications');
-  const tokens = { h: hostname, r: user ?? os.userInfo().username };
+  const remoteUser = user ?? os.userInfo().username;
+  const identityTokens = { h: hostname, r: remoteUser };
+  const proxyJump = first.get('proxyjump');
+  const knownHostsTokens: KnownHostsPathTokens = {
+    h: hostname,
+    n: host,
+    p: port,
+    r: remoteUser,
+    j: proxyJump?.toLowerCase() === 'none' ? '' : (proxyJump ?? ''),
+    k: host,
+  };
 
   return {
     hostname,
     user,
     port,
-    identityFiles: identityFiles.map((f) => expandIdentityPath(f, tokens)),
-    certificateFiles: certificateFiles.map((f) => expandIdentityPath(f, tokens)),
+    identityFiles: identityFiles.map((f) => expandIdentityPath(f, identityTokens)),
+    certificateFiles: certificateFiles.map((f) => expandIdentityPath(f, identityTokens)),
     identitiesOnly: yes(first.get('identitiesonly')),
     forwardAgent: yes(first.get('forwardagent')),
     proxyJump: parseProxyJumpList(first.get('proxyjump')),
@@ -372,16 +404,14 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
     hostKeyAlgorithms: first.get('hostkeyalgorithms'),
     macs: first.get('macs'),
     compression: flag(first.get('compression')),
-    identityAgent: parseIdentityAgent(first.get('identityagent'), tokens),
+    identityAgent: parseIdentityAgent(first.get('identityagent'), identityTokens),
     passwordAuthentication: flag(first.get('passwordauthentication')),
-    kbdInteractiveAuthentication: flag(
-      first.get('kbdinteractiveauthentication') ?? first.get('challengeresponseauthentication'),
-    ),
-    userKnownHostsFiles: parseKnownHostsFiles(first.get('userknownhostsfile'), tokens),
-    globalKnownHostsFiles: parseKnownHostsFiles(first.get('globalknownhostsfile'), tokens),
+    kbdInteractiveAuthentication: flag(first.get('kbdinteractiveauthentication')),
+    userKnownHostsFiles: parseKnownHostsFiles(first.get('userknownhostsfile'), knownHostsTokens),
+    globalKnownHostsFiles: parseKnownHostsFiles(first.get('globalknownhostsfile'), knownHostsTokens),
     setEnv,
     sendEnv,
-    remoteCommand: first.get('remotecommand'),
+    remoteCommand: parseRemoteCommand(first.get('remotecommand')),
     requestTty: parseChoice(first.get('requesttty'), ['no', 'yes', 'force', 'auto']),
     strictHostKeyChecking: parseChoice(first.get('stricthostkeychecking'), ['yes', 'no', 'accept-new', 'ask']),
   };
@@ -398,7 +428,7 @@ function parseChoice<T extends string>(value: string | undefined, choices: reado
   return choices.includes(v as T) ? (v as T) : undefined;
 }
 
-/** `none` and `$VAR`/`SSH_AUTH_SOCK` indirections pass through; paths expand. */
+/** `none`, `$VAR`/`${VAR}`, and `SSH_AUTH_SOCK` indirections pass through; paths expand. */
 function parseIdentityAgent(value: string | undefined, tokens: { h: string; r: string }): string | undefined {
   const arg = value === undefined ? undefined : splitArgs(value)[0];
   if (!arg) return undefined;
@@ -407,11 +437,11 @@ function parseIdentityAgent(value: string | undefined, tokens: { h: string; r: s
 }
 
 /** Space-separated path list; `none` → []; unset → undefined (defaults). */
-function parseKnownHostsFiles(value: string | undefined, tokens: { h: string; r: string }): string[] | undefined {
+function parseKnownHostsFiles(value: string | undefined, tokens: KnownHostsPathTokens): string[] | undefined {
   if (value === undefined) return undefined;
   const args = splitArgs(value).filter(Boolean);
   if (args.length === 1 && args[0]!.toLowerCase() === 'none') return [];
-  return args.map((f) => expandIdentityPath(f, tokens));
+  return args.map((f) => expandKnownHostsPath(f, tokens));
 }
 
 /**
@@ -459,7 +489,6 @@ const RESOLVED_KEYS = new Set([
   'identityagent',
   'passwordauthentication',
   'kbdinteractiveauthentication',
-  'challengeresponseauthentication',
   'userknownhostsfile',
   'globalknownhostsfile',
   'remotecommand',
@@ -468,6 +497,10 @@ const RESOLVED_KEYS = new Set([
 ]);
 
 function parseProxyCommand(value: string | undefined): string | undefined {
+  return value && value.toLowerCase() !== 'none' ? value : undefined;
+}
+
+function parseRemoteCommand(value: string | undefined): string | undefined {
   return value && value.toLowerCase() !== 'none' ? value : undefined;
 }
 
@@ -528,6 +561,49 @@ export function expandIdentityPath(value: string, tokens: { h: string; r: string
     return os.userInfo().username; // %u
   });
   return p;
+}
+
+interface KnownHostsPathTokens {
+  /** Resolved remote hostname. */
+  h: string;
+  /** Original host argument. */
+  n: string;
+  /** Resolved remote port. */
+  p: number;
+  /** Resolved remote username. */
+  r: string;
+  /** ProxyJump contents, or empty when unset. */
+  j: string;
+  /** HostKeyAlias, or the original host when none is configured. */
+  k: string;
+}
+
+/** Expand the full token set OpenSSH accepts in UserKnownHostsFile paths. */
+function expandKnownHostsPath(value: string, tokens: KnownHostsPathTokens): string {
+  const home = os.homedir();
+  const local = os.userInfo();
+  const localHostname = os.hostname();
+  const connectionHash = createHash('sha1')
+    .update(`${localHostname}${tokens.h}${tokens.p}${tokens.r}${tokens.j}`)
+    .digest('hex');
+  const replacements: Record<string, string> = {
+    '%%': '%',
+    '%C': connectionHash,
+    '%d': home,
+    '%h': tokens.h,
+    '%i': String(local.uid),
+    '%j': tokens.j,
+    '%k': tokens.k,
+    '%L': localHostname.split('.')[0] ?? localHostname,
+    '%l': localHostname,
+    '%n': tokens.n,
+    '%p': String(tokens.p),
+    '%r': tokens.r,
+    '%u': local.username,
+  };
+  return value
+    .replace(/^~(?=$|[\\/])/, home)
+    .replace(/%%|%[CdhijkLlnpru]/g, (token) => replacements[token] ?? token);
 }
 
 /** Parse a LocalForward/RemoteForward/DynamicForward option's arguments. */

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -260,6 +260,12 @@ export function isConcreteAlias(pattern: string): boolean {
 export interface ResolvedTarget extends ResolvedHostSettings {
   connectTimeout?: number;
   serverAliveInterval?: number;
+  serverAliveCountMax?: number;
+  /** Raw ssh_config algorithm lists; translated to ssh2 form at dial time. */
+  ciphers?: string;
+  kexAlgorithms?: string;
+  hostKeyAlgorithms?: string;
+  macs?: string;
 }
 
 const yes = (v: string | undefined): boolean => (v ?? '').toLowerCase() === 'yes';
@@ -331,6 +337,11 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
       (!!preferred && !preferred.toLowerCase().split(',').includes('publickey')),
     connectTimeout: parseNumber(first.get('connecttimeout')),
     serverAliveInterval: parseNumber(first.get('serveraliveinterval')),
+    serverAliveCountMax: parseNumber(first.get('serveralivecountmax')),
+    ciphers: first.get('ciphers'),
+    kexAlgorithms: first.get('kexalgorithms'),
+    hostKeyAlgorithms: first.get('hostkeyalgorithms'),
+    macs: first.get('macs'),
   };
 }
 
@@ -344,6 +355,11 @@ const RESOLVED_KEYS = new Set([
   'pubkeyauthentication',
   'connecttimeout',
   'serveraliveinterval',
+  'serveralivecountmax',
+  'ciphers',
+  'kexalgorithms',
+  'hostkeyalgorithms',
+  'macs',
 ]);
 
 function parseProxyCommand(value: string | undefined): string | undefined {

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -669,6 +669,10 @@ export function blockToOptions(block: HostBlock): HostBlockOptions {
       case 'identitiesonly':
         out.identitiesOnly = yes(opt.args[0]);
         break;
+      case 'identityagent':
+        if (out.identityAgent === undefined && opt.args[0]) out.identityAgent = opt.args[0];
+        else extras.push({ keyword: opt.keyword, value: opt.value });
+        break;
       case 'forwardagent':
         out.forwardAgent = yes(opt.args[0]);
         break;
@@ -703,6 +707,22 @@ export function blockToOptions(block: HostBlock): HostBlockOptions {
         if (opt.value.toLowerCase() === 'keyboard-interactive,password') preferredConsumed = true;
         else extras.push({ keyword: opt.keyword, value: opt.value });
         break;
+      case 'remotecommand':
+        if (out.remoteCommand === undefined && opt.value) out.remoteCommand = opt.value;
+        else extras.push({ keyword: opt.keyword, value: opt.value });
+        break;
+      case 'requesttty': {
+        const requestTty = parseChoice(opt.value, ['no', 'yes', 'force', 'auto']);
+        if (requestTty && out.requestTty === undefined) out.requestTty = requestTty;
+        else extras.push({ keyword: opt.keyword, value: opt.value });
+        break;
+      }
+      case 'stricthostkeychecking': {
+        const strict = parseChoice(opt.value, ['yes', 'no', 'accept-new', 'ask']);
+        if (strict && out.strictHostKeyChecking === undefined) out.strictHostKeyChecking = strict;
+        else extras.push({ keyword: opt.keyword, value: opt.value });
+        break;
+      }
       default:
         extras.push({ keyword: opt.keyword, value: opt.value });
     }

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -266,6 +266,22 @@ export interface ResolvedTarget extends ResolvedHostSettings {
   kexAlgorithms?: string;
   hostKeyAlgorithms?: string;
   macs?: string;
+  compression?: boolean;
+  /** Agent socket override: a path, `$VAR`, `SSH_AUTH_SOCK`, or `none`. */
+  identityAgent?: string;
+  /** false ⇒ never try this method (`PasswordAuthentication no`). */
+  passwordAuthentication?: boolean;
+  kbdInteractiveAuthentication?: boolean;
+  /** Expanded paths; [] means `none`. undefined ⇒ OpenSSH defaults. */
+  userKnownHostsFiles?: string[];
+  globalKnownHostsFiles?: string[];
+  /** First-obtained value per variable, ssh_config SetEnv order. */
+  setEnv: Record<string, string>;
+  /** SendEnv patterns in obtained order, `-` removals included. */
+  sendEnv: string[];
+  remoteCommand?: string;
+  requestTty?: 'no' | 'yes' | 'force' | 'auto';
+  strictHostKeyChecking?: 'yes' | 'no' | 'accept-new' | 'ask';
 }
 
 const yes = (v: string | undefined): boolean => (v ?? '').toLowerCase() === 'yes';
@@ -281,6 +297,8 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
   const identityFiles: string[] = [];
   const certificateFiles: string[] = [];
   const forwards: ConfigForward[] = [];
+  const setEnv: Record<string, string> = {};
+  const sendEnv: string[] = [];
 
   for (const entry of doc.sequence) {
     if (entry.patterns && !hostPatternsMatch(entry.patterns, host)) continue;
@@ -291,6 +309,17 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
           if (file && !identityFiles.includes(file)) identityFiles.push(file);
           break;
         }
+        case 'setenv':
+          for (const arg of opt.args) {
+            const eq = arg.indexOf('=');
+            if (eq <= 0) continue;
+            const name = arg.slice(0, eq);
+            if (!(name in setEnv)) setEnv[name] = arg.slice(eq + 1);
+          }
+          break;
+        case 'sendenv':
+          sendEnv.push(...opt.args.filter(Boolean));
+          break;
         case 'certificatefile': {
           const file = opt.args[0];
           if (file && !certificateFiles.includes(file)) certificateFiles.push(file);
@@ -342,7 +371,73 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
     kexAlgorithms: first.get('kexalgorithms'),
     hostKeyAlgorithms: first.get('hostkeyalgorithms'),
     macs: first.get('macs'),
+    compression: flag(first.get('compression')),
+    identityAgent: parseIdentityAgent(first.get('identityagent'), tokens),
+    passwordAuthentication: flag(first.get('passwordauthentication')),
+    kbdInteractiveAuthentication: flag(
+      first.get('kbdinteractiveauthentication') ?? first.get('challengeresponseauthentication'),
+    ),
+    userKnownHostsFiles: parseKnownHostsFiles(first.get('userknownhostsfile'), tokens),
+    globalKnownHostsFiles: parseKnownHostsFiles(first.get('globalknownhostsfile'), tokens),
+    setEnv,
+    sendEnv,
+    remoteCommand: first.get('remotecommand'),
+    requestTty: parseChoice(first.get('requesttty'), ['no', 'yes', 'force', 'auto']),
+    strictHostKeyChecking: parseChoice(first.get('stricthostkeychecking'), ['yes', 'no', 'accept-new', 'ask']),
   };
+}
+
+/** yes/no → boolean; anything else (including unset) → undefined. */
+function flag(value: string | undefined): boolean | undefined {
+  const v = (value ?? '').toLowerCase();
+  return v === 'yes' ? true : v === 'no' ? false : undefined;
+}
+
+function parseChoice<T extends string>(value: string | undefined, choices: readonly T[]): T | undefined {
+  const v = (value ?? '').toLowerCase();
+  return choices.includes(v as T) ? (v as T) : undefined;
+}
+
+/** `none` and `$VAR`/`SSH_AUTH_SOCK` indirections pass through; paths expand. */
+function parseIdentityAgent(value: string | undefined, tokens: { h: string; r: string }): string | undefined {
+  const arg = value === undefined ? undefined : splitArgs(value)[0];
+  if (!arg) return undefined;
+  if (arg.toLowerCase() === 'none' || arg.startsWith('$') || arg === 'SSH_AUTH_SOCK') return arg;
+  return expandIdentityPath(arg, tokens);
+}
+
+/** Space-separated path list; `none` → []; unset → undefined (defaults). */
+function parseKnownHostsFiles(value: string | undefined, tokens: { h: string; r: string }): string[] | undefined {
+  if (value === undefined) return undefined;
+  const args = splitArgs(value).filter(Boolean);
+  if (args.length === 1 && args[0]!.toLowerCase() === 'none') return [];
+  return args.map((f) => expandIdentityPath(f, tokens));
+}
+
+/**
+ * The environment for a session channel: process variables matched by the
+ * SendEnv patterns (later `-pattern` entries remove earlier matches, as in
+ * ssh_config), overridden by explicit SetEnv values. undefined when empty.
+ */
+export function sessionEnvironment(
+  resolved: Pick<ResolvedTarget, 'setEnv' | 'sendEnv'>,
+  source: NodeJS.ProcessEnv = process.env,
+): Record<string, string> | undefined {
+  const names = new Set<string>();
+  for (const pattern of resolved.sendEnv) {
+    if (pattern.startsWith('-')) {
+      for (const name of names) if (globMatch(pattern.slice(1), name)) names.delete(name);
+    } else {
+      for (const name of Object.keys(source)) if (globMatch(pattern, name)) names.add(name);
+    }
+  }
+  const env: Record<string, string> = {};
+  for (const name of names) {
+    const value = source[name];
+    if (value !== undefined) env[name] = value;
+  }
+  Object.assign(env, resolved.setEnv);
+  return Object.keys(env).length ? env : undefined;
 }
 
 const RESOLVED_KEYS = new Set([
@@ -360,6 +455,16 @@ const RESOLVED_KEYS = new Set([
   'kexalgorithms',
   'hostkeyalgorithms',
   'macs',
+  'compression',
+  'identityagent',
+  'passwordauthentication',
+  'kbdinteractiveauthentication',
+  'challengeresponseauthentication',
+  'userknownhostsfile',
+  'globalknownhostsfile',
+  'remotecommand',
+  'requesttty',
+  'stricthostkeychecking',
 ]);
 
 function parseProxyCommand(value: string | undefined): string | undefined {

--- a/server/src/ssh/ssh2-internals.ts
+++ b/server/src/ssh/ssh2-internals.ts
@@ -1,0 +1,13 @@
+// ssh2 does not declare its private protocol modules, but a static import is
+// required here so the Electron build can include this dependency.
+// @ts-expect-error -- no declaration exists for this ssh2 internal module.
+import constants from 'ssh2/lib/protocol/constants.js';
+
+interface Ssh2Constants {
+  SUPPORTED_KEX: string[];
+  SUPPORTED_CIPHER: string[];
+  SUPPORTED_SERVER_HOST_KEY: string[];
+  SUPPORTED_MAC: string[];
+}
+
+export default constants as Ssh2Constants;

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -13,7 +13,42 @@ export interface AppInfo {
   homeDir: string;
   /** Default login shell the server would spawn for local terminals. */
   defaultShell: string;
+  /**
+   * Algorithm names the SSH engine can negotiate, per ssh_config keyword
+   * ("Ciphers", "KexAlgorithms", "HostKeyAlgorithms", "MACs") — the editor
+   * warns about entries the dialer would have to skip.
+   */
+  sshAlgorithms: Record<string, string[]>;
 }
+
+/**
+ * ssh_config keywords the dialer applies even though they have no editor
+ * field of their own (they are edited under Advanced). Everything else in
+ * Advanced is preserved for OpenSSH but never used by Muxus itself.
+ * Lowercased for comparison, per ssh_config's case-insensitive keywords.
+ */
+export const DIAL_TIME_KEYWORDS: ReadonlySet<string> = new Set([
+  'ciphers',
+  'kexalgorithms',
+  'hostkeyalgorithms',
+  'macs',
+  'compression',
+  'connecttimeout',
+  'serveraliveinterval',
+  'serveralivecountmax',
+  'identityagent',
+  'passwordauthentication',
+  'kbdinteractiveauthentication',
+  'challengeresponseauthentication',
+  'preferredauthentications',
+  'userknownhostsfile',
+  'globalknownhostsfile',
+  'setenv',
+  'sendenv',
+  'remotecommand',
+  'requesttty',
+  'stricthostkeychecking',
+]);
 
 export type UpdateCheckResult =
   | {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -259,6 +259,8 @@ export interface HostBlockOptions {
   /** OpenSSH user certificates paired to matching IdentityFile keys. */
   certificateFiles?: string[];
   identitiesOnly?: boolean;
+  /** Per-host authentication agent: socket path, environment indirection, SSH_AUTH_SOCK, or none. */
+  identityAgent?: string;
   forwardAgent?: boolean;
   /** ProxyJump hops in order ("bastion", "user@host:2222"); absent = none. */
   proxyJump?: string[];
@@ -267,6 +269,10 @@ export interface HostBlockOptions {
   forwards?: ConfigForward[];
   /** Skip public keys and go straight to password/keyboard-interactive. */
   passwordOnly?: boolean;
+  /** Command to run after connecting; `none` explicitly restores a login shell. */
+  remoteCommand?: string;
+  requestTty?: 'no' | 'yes' | 'force' | 'auto';
+  strictHostKeyChecking?: 'yes' | 'no' | 'accept-new' | 'ask';
   /** Unmodeled options, order-preserved ("Compression yes", …). */
   extras?: Array<{ keyword: string; value: string }>;
 }

--- a/tests/unit/client/advanced-options.test.ts
+++ b/tests/unit/client/advanced-options.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { DIAL_TIME_KEYWORDS } from '@muxus/shared';
 import {
+  applyLegacyPreset,
   LEGACY_ALGORITHM_PRESET,
+  legacyPresetState,
   unsupportedEntries,
 } from '../../../client/src/components/host-editor/advanced-options.js';
 
@@ -31,5 +33,33 @@ describe('legacy algorithm preset', () => {
       expect(row.value.startsWith('+')).toBe(true);
       expect(DIAL_TIME_KEYWORDS.has(row.keyword.toLowerCase())).toBe(true);
     }
+  });
+
+  it('adds the preset to a host using modern defaults', () => {
+    const extras = [{ keyword: 'Compression', value: 'yes' }];
+    const next = applyLegacyPreset(extras);
+    expect(legacyPresetState(extras)).toBe('missing');
+    expect(legacyPresetState(next)).toBe('enabled');
+    expect(next[0]).toEqual(extras[0]);
+    expect(next.slice(1)).toEqual(LEGACY_ALGORITHM_PRESET);
+  });
+
+  it('completes existing append and exact policies without replacing them', () => {
+    const extras = [
+      { keyword: 'KexAlgorithms', value: '+curve25519-sha256' },
+      { keyword: 'HostKeyAlgorithms', value: 'ssh-ed25519' },
+    ];
+    const next = applyLegacyPreset(extras);
+    expect(legacyPresetState(extras)).toBe('partial');
+    expect(next[0]!.value).toContain('+curve25519-sha256,');
+    expect(next[0]!.value).toContain('diffie-hellman-group14-sha1');
+    expect(next[1]!.value).toBe('ssh-ed25519,ssh-rsa');
+    expect(legacyPresetState(next)).toBe('enabled');
+  });
+
+  it('leaves removal policies untouched for manual review', () => {
+    const extras = [{ keyword: 'Ciphers', value: '-*cbc' }];
+    expect(legacyPresetState(extras)).toBe('conflict');
+    expect(applyLegacyPreset(extras).find((row) => row.keyword === 'Ciphers')).toEqual(extras[0]);
   });
 });

--- a/tests/unit/client/advanced-options.test.ts
+++ b/tests/unit/client/advanced-options.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { DIAL_TIME_KEYWORDS } from '@muxus/shared';
+import {
+  LEGACY_ALGORITHM_PRESET,
+  unsupportedEntries,
+} from '../../../client/src/components/host-editor/advanced-options.js';
+
+const TABLES = {
+  Ciphers: ['aes128-cbc', 'aes256-ctr', 'chacha20-poly1305@openssh.com'],
+  KexAlgorithms: ['curve25519-sha256', 'diffie-hellman-group14-sha1'],
+};
+
+describe('unsupportedEntries', () => {
+  it('flags entries the SSH engine cannot offer, keeping prefix and case out of it', () => {
+    expect(unsupportedEntries('ciphers', '+AES128-CBC,serpent-cbc', TABLES)).toEqual(['serpent-cbc']);
+    expect(unsupportedEntries('KexAlgorithms', 'sntrup761x25519-sha512@openssh.com', TABLES)).toEqual([
+      'sntrup761x25519-sha512@openssh.com',
+    ]);
+  });
+
+  it('skips wildcard patterns, unknown keywords and missing tables', () => {
+    expect(unsupportedEntries('Ciphers', '-*cbc', TABLES)).toEqual([]);
+    expect(unsupportedEntries('Compression', 'yes', TABLES)).toEqual([]);
+    expect(unsupportedEntries('Ciphers', 'serpent-cbc', undefined)).toEqual([]);
+  });
+});
+
+describe('legacy algorithm preset', () => {
+  it('only uses append forms and dial-time keywords', () => {
+    for (const row of LEGACY_ALGORITHM_PRESET) {
+      expect(row.value.startsWith('+')).toBe(true);
+      expect(DIAL_TIME_KEYWORDS.has(row.keyword.toLowerCase())).toBe(true);
+    }
+  });
+});

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -14,7 +14,11 @@ const entry: SshHostEntry = {
     hostname: 'cloud.example.test',
     identityFiles: ['~/.ssh/cloud'],
     certificateFiles: ['~/.ssh/cloud-cert.pub'],
+    identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
     proxyCommand: 'cloudflared access ssh --hostname %h',
+    remoteCommand: 'tmux new -A -s main',
+    requestTty: 'yes',
+    strictHostKeyChecking: 'accept-new',
   },
   resolved: {
     hostname: 'cloud.example.test',
@@ -31,17 +35,27 @@ const entry: SshHostEntry = {
 };
 
 describe('SSH host editor draft', () => {
-  it('loads and saves CertificateFile and ProxyCommand as first-class fields', () => {
+  it('loads and saves modeled connection options as first-class fields', () => {
     const draft = draftFromEntry(entry, false);
     expect(draft.authMode).toBe('key');
     expect(draft.certificateFiles).toEqual(['~/.ssh/cloud-cert.pub']);
+    expect(draft.identityAgentMode).toBe('custom');
+    expect(draft.identityAgent).toBe('${ONEPASSWORD_SSH_AUTH_SOCK}');
     expect(draft.routeMode).toBe('command');
     expect(draft.proxyCommand).toBe('cloudflared access ssh --hostname %h');
+    expect(draft.remoteCommandMode).toBe('command');
+    expect(draft.remoteCommand).toBe('tmux new -A -s main');
+    expect(draft.requestTty).toBe('yes');
+    expect(draft.strictHostKeyChecking).toBe('accept-new');
 
     expect(draftToRequest(draft, 'cloud').options).toMatchObject({
       identityFiles: ['~/.ssh/cloud'],
       certificateFiles: ['~/.ssh/cloud-cert.pub'],
+      identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
       proxyCommand: 'cloudflared access ssh --hostname %h',
+      remoteCommand: 'tmux new -A -s main',
+      requestTty: 'yes',
+      strictHostKeyChecking: 'accept-new',
     });
   });
 
@@ -49,7 +63,23 @@ describe('SSH host editor draft', () => {
     const draft = blankDraft();
     expect(draft.routeMode).toBe('direct');
     expect(draft.certificateFiles).toEqual([]);
+    expect(draft.identityAgentMode).toBe('default');
+    expect(draft.remoteCommandMode).toBe('inherit');
+    expect(draft.requestTty).toBe('inherit');
+    expect(draft.strictHostKeyChecking).toBe('inherit');
     expect(draftToRequest(draft).options.proxyCommand).toBeUndefined();
+  });
+
+  it('round-trips explicit agent and login-shell choices', () => {
+    const draft = blankDraft();
+    draft.identityAgentMode = 'environment';
+    draft.remoteCommandMode = 'shell';
+    draft.requestTty = 'auto';
+    expect(draftToRequest(draft).options).toMatchObject({
+      identityAgent: 'SSH_AUTH_SOCK',
+      remoteCommand: 'none',
+      requestTty: 'auto',
+    });
   });
 
   it('splits a prefilled quick-connect target, and leaves a bare name as the alias', () => {

--- a/tests/unit/server/agent-socket.test.ts
+++ b/tests/unit/server/agent-socket.test.ts
@@ -18,11 +18,13 @@ describe('resolveAgentSocket', () => {
     expect(resolveAgentSocket('/home/user/.1password/agent.sock')).toBe('/home/user/.1password/agent.sock');
   });
 
-  it('dereferences $VAR and the literal SSH_AUTH_SOCK', () => {
+  it('dereferences $VAR, ${VAR}, and the literal SSH_AUTH_SOCK', () => {
     vi.stubEnv('CUSTOM_SOCK', '/tmp/custom.sock');
     vi.stubEnv('SSH_AUTH_SOCK', '/tmp/default.sock');
     expect(resolveAgentSocket('$CUSTOM_SOCK')).toBe('/tmp/custom.sock');
+    expect(resolveAgentSocket('${CUSTOM_SOCK}')).toBe('/tmp/custom.sock');
     expect(resolveAgentSocket('SSH_AUTH_SOCK')).toBe('/tmp/default.sock');
     expect(resolveAgentSocket('$MISSING_VAR')).toBeUndefined();
+    expect(resolveAgentSocket('${MISSING_VAR}')).toBeUndefined();
   });
 });

--- a/tests/unit/server/agent-socket.test.ts
+++ b/tests/unit/server/agent-socket.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveAgentSocket } from '../../../server/src/ssh/key-scan.js';
+
+describe('resolveAgentSocket', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('falls back to the environment default when no IdentityAgent is set', () => {
+    vi.stubEnv('SSH_AUTH_SOCK', '/run/user/1000/ssh-agent.sock');
+    expect(resolveAgentSocket(undefined)).toBe('/run/user/1000/ssh-agent.sock');
+  });
+
+  it('disables the agent for IdentityAgent none', () => {
+    vi.stubEnv('SSH_AUTH_SOCK', '/run/user/1000/ssh-agent.sock');
+    expect(resolveAgentSocket('none')).toBeUndefined();
+  });
+
+  it('uses a configured socket path (1Password-style)', () => {
+    expect(resolveAgentSocket('/home/user/.1password/agent.sock')).toBe('/home/user/.1password/agent.sock');
+  });
+
+  it('dereferences $VAR and the literal SSH_AUTH_SOCK', () => {
+    vi.stubEnv('CUSTOM_SOCK', '/tmp/custom.sock');
+    vi.stubEnv('SSH_AUTH_SOCK', '/tmp/default.sock');
+    expect(resolveAgentSocket('$CUSTOM_SOCK')).toBe('/tmp/custom.sock');
+    expect(resolveAgentSocket('SSH_AUTH_SOCK')).toBe('/tmp/default.sock');
+    expect(resolveAgentSocket('$MISSING_VAR')).toBeUndefined();
+  });
+});

--- a/tests/unit/server/connection-algorithms.test.ts
+++ b/tests/unit/server/connection-algorithms.test.ts
@@ -1,0 +1,150 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import type net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { Server } from 'ssh2';
+import { afterEach, afterAll, describe, expect, it, vi } from 'vitest';
+import type { SshProfile } from '@muxus/shared/ws-protocol';
+import { SshConnectionManager, type ConnectIo } from '../../../server/src/ssh/connection-manager.js';
+import { KnownHostsStore } from '../../../server/src/ssh/known-hosts.js';
+import { loadConfigDocument } from '../../../server/src/ssh/ssh-config.js';
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-algo-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+const PASSWORD = 'secret';
+
+const HOST_KEY = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+}).privateKey;
+
+/**
+ * An sshd stand-in for an old console server: ssh-rsa host key only, and a
+ * handshake restricted to the legacy algorithms modern clients disable by
+ * default (aes128-cbc, diffie-hellman-group14-sha1).
+ */
+function startLegacyServer(): Promise<{ server: Server; port: number }> {
+  const server = new Server(
+    {
+      hostKeys: [HOST_KEY],
+      algorithms: {
+        kex: ['diffie-hellman-group14-sha1'],
+        cipher: ['aes128-cbc'],
+        serverHostKey: ['ssh-rsa'],
+      },
+    },
+    (conn) => {
+      conn.on('error', () => undefined);
+      conn.on('authentication', (authCtx) => {
+        if (authCtx.method === 'password' && authCtx.password === PASSWORD) authCtx.accept();
+        else authCtx.reject(['password']);
+      });
+      conn.on('ready', () => {
+        conn.on('session', (acceptSession) => {
+          const session = acceptSession();
+          session.on('pty', (acceptPty) => acceptPty?.());
+          session.on('exec', (acceptExec) => {
+            const stream = acceptExec();
+            stream.exit(0);
+            stream.end();
+          });
+          session.on('sftp', (_acceptSftp, rejectSftp) => rejectSftp?.());
+          session.on('shell', (acceptShell) => {
+            acceptShell().write('console ready\n');
+          });
+        });
+      });
+    },
+  );
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as net.AddressInfo).port });
+    });
+  });
+}
+
+let counter = 0;
+function makeManager(configFile: string): SshConnectionManager {
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return new SshConnectionManager(log as never, {
+    knownHosts: new KnownHostsStore(
+      path.join(tmp, `known_hosts-${counter++}`),
+      path.join(tmp, 'no-global-known-hosts'),
+    ),
+    loadConfig: () => loadConfigDocument(configFile),
+  });
+}
+
+function makeIo(): ConnectIo {
+  return {
+    status: () => undefined,
+    prompt: (info) => Promise.resolve(info.prompts.map(() => PASSWORD)),
+    hostKey: () => Promise.resolve(true),
+  };
+}
+
+function writeConfig(port: number, algorithmLines: string[]): string {
+  const file = path.join(tmp, `ssh_config-${counter++}`);
+  writeFileSync(
+    file,
+    [
+      'Host console',
+      '  HostName 127.0.0.1',
+      '  User tester',
+      `  Port ${port}`,
+      '  PubkeyAuthentication no',
+      ...algorithmLines,
+      '',
+    ].join('\n'),
+  );
+  return file;
+}
+
+const profile: SshProfile = { kind: 'ssh', target: 'console' };
+
+describe('legacy algorithm negotiation', () => {
+  let manager: SshConnectionManager | undefined;
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    manager?.closeAll();
+    manager = undefined;
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  it('fails against a legacy-only server when the config sets no algorithms', async () => {
+    const started = await startLegacyServer();
+    server = started.server;
+    manager = makeManager(writeConfig(started.port, []));
+
+    await expect(manager.connect(profile, makeIo())).rejects.toThrow(
+      /no matching key exchange algorithm.*KexAlgorithms/s,
+    );
+  }, 15_000);
+
+  it('connects once the config lists the legacy algorithms', async () => {
+    const started = await startLegacyServer();
+    server = started.server;
+    manager = makeManager(
+      writeConfig(started.port, [
+        '  Ciphers aes128-cbc',
+        '  KexAlgorithms +diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1',
+        '  HostKeyAlgorithms +ssh-rsa',
+      ]),
+    );
+
+    const shell = await manager.connectShell(profile, makeIo(), 80, 24, 'xterm-256color');
+    const banner = await new Promise<string>((resolve) => {
+      shell.stream.once('data', (chunk: Buffer) => resolve(chunk.toString()));
+    });
+    expect(banner).toContain('console ready');
+    shell.stream.close();
+    shell.lease.release();
+  }, 15_000);
+});

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -1,0 +1,183 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import type net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { Server } from 'ssh2';
+import { afterEach, afterAll, describe, expect, it, vi } from 'vitest';
+import type { SshProfile } from '@muxus/shared/ws-protocol';
+import { SshConnectionManager, type ConnectIo } from '../../../server/src/ssh/connection-manager.js';
+import { KnownHostsStore } from '../../../server/src/ssh/known-hosts.js';
+import { loadConfigDocument } from '../../../server/src/ssh/ssh-config.js';
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-session-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+const PASSWORD = 'secret';
+
+const HOST_KEY = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+}).privateKey;
+
+interface SessionCapture {
+  env: Record<string, string>;
+  exec?: string;
+  ptyRequested: boolean;
+  shellRequested: boolean;
+  authMethods: string[];
+}
+
+/** sshd stand-in that records what the client requested on its session. */
+function startCapturingServer(): Promise<{ server: Server; port: number; capture: SessionCapture }> {
+  const capture: SessionCapture = { env: {}, ptyRequested: false, shellRequested: false, authMethods: [] };
+  const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
+    conn.on('error', () => undefined);
+    conn.on('authentication', (authCtx) => {
+      if (authCtx.method !== 'none') capture.authMethods.push(authCtx.method);
+      if (authCtx.method === 'password' && authCtx.password === PASSWORD) authCtx.accept();
+      else authCtx.reject(['password']);
+    });
+    conn.on('ready', () => {
+      conn.on('session', (acceptSession) => {
+        const session = acceptSession();
+        session.on('env', (accept, _reject, info) => {
+          capture.env[info.key] = info.val;
+          accept?.();
+        });
+        session.on('pty', (acceptPty) => {
+          capture.ptyRequested = true;
+          acceptPty?.();
+        });
+        session.on('exec', (acceptExec, _rejectExec, info) => {
+          capture.exec = info.command;
+          const stream = acceptExec();
+          stream.write('exec ok\n');
+        });
+        session.on('sftp', (_acceptSftp, rejectSftp) => rejectSftp?.());
+        session.on('shell', (acceptShell) => {
+          capture.shellRequested = true;
+          acceptShell().write('shell ok\n');
+        });
+      });
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as net.AddressInfo).port, capture });
+    });
+  });
+}
+
+let counter = 0;
+function makeManager(configFile: string): SshConnectionManager {
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return new SshConnectionManager(log as never, {
+    knownHosts: new KnownHostsStore(
+      path.join(tmp, `known_hosts-${counter++}`),
+      path.join(tmp, 'no-global-known-hosts'),
+    ),
+    loadConfig: () => loadConfigDocument(configFile),
+  });
+}
+
+function makeIo(overrides: Partial<ConnectIo> = {}): ConnectIo & { passwordPrompts: number } {
+  const io = {
+    passwordPrompts: 0,
+    status: () => undefined,
+    prompt: (info: { prompts: Array<{ prompt: string }> }) => {
+      io.passwordPrompts += info.prompts.length;
+      return Promise.resolve(info.prompts.map(() => PASSWORD));
+    },
+    hostKey: () => Promise.resolve(true),
+    ...overrides,
+  };
+  return io;
+}
+
+function writeConfig(port: number, lines: string[]): string {
+  const file = path.join(tmp, `ssh_config-${counter++}`);
+  writeFileSync(
+    file,
+    ['Host lab', '  HostName 127.0.0.1', '  User tester', `  Port ${port}`, '  PubkeyAuthentication no', ...lines, ''].join('\n'),
+  );
+  return file;
+}
+
+const profile: SshProfile = { kind: 'ssh', target: 'lab' };
+
+async function firstData(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve) => stream.once('data', (chunk: Buffer) => resolve(chunk.toString())));
+}
+
+describe('session settings from ssh config', () => {
+  let manager: SshConnectionManager | undefined;
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    manager?.closeAll();
+    manager = undefined;
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  it('sends SetEnv/SendEnv variables and runs RemoteCommand without a tty by default', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    manager = makeManager(
+      writeConfig(started.port, ['  SetEnv MUXUS_TEST=from-config', '  RemoteCommand tmux new -A -s main']),
+    );
+
+    const shell = await manager.connectShell(profile, makeIo(), 80, 24, 'xterm-256color');
+    expect(await firstData(shell.stream)).toContain('exec ok');
+    expect(started.capture.exec).toBe('tmux new -A -s main');
+    expect(started.capture.ptyRequested).toBe(false); // RequestTTY auto + command ⇒ no tty, like ssh(1)
+    expect(started.capture.shellRequested).toBe(false);
+    expect(started.capture.env).toMatchObject({ MUXUS_TEST: 'from-config' });
+    shell.stream.close();
+    shell.lease.release();
+  }, 15_000);
+
+  it('RequestTTY yes allocates a tty for a RemoteCommand', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    manager = makeManager(writeConfig(started.port, ['  RemoteCommand tmux attach', '  RequestTTY yes']));
+
+    const shell = await manager.connectShell(profile, makeIo(), 80, 24, 'xterm-256color');
+    expect(await firstData(shell.stream)).toContain('exec ok');
+    expect(started.capture.ptyRequested).toBe(true);
+    shell.stream.close();
+    shell.lease.release();
+  }, 15_000);
+
+  it('StrictHostKeyChecking accept-new records into UserKnownHostsFile without prompting', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    const hostsFile = path.join(tmp, `custom_known_hosts-${counter++}`);
+    manager = makeManager(
+      writeConfig(started.port, ['  StrictHostKeyChecking accept-new', `  UserKnownHostsFile ${hostsFile}`]),
+    );
+
+    const io = makeIo({ hostKey: () => Promise.reject(new Error('must not prompt')) });
+    const shell = await manager.connectShell(profile, io, 80, 24, 'xterm-256color');
+    expect(await firstData(shell.stream)).toContain('shell ok');
+    expect(existsSync(hostsFile)).toBe(true);
+    expect(readFileSync(hostsFile, 'utf8')).toContain(`[127.0.0.1]:${started.port}`);
+    shell.stream.close();
+    shell.lease.release();
+  }, 15_000);
+
+  it('PasswordAuthentication no never prompts for or offers a password', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    manager = makeManager(writeConfig(started.port, ['  PasswordAuthentication no']));
+
+    const io = makeIo();
+    await expect(manager.connect(profile, io)).rejects.toThrow(/authentication/);
+    expect(io.passwordPrompts).toBe(0);
+    expect(started.capture.authMethods).not.toContain('password');
+  }, 15_000);
+});

--- a/tests/unit/server/known-hosts.test.ts
+++ b/tests/unit/server/known-hosts.test.ts
@@ -38,6 +38,26 @@ describe('KnownHostsStore', () => {
     expect(store.verify('example.com', 22, key)).toEqual({ state: 'ok' });
   });
 
+  it('reads every configured user file but records into the first', () => {
+    const primary = freshFile();
+    const extra = freshFile();
+    const key = makeKey();
+    writeFileSync(extra, `readonly.example ${hostKeyType(key)} ${key.toString('base64')}\n`);
+    const store = new KnownHostsStore([primary, extra], missing);
+    expect(store.verify('readonly.example', 22, key)).toEqual({ state: 'ok' });
+    store.record('new.example', 22, key);
+    expect(readFileSync(primary, 'utf8')).toContain('new.example');
+    expect(readFileSync(extra, 'utf8')).not.toContain('new.example');
+  });
+
+  it('UserKnownHostsFile none: nothing matches and record is a no-op', () => {
+    const store = new KnownHostsStore([], missing);
+    const key = makeKey();
+    expect(store.verify('example.com', 22, key)).toEqual({ state: 'unknown' });
+    expect(() => store.record('example.com', 22, key)).not.toThrow();
+    expect(store.verify('example.com', 22, key)).toEqual({ state: 'unknown' });
+  });
+
   it('stores non-22 ports in [host]:port notation', () => {
     const file = freshFile();
     const store = new KnownHostsStore(file, missing);

--- a/tests/unit/server/ssh-algorithms.test.ts
+++ b/tests/unit/server/ssh-algorithms.test.ts
@@ -58,6 +58,14 @@ describe('connectionAlgorithms', () => {
     expect(() => connectionAlgorithms({ ciphers: 'chacha8-poly1305' })).toThrow(/Ciphers/);
   });
 
+  it('maps Compression yes/no to a compress preference and leaves unset alone', () => {
+    expect(connectionAlgorithms({ compression: true }).algorithms).toEqual({
+      compress: ['zlib@openssh.com', 'zlib', 'none'],
+    });
+    expect(connectionAlgorithms({ compression: false }).algorithms).toEqual({ compress: ['none'] });
+    expect(connectionAlgorithms({}).algorithms).toBeUndefined();
+  });
+
   it('handles the legacy console-server recipe end to end', () => {
     const { algorithms, notes } = connectionAlgorithms({
       ciphers: 'aes128-cbc',

--- a/tests/unit/server/ssh-algorithms.test.ts
+++ b/tests/unit/server/ssh-algorithms.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { connectionAlgorithms } from '../../../server/src/ssh/algorithms.js';
+
+describe('connectionAlgorithms', () => {
+  it('returns no override when the config sets nothing', () => {
+    expect(connectionAlgorithms({})).toEqual({ algorithms: undefined, notes: [] });
+  });
+
+  it('maps a bare list to an exact ssh2 list, order preserved', () => {
+    const { algorithms, notes } = connectionAlgorithms({ ciphers: 'aes128-cbc,aes256-ctr' });
+    expect(algorithms).toEqual({ cipher: ['aes128-cbc', 'aes256-ctr'] });
+    expect(notes).toEqual([]);
+  });
+
+  it('maps +/^/- prefixes to append/prepend/remove on the defaults', () => {
+    const { algorithms } = connectionAlgorithms({
+      kexAlgorithms: '+diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1',
+      hostKeyAlgorithms: '^ssh-ed25519',
+      macs: '-hmac-md5',
+    });
+    expect(algorithms).toEqual({
+      kex: { append: ['diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1'] },
+      serverHostKey: { prepend: ['ssh-ed25519'] },
+      hmac: { remove: ['hmac-md5'] },
+    });
+  });
+
+  it('expands wildcard patterns against the supported table', () => {
+    const { algorithms } = connectionAlgorithms({ ciphers: '-*cbc' });
+    expect(algorithms).toEqual({
+      cipher: { remove: ['aes256-cbc', 'aes192-cbc', 'aes128-cbc', '3des-cbc'] },
+    });
+  });
+
+  it('drops entries ssh2 does not implement and reports them', () => {
+    const { algorithms, notes } = connectionAlgorithms({
+      kexAlgorithms: '+sntrup761x25519-sha512@openssh.com,diffie-hellman-group14-sha1',
+    });
+    expect(algorithms).toEqual({ kex: { append: ['diffie-hellman-group14-sha1'] } });
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain('KexAlgorithms');
+    expect(notes[0]).toContain('sntrup761x25519-sha512@openssh.com');
+  });
+
+  it('omits the category when nothing supported remains to append', () => {
+    const { algorithms, notes } = connectionAlgorithms({ kexAlgorithms: '+mlkem768x25519-sha256' });
+    expect(algorithms).toBeUndefined();
+    expect(notes).toHaveLength(1);
+  });
+
+  it('silently ignores removals of algorithms ssh2 never offers', () => {
+    const { algorithms, notes } = connectionAlgorithms({ macs: '-umac-64@openssh.com' });
+    expect(algorithms).toBeUndefined();
+    expect(notes).toEqual([]);
+  });
+
+  it('rejects an exact list with no supported entries', () => {
+    expect(() => connectionAlgorithms({ ciphers: 'chacha8-poly1305' })).toThrow(/Ciphers/);
+  });
+
+  it('handles the legacy console-server recipe end to end', () => {
+    const { algorithms, notes } = connectionAlgorithms({
+      ciphers: 'aes128-cbc',
+      kexAlgorithms: '+diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1',
+      hostKeyAlgorithms: '+ssh-rsa',
+    });
+    expect(algorithms).toEqual({
+      cipher: ['aes128-cbc'],
+      kex: { append: ['diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1'] },
+      serverHostKey: { append: ['ssh-rsa'] },
+    });
+    expect(notes).toEqual([]);
+  });
+});

--- a/tests/unit/server/ssh-config-edit.test.ts
+++ b/tests/unit/server/ssh-config-edit.test.ts
@@ -97,8 +97,12 @@ describe('upsertHost', () => {
         '  ProxyJump bastion',
         '  IdentityFile ~/.ssh/app',
         '  CertificateFile ~/.ssh/app-cert.pub',
+        '  IdentityAgent ${ONEPASSWORD_SSH_AUTH_SOCK}',
         '  ProxyCommand custom-proxy %h %p',
         '  LocalForward 8080 localhost:80',
+        '  StrictHostKeyChecking accept-new',
+        '  RemoteCommand tmux new -A -s main',
+        '  RequestTTY yes',
         '  Compression yes',
         '',
       ].join('\n'),
@@ -174,20 +178,28 @@ describe('previewHost', () => {
     expect(existsSync(`${root}.muxus.tmp`)).toBe(false);
   });
 
-  it('renders CertificateFile and ProxyCommand from modeled options', () => {
+  it('renders modeled authentication, security, and startup options', () => {
     const root = seed('');
     const text = previewHost(
       req({
         options: {
           identityFiles: ['~/.ssh/app'],
           certificateFiles: ['~/.ssh/app-cert.pub'],
+          identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
           proxyCommand: 'cloudflared access ssh --hostname %h',
+          strictHostKeyChecking: 'accept-new',
+          remoteCommand: 'tmux new -A -s main',
+          requestTty: 'yes',
         },
       }),
       root,
     );
     expect(text).toContain('  IdentityFile ~/.ssh/app');
     expect(text).toContain('  CertificateFile ~/.ssh/app-cert.pub');
+    expect(text).toContain('  IdentityAgent ${ONEPASSWORD_SSH_AUTH_SOCK}');
     expect(text).toContain('  ProxyCommand cloudflared access ssh --hostname %h');
+    expect(text).toContain('  StrictHostKeyChecking accept-new');
+    expect(text).toContain('  RemoteCommand tmux new -A -s main');
+    expect(text).toContain('  RequestTTY yes');
   });
 });

--- a/tests/unit/server/ssh-config.test.ts
+++ b/tests/unit/server/ssh-config.test.ts
@@ -101,6 +101,25 @@ describe('listHosts', () => {
     expect(hosts[0]!.options.extras).toBeUndefined();
   });
 
+  it('models agent, host verification, and startup behavior as first-class options', () => {
+    const hosts = hostsOf(
+      [
+        'Host console',
+        '  IdentityAgent ${ONEPASSWORD_SSH_AUTH_SOCK}',
+        '  StrictHostKeyChecking accept-new',
+        '  RemoteCommand tmux new -A -s main',
+        '  RequestTTY yes',
+      ].join('\n'),
+    );
+    expect(hosts[0]!.options).toMatchObject({
+      identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
+      strictHostKeyChecking: 'accept-new',
+      remoteCommand: 'tmux new -A -s main',
+      requestTty: 'yes',
+    });
+    expect(hosts[0]!.options.extras).toBeUndefined();
+  });
+
   it('maps PubkeyAuthentication no to passwordOnly', () => {
     const hosts = hostsOf(['Host legacy', '  PubkeyAuthentication no', '  PreferredAuthentications keyboard-interactive,password'].join('\n'));
     expect(hosts[0]!.options.passwordOnly).toBe(true);

--- a/tests/unit/server/ssh-config.test.ts
+++ b/tests/unit/server/ssh-config.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -229,11 +230,24 @@ describe('resolveHost', () => {
 
   it('keeps IdentityAgent indirections verbatim and maps `none` known_hosts to []', () => {
     const doc = loadConfigDocument(
-      write(['Host a', '  IdentityAgent $CUSTOM_SOCK', '  UserKnownHostsFile none', '', 'Host b', '  IdentityAgent none'].join('\n')),
+      write(
+        [
+          'Host a',
+          '  IdentityAgent $CUSTOM_SOCK',
+          '  UserKnownHostsFile none',
+          '',
+          'Host b',
+          '  IdentityAgent ${CUSTOM_SOCK}',
+          '',
+          'Host c',
+          '  IdentityAgent none',
+        ].join('\n'),
+      ),
     );
     expect(resolveHost(doc, 'a').identityAgent).toBe('$CUSTOM_SOCK');
     expect(resolveHost(doc, 'a').userKnownHostsFiles).toEqual([]);
-    expect(resolveHost(doc, 'b').identityAgent).toBe('none');
+    expect(resolveHost(doc, 'b').identityAgent).toBe('${CUSTOM_SOCK}');
+    expect(resolveHost(doc, 'c').identityAgent).toBe('none');
   });
 
   it('leaves unset flags undefined and rejects invalid choice values', () => {
@@ -249,6 +263,26 @@ describe('resolveHost', () => {
   it('honors the legacy ChallengeResponseAuthentication spelling', () => {
     const doc = loadConfigDocument(write(['Host old', '  ChallengeResponseAuthentication no'].join('\n')));
     expect(resolveHost(doc, 'old').kbdInteractiveAuthentication).toBe(false);
+  });
+
+  it('preserves first-obtained wins across keyboard-interactive auth aliases', () => {
+    const doc = loadConfigDocument(
+      write(
+        [
+          'Host legacy-first',
+          '  ChallengeResponseAuthentication no',
+          '',
+          'Host modern-first',
+          '  KbdInteractiveAuthentication no',
+          '',
+          'Host *',
+          '  KbdInteractiveAuthentication yes',
+          '  ChallengeResponseAuthentication yes',
+        ].join('\n'),
+      ),
+    );
+    expect(resolveHost(doc, 'legacy-first').kbdInteractiveAuthentication).toBe(false);
+    expect(resolveHost(doc, 'modern-first').kbdInteractiveAuthentication).toBe(false);
   });
 
   it('accumulates SetEnv first-wins per variable and SendEnv patterns in order', () => {
@@ -268,6 +302,64 @@ describe('resolveHost', () => {
     const r = resolveHost(doc, 'env');
     expect(r.setEnv).toEqual({ FOO: 'bar', BAZ: 'qux', EXTRA: 'yes' });
     expect(r.sendEnv).toEqual(['LANG', 'LC_*', '-LC_ALL', 'EDITOR']);
+  });
+
+  it('preserves quoted spaces in SetEnv assignments', () => {
+    const doc = loadConfigDocument(
+      write(['Host env', '  SetEnv GREETING="hello world" EMPTY="" PLAIN=value'].join('\n')),
+    );
+    expect(resolveHost(doc, 'env').setEnv).toEqual({
+      GREETING: 'hello world',
+      EMPTY: '',
+      PLAIN: 'value',
+    });
+  });
+
+  it('treats RemoteCommand none as disabled', () => {
+    const doc = loadConfigDocument(write(['Host shell', '  RemoteCommand NoNe'].join('\n')));
+    expect(resolveHost(doc, 'shell').remoteCommand).toBeUndefined();
+  });
+
+  it('expands the full UserKnownHostsFile token context', () => {
+    const local = os.userInfo();
+    const localHostname = os.hostname();
+    const connectionHash = createHash('sha1')
+      .update(`${localHostname}server.example.com2200remotejump`)
+      .digest('hex');
+    const doc = loadConfigDocument(
+      write(
+        [
+          'Host alias',
+          '  HostName server.example.com',
+          '  Port 2200',
+          '  User remote',
+          '  ProxyJump jump',
+          '  UserKnownHostsFile ~/.ssh/known_hosts-%C-%d-%h-%i-%j-%k-%L-%l-%n-%p-%r-%u-%%',
+        ].join('\n'),
+      ),
+    );
+    expect(resolveHost(doc, 'alias').userKnownHostsFiles).toEqual([
+      path.join(
+        os.homedir(),
+        '.ssh',
+        [
+          'known_hosts',
+          connectionHash,
+          os.homedir(),
+          'server.example.com',
+          String(local.uid),
+          'jump',
+          'alias',
+          localHostname.split('.')[0],
+          localHostname,
+          'alias',
+          '2200',
+          'remote',
+          local.username,
+          '%',
+        ].join('-'),
+      ),
+    ]);
   });
 
   it('reads ServerAliveCountMax and the raw algorithm lists', () => {

--- a/tests/unit/server/ssh-config.test.ts
+++ b/tests/unit/server/ssh-config.test.ts
@@ -195,6 +195,27 @@ describe('resolveHost', () => {
     expect(r.serverAliveInterval).toBe(30);
   });
 
+  it('reads ServerAliveCountMax and the raw algorithm lists', () => {
+    const doc = loadConfigDocument(
+      write(
+        [
+          'Host console',
+          '  ServerAliveCountMax 5',
+          '  Ciphers aes128-cbc',
+          '  KexAlgorithms +diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1',
+          '  HostKeyAlgorithms +ssh-rsa',
+          '  MACs hmac-sha1',
+        ].join('\n'),
+      ),
+    );
+    const r = resolveHost(doc, 'console');
+    expect(r.serverAliveCountMax).toBe(5);
+    expect(r.ciphers).toBe('aes128-cbc');
+    expect(r.kexAlgorithms).toBe('+diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1');
+    expect(r.hostKeyAlgorithms).toBe('+ssh-rsa');
+    expect(r.macs).toBe('hmac-sha1');
+  });
+
   it('follows Include files with evaluation order intact', () => {
     const inc = write(['Host from-include', '  User inc'].join('\n'), 'conf.d/extra');
     const doc = loadConfigDocument(write([`Include ${inc}`, '', 'Host base', '  User base'].join('\n')));

--- a/tests/unit/server/ssh-config.test.ts
+++ b/tests/unit/server/ssh-config.test.ts
@@ -9,6 +9,7 @@ import {
   parseHostSpec,
   parseProxyJumpList,
   resolveHost,
+  sessionEnvironment,
 } from '../../../server/src/ssh/ssh-config.js';
 
 const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-sshconf-'));
@@ -195,6 +196,80 @@ describe('resolveHost', () => {
     expect(r.serverAliveInterval).toBe(30);
   });
 
+  it('resolves the dial-time tunables Muxus applies from Advanced options', () => {
+    const doc = loadConfigDocument(
+      write(
+        [
+          'Host lab',
+          '  Compression yes',
+          '  IdentityAgent ~/.1password/agent.sock',
+          '  PasswordAuthentication no',
+          '  KbdInteractiveAuthentication no',
+          '  RemoteCommand tmux new -A -s main',
+          '  RequestTTY yes',
+          '  StrictHostKeyChecking accept-new',
+          '  UserKnownHostsFile ~/.ssh/lab_hosts ~/.ssh/extra_hosts',
+        ].join('\n'),
+      ),
+    );
+    const r = resolveHost(doc, 'lab');
+    expect(r.compression).toBe(true);
+    expect(r.identityAgent).toBe(path.join(os.homedir(), '.1password', 'agent.sock'));
+    expect(r.passwordAuthentication).toBe(false);
+    expect(r.kbdInteractiveAuthentication).toBe(false);
+    expect(r.remoteCommand).toBe('tmux new -A -s main');
+    expect(r.requestTty).toBe('yes');
+    expect(r.strictHostKeyChecking).toBe('accept-new');
+    expect(r.userKnownHostsFiles).toEqual([
+      path.join(os.homedir(), '.ssh', 'lab_hosts'),
+      path.join(os.homedir(), '.ssh', 'extra_hosts'),
+    ]);
+    expect(r.globalKnownHostsFiles).toBeUndefined();
+  });
+
+  it('keeps IdentityAgent indirections verbatim and maps `none` known_hosts to []', () => {
+    const doc = loadConfigDocument(
+      write(['Host a', '  IdentityAgent $CUSTOM_SOCK', '  UserKnownHostsFile none', '', 'Host b', '  IdentityAgent none'].join('\n')),
+    );
+    expect(resolveHost(doc, 'a').identityAgent).toBe('$CUSTOM_SOCK');
+    expect(resolveHost(doc, 'a').userKnownHostsFiles).toEqual([]);
+    expect(resolveHost(doc, 'b').identityAgent).toBe('none');
+  });
+
+  it('leaves unset flags undefined and rejects invalid choice values', () => {
+    const doc = loadConfigDocument(write(['Host plain', '  RequestTTY sometimes', '  StrictHostKeyChecking maybe'].join('\n')));
+    const r = resolveHost(doc, 'plain');
+    expect(r.compression).toBeUndefined();
+    expect(r.passwordAuthentication).toBeUndefined();
+    expect(r.kbdInteractiveAuthentication).toBeUndefined();
+    expect(r.requestTty).toBeUndefined();
+    expect(r.strictHostKeyChecking).toBeUndefined();
+  });
+
+  it('honors the legacy ChallengeResponseAuthentication spelling', () => {
+    const doc = loadConfigDocument(write(['Host old', '  ChallengeResponseAuthentication no'].join('\n')));
+    expect(resolveHost(doc, 'old').kbdInteractiveAuthentication).toBe(false);
+  });
+
+  it('accumulates SetEnv first-wins per variable and SendEnv patterns in order', () => {
+    const doc = loadConfigDocument(
+      write(
+        [
+          'Host env',
+          '  SetEnv FOO=bar BAZ=qux',
+          '  SendEnv LANG LC_*',
+          '',
+          'Host *',
+          '  SetEnv FOO=global EXTRA=yes',
+          '  SendEnv -LC_ALL EDITOR',
+        ].join('\n'),
+      ),
+    );
+    const r = resolveHost(doc, 'env');
+    expect(r.setEnv).toEqual({ FOO: 'bar', BAZ: 'qux', EXTRA: 'yes' });
+    expect(r.sendEnv).toEqual(['LANG', 'LC_*', '-LC_ALL', 'EDITOR']);
+  });
+
   it('reads ServerAliveCountMax and the raw algorithm lists', () => {
     const doc = loadConfigDocument(
       write(
@@ -227,6 +302,21 @@ describe('resolveHost', () => {
     const doc = loadConfigDocument(write([`Include ${path.join(tmp, 'nope', 'missing')}`, 'Host still-here'].join('\n')));
     expect(doc.error).toMatch(/could not read/);
     expect(listHosts(doc).map((h) => h.alias)).toEqual(['still-here']);
+  });
+});
+
+describe('sessionEnvironment', () => {
+  it('sends variables matched by SendEnv, honoring later removals', () => {
+    const env = sessionEnvironment(
+      { setEnv: {}, sendEnv: ['LANG', 'LC_*', '-LC_ALL'] },
+      { LANG: 'en_US.UTF-8', LC_ALL: 'C', LC_TIME: 'de_DE', PATH: '/bin' },
+    );
+    expect(env).toEqual({ LANG: 'en_US.UTF-8', LC_TIME: 'de_DE' });
+  });
+
+  it('lets SetEnv override sent variables and returns undefined when empty', () => {
+    expect(sessionEnvironment({ setEnv: { FOO: 'bar' }, sendEnv: ['FOO'] }, { FOO: 'host' })).toEqual({ FOO: 'bar' });
+    expect(sessionEnvironment({ setEnv: {}, sendEnv: [] }, { FOO: 'x' })).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

Reported from the lab: a Lantronix console server needing legacy algorithms could not be reached through Muxus even though the exact same `~/.ssh/config` block works with plain `ssh`:

```
Host console-S1L1-H4
  ...
  Ciphers aes128-cbc
  KexAlgorithms +diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1
  HostKeyAlgorithms +ssh-rsa
```

The connection failed with `Handshake failed: no matching key exchange algorithm`. Root cause: these keywords were parsed into the editor's Advanced extras and written back to the config, but never reached the dialer — ssh2 negotiated with its modern-only defaults. The same "parsed but not honored" gap applied to a whole family of options.

## What the dialer honors now

| Keyword | Behavior |
| --- | --- |
| `Ciphers`, `KexAlgorithms`, `HostKeyAlgorithms`, `MACs` | Translated to the ssh2 `algorithms` option, including the `+`/`^`/`-` list syntax and `*` patterns. Entries the engine does not implement are skipped with a notice, so a config shared with OpenSSH keeps working |
| `Compression` | `yes` prefers zlib like `ssh -C` |
| `ServerAliveCountMax` | Was hardcoded to 3 |
| `IdentityAgent` | `none`, `$VAR`, `SSH_AUTH_SOCK`, or a path (1Password/Secretive agents), for auth and agent forwarding |
| `PasswordAuthentication no`, `KbdInteractiveAuthentication no` | Removes that rung from the auth ladder (legacy `ChallengeResponseAuthentication` spelling included) |
| `UserKnownHostsFile`, `GlobalKnownHostsFile` | Verification reads all listed files, records into the first user file, `none` disables |
| `StrictHostKeyChecking` | `accept-new`/`no` accept first contact silently, `yes` refuses unknown or changed keys |
| `SetEnv`, `SendEnv` | Full semantics: accumulation, `-pattern` removals, SetEnv overrides |
| `RemoteCommand`, `RequestTTY` | exec instead of login shell with `ssh(1)` tty rules (`auto` ⇒ tty only for plain shells) |

`RemoteCommand`, `RequestTTY` and the environment resolve **per connect call**, so two aliases multiplexed onto one shared transport each keep their own command and environment — the same semantics ControlMaster gives each `ssh` invocation.

Deliberate deviation, documented: a **changed** host key always prompts, even under `StrictHostKeyChecking no` — OpenSSH's silently-degraded continue-mode is not reproduced.

## Editor UX

- Every Advanced row is badged: **applied** (the dialer uses this keyword) or **kept** (preserved for OpenSSH, unused by Muxus) — the silent-failure mode behind the original report is gone.
- Algorithm values are validated while typing against the engine's real tables (served via `GET /api/app/info`); unsupported entries flag the field with the names that would be skipped.
- A one-click **Legacy device algorithms** button adds the append-form `KexAlgorithms`/`HostKeyAlgorithms`/`Ciphers` lines old console servers and network appliances need.
- A failed handshake now names the config keywords to set instead of only the raw ssh2 error.

## Notes

- The ssh2 algorithm tables are read through a static import (`ssh2-internals.ts`) so esbuild inlines them into the Electron bundle.
- Docs: `docs/reference/ssh-config.md` states the full dial-time contract.

## Testing

- Unit tests for resolution, translation (`+`/`^`/`-`, patterns, unsupported filtering), agent socket resolution, known-hosts file lists, and session environment assembly.
- End-to-end tests against in-process sshds: a legacy-only server (aes128-cbc / dh-group14-sha1 / ssh-rsa) fails without the config options and connects with them; RemoteCommand/RequestTTY/SetEnv capture what the server actually received; accept-new records into a custom known_hosts without prompting; `PasswordAuthentication no` never prompts or offers a password.
- Full suite: 72 files / 531 tests, typecheck, lint, and the Electron bundle all pass.