### PR TITLE
Exclude restore dividers from scrollback snapshots

### DIFF
--- a/client/src/terminal/scrollback-snapshots.ts
+++ b/client/src/terminal/scrollback-snapshots.ts
@@ -13,11 +13,15 @@ export const TERMINAL_SNAPSHOT_INTERVAL_MS = 10_000;
  *  command does not lose it to the interval above. */
 export const TERMINAL_SNAPSHOT_QUIET_MS = 1_500;
 
+const TERMINAL_HISTORY_DIVIDER_TEXT = '[end of restored output]';
+
 /** Written after replayed history, before the new session's output. */
-export const TERMINAL_HISTORY_DIVIDER = '\r\n\x1b[90m[end of restored output]\x1b[0m\r\n';
+export const TERMINAL_HISTORY_DIVIDER =
+  `\r\n\x1b[90m${TERMINAL_HISTORY_DIVIDER_TEXT}\x1b[0m\r\n`;
 
 const ESC = String.fromCharCode(27);
 const CURSOR_MOVE_FINALS = 'ABCDEFGHdf`';
+const CSI_SEQUENCE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g');
 
 /** Start index of a cursor-move sequence (ESC [ params final) ending exactly
  *  at `end`, or `end` itself when none does. A plain scan — regexes over
@@ -49,6 +53,22 @@ export function trimReplayTail(data: string): string {
   }
 }
 
+/**
+ * Remove the visual replay boundary before a terminal buffer becomes the next
+ * snapshot. Otherwise every restore serializes the client-injected divider
+ * and accumulates another copy on the following restore.
+ *
+ * SerializeAddon emits logical row breaks as CRLF and may choose different
+ * SGR sequences as surrounding cell attributes change, so compare visible row
+ * text instead of relying on the exact bytes used when the divider was drawn.
+ */
+export function stripTerminalHistoryDividers(data: string): string {
+  return data
+    .split('\r\n')
+    .filter((row) => row.replace(CSI_SEQUENCE, '') !== TERMINAL_HISTORY_DIVIDER_TEXT)
+    .join('\r\n');
+}
+
 export function snapshotRequestBody(data: string): string {
   return JSON.stringify({ data });
 }
@@ -72,7 +92,9 @@ export function serializeScrollback(
   try {
     for (const scrollback of SNAPSHOT_SCROLLBACK_LADDER) {
       const data = trimReplayTail(
-        addon.serialize({ scrollback, excludeModes: true, excludeAltBuffer: true }),
+        stripTerminalHistoryDividers(
+          addon.serialize({ scrollback, excludeModes: true, excludeAltBuffer: true }),
+        ),
       );
       if (data.length === 0) return undefined;
       if (data.length > TERMINAL_SNAPSHOT_MAX_CHARS) continue;
@@ -92,7 +114,7 @@ export async function fetchTerminalSnapshot(tabId: string): Promise<string | nul
     const { snapshot } = await apiFetch<{ snapshot: TerminalSnapshotRecord | null }>(
       `/api/terminal-snapshots/${encodeURIComponent(tabId)}`,
     );
-    return snapshot?.data ?? null;
+    return snapshot ? stripTerminalHistoryDividers(snapshot.data) : null;
   } catch {
     return null;
   }

--- a/client/src/terminal/scrollback-snapshots.ts
+++ b/client/src/terminal/scrollback-snapshots.ts
@@ -1,5 +1,9 @@
 import type { SerializeAddon } from '@xterm/addon-serialize';
-import { TERMINAL_SNAPSHOT_MAX_CHARS, type TerminalSnapshotRecord } from '@muxus/shared';
+import {
+  TERMINAL_SNAPSHOT_FORMAT_VERSION,
+  TERMINAL_SNAPSHOT_MAX_CHARS,
+  type TerminalSnapshotRecord,
+} from '@muxus/shared';
 import { apiFetch, authToken } from '../api/http.js';
 import { requestBodyBytes } from '../unload-keepalive.js';
 
@@ -14,14 +18,23 @@ export const TERMINAL_SNAPSHOT_INTERVAL_MS = 10_000;
 export const TERMINAL_SNAPSHOT_QUIET_MS = 1_500;
 
 const TERMINAL_HISTORY_DIVIDER_TEXT = '[end of restored output]';
+// Zero-width characters survive xterm serialization without changing the
+// divider's appearance. They give client-injected rows provenance that genuine
+// terminal output containing the same visible text does not have.
+const TERMINAL_HISTORY_DIVIDER_MARKER = '\u2063\u2060\u200b\u2063';
+const MARKED_TERMINAL_HISTORY_DIVIDER_TEXT =
+  `[${TERMINAL_HISTORY_DIVIDER_MARKER}end of restored output]`;
 
 /** Written after replayed history, before the new session's output. */
 export const TERMINAL_HISTORY_DIVIDER =
-  `\r\n\x1b[90m${TERMINAL_HISTORY_DIVIDER_TEXT}\x1b[0m\r\n`;
+  `\r\n\x1b[90m${MARKED_TERMINAL_HISTORY_DIVIDER_TEXT}\x1b[0m\r\n`;
 
 const ESC = String.fromCharCode(27);
 const CURSOR_MOVE_FINALS = 'ABCDEFGHdf`';
 const CSI_SEQUENCE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g');
+const LEGACY_DIVIDER_COLOR = new RegExp(
+  `${ESC}\\[(?:[0-9:;]*;)?(?:90|38[;:]5[;:]8)(?:;[0-9:;]*)?m`,
+);
 
 /** Start index of a cursor-move sequence (ESC [ params final) ending exactly
  *  at `end`, or `end` itself when none does. A plain scan — regexes over
@@ -58,19 +71,29 @@ export function trimReplayTail(data: string): string {
  * snapshot. Otherwise every restore serializes the client-injected divider
  * and accumulates another copy on the following restore.
  *
- * SerializeAddon emits logical row breaks as CRLF and may choose different
- * SGR sequences as surrounding cell attributes change, so compare visible row
- * text instead of relying on the exact bytes used when the divider was drawn.
+ * New dividers carry an invisible marker, so a remote process can safely emit
+ * the same visible text. Previously saved dividers have no provenance; migrate
+ * only rows that also use the dark-gray color written by older clients.
  */
-export function stripTerminalHistoryDividers(data: string): string {
+export function stripTerminalHistoryDividers(
+  data: string,
+  options: { includeLegacy?: boolean } = {},
+): string {
   return data
     .split('\r\n')
-    .filter((row) => row.replace(CSI_SEQUENCE, '') !== TERMINAL_HISTORY_DIVIDER_TEXT)
+    .filter((row) => {
+      const visible = row.replace(CSI_SEQUENCE, '');
+      if (visible === MARKED_TERMINAL_HISTORY_DIVIDER_TEXT) return false;
+      if (!options.includeLegacy || visible !== TERMINAL_HISTORY_DIVIDER_TEXT) return true;
+
+      const textStart = row.indexOf(TERMINAL_HISTORY_DIVIDER_TEXT);
+      return !LEGACY_DIVIDER_COLOR.test(row.slice(0, textStart));
+    })
     .join('\r\n');
 }
 
 export function snapshotRequestBody(data: string): string {
-  return JSON.stringify({ data });
+  return JSON.stringify({ data, formatVersion: TERMINAL_SNAPSHOT_FORMAT_VERSION });
 }
 
 /** Wire size of a snapshot. JSON escapes every ESC to six characters, so the
@@ -114,7 +137,11 @@ export async function fetchTerminalSnapshot(tabId: string): Promise<string | nul
     const { snapshot } = await apiFetch<{ snapshot: TerminalSnapshotRecord | null }>(
       `/api/terminal-snapshots/${encodeURIComponent(tabId)}`,
     );
-    return snapshot ? stripTerminalHistoryDividers(snapshot.data) : null;
+    if (!snapshot) return null;
+    return stripTerminalHistoryDividers(snapshot.data, {
+      includeLegacy:
+        (snapshot.formatVersion ?? 1) < TERMINAL_SNAPSHOT_FORMAT_VERSION,
+    });
   } catch {
     return null;
   }

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -270,6 +270,15 @@ const MIGRATIONS = [
       );
     `,
   },
+  {
+    version: 11,
+    name: 'version-terminal-scrollback-snapshots',
+    sql: `
+      ALTER TABLE terminal_snapshots
+        ADD COLUMN format_version INTEGER NOT NULL DEFAULT 1
+        CHECK(format_version >= 1);
+    `,
+  },
 ] as const;
 
 const DEFAULT_SESSION_LOGGING_POLICY: SessionLoggingPolicyInput = {
@@ -328,6 +337,7 @@ export type WorkspaceSummary = Omit<WorkspaceRecord, 'layout' | 'multiExecGroups
 export interface TerminalSnapshotRecord {
   tabId: string;
   data: string;
+  formatVersion: number;
   updatedAt: string;
 }
 
@@ -860,27 +870,31 @@ export class MuxusDatabase {
     return this.db.prepare('DELETE FROM workspaces WHERE id = ?').run(id).changes > 0;
   }
 
-  saveTerminalSnapshot(tabId: string, data: string): void {
+  saveTerminalSnapshot(tabId: string, data: string, formatVersion = 1): void {
     requireNonEmpty(tabId, 'tabId');
     this.db
       .prepare(`
-        INSERT INTO terminal_snapshots(tab_id, data, updated_at)
-        VALUES (?, ?, CURRENT_TIMESTAMP)
+        INSERT INTO terminal_snapshots(tab_id, data, format_version, updated_at)
+        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
         ON CONFLICT(tab_id) DO UPDATE SET
           data = excluded.data,
+          format_version = excluded.format_version,
           updated_at = CURRENT_TIMESTAMP
       `)
-      .run(tabId, data);
+      .run(tabId, data, formatVersion);
   }
 
   terminalSnapshot(tabId: string): TerminalSnapshotRecord | undefined {
     const row = this.db
-      .prepare('SELECT tab_id, data, updated_at FROM terminal_snapshots WHERE tab_id = ?')
+      .prepare(
+        'SELECT tab_id, data, format_version, updated_at FROM terminal_snapshots WHERE tab_id = ?',
+      )
       .get(tabId);
     if (!row) return undefined;
     return {
       tabId: String(row.tab_id),
       data: String(row.data),
+      formatVersion: Number(row.format_version),
       updatedAt: String(row.updated_at),
     };
   }

--- a/server/src/routes/terminal-snapshots.ts
+++ b/server/src/routes/terminal-snapshots.ts
@@ -1,11 +1,15 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
-import { TERMINAL_SNAPSHOT_MAX_CHARS, type TerminalSnapshotRecord } from '@muxus/shared';
+import {
+  TERMINAL_SNAPSHOT_MAX_CHARS,
+  type TerminalSnapshotRecord,
+} from '@muxus/shared';
 import type { AppContext } from '../app.js';
 import { HttpProblem, sendError } from '../util/errors.js';
 
 const snapshotSaveSchema = z.object({
   data: z.string().min(1).max(TERMINAL_SNAPSHOT_MAX_CHARS),
+  formatVersion: z.number().int().positive().optional(),
 });
 
 // Serialized scrollback rides in a JSON string, where every ESC byte inflates
@@ -30,7 +34,11 @@ export function registerTerminalSnapshotRoutes(app: FastifyInstance, ctx: AppCon
       if (!parsed.success) {
         return sendError(reply, new HttpProblem(400, 'invalid terminal snapshot'));
       }
-      ctx.database.saveTerminalSnapshot(tabId, parsed.data.data);
+      ctx.database.saveTerminalSnapshot(
+        tabId,
+        parsed.data.data,
+        parsed.data.formatVersion,
+      );
       return { saved: true };
     },
   );

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -436,11 +436,14 @@ export interface TerminalSnapshotRecord {
   tabId: string;
   /** Serialized terminal buffer, replayable by writing it back to a terminal. */
   data: string;
+  /** Encoding version used to distinguish legacy unmarked UI dividers. */
+  formatVersion: number;
   updatedAt: string;
 }
 
 /** Upper bound for one tab's serialized scrollback, enforced on both sides. */
 export const TERMINAL_SNAPSHOT_MAX_CHARS = 512_000;
+export const TERMINAL_SNAPSHOT_FORMAT_VERSION = 2;
 
 export interface SshConfigResponse {
   /** Root config path (~/.ssh/config). */

--- a/tests/unit/client/scrollback-snapshots.test.ts
+++ b/tests/unit/client/scrollback-snapshots.test.ts
@@ -3,6 +3,7 @@ import {
   serializeScrollback,
   snapshotBodyBytes,
   SNAPSHOT_SCROLLBACK_LADDER,
+  stripTerminalHistoryDividers,
   TERMINAL_HISTORY_DIVIDER,
   trimReplayTail,
 } from '../../../client/src/terminal/scrollback-snapshots.js';
@@ -17,6 +18,12 @@ function fakeAddon(charsPerLine: number, options: { escapes?: boolean } = {}): A
   return {
     serialize: ({ scrollback = 0 }: { scrollback?: number } = {}) =>
       unit.repeat(scrollback * charsPerLine),
+  } as unknown as Addon;
+}
+
+function literalAddon(data: string): Addon {
+  return {
+    serialize: () => data,
   } as unknown as Addon;
 }
 
@@ -65,6 +72,33 @@ describe('history divider', () => {
     expect(TERMINAL_HISTORY_DIVIDER).toContain('[end of restored output]');
     expect(TERMINAL_HISTORY_DIVIDER.startsWith('\r\n')).toBe(true);
     expect(TERMINAL_HISTORY_DIVIDER.endsWith('\r\n')).toBe(true);
+  });
+
+  it('does not retain injected dividers in the next snapshot', () => {
+    const nested =
+      `first restore${TERMINAL_HISTORY_DIVIDER}` +
+      `second restore${TERMINAL_HISTORY_DIVIDER}` +
+      'live output';
+
+    expect(stripTerminalHistoryDividers(nested)).toBe(
+      'first restore\r\nsecond restore\r\nlive output',
+    );
+    expect(serializeScrollback(literalAddon(nested))).toBe(
+      'first restore\r\nsecond restore\r\nlive output',
+    );
+  });
+
+  it('recognizes serialized divider rows independent of their SGR encoding', () => {
+    const serialized =
+      'before\r\n\x1b[38;5;8m[end of restored output]\x1b[39m\r\nafter';
+
+    expect(stripTerminalHistoryDividers(serialized)).toBe('before\r\nafter');
+  });
+
+  it('keeps terminal output that merely mentions the divider text', () => {
+    const output = 'echo [end of restored output]\r\n[end of restored output] from remote';
+
+    expect(stripTerminalHistoryDividers(output)).toBe(output);
   });
 });
 

--- a/tests/unit/client/scrollback-snapshots.test.ts
+++ b/tests/unit/client/scrollback-snapshots.test.ts
@@ -69,7 +69,9 @@ describe('replay tail trimming', () => {
 
 describe('history divider', () => {
   it('is a dim single line between restored and live output', () => {
-    expect(TERMINAL_HISTORY_DIVIDER).toContain('[end of restored output]');
+    expect(TERMINAL_HISTORY_DIVIDER.replace(/[\u200b\u2060\u2063]/g, '')).toContain(
+      '[end of restored output]',
+    );
     expect(TERMINAL_HISTORY_DIVIDER.startsWith('\r\n')).toBe(true);
     expect(TERMINAL_HISTORY_DIVIDER.endsWith('\r\n')).toBe(true);
   });
@@ -89,24 +91,46 @@ describe('history divider', () => {
   });
 
   it('recognizes serialized divider rows independent of their SGR encoding', () => {
-    const serialized =
-      'before\r\n\x1b[38;5;8m[end of restored output]\x1b[39m\r\nafter';
+    const serializedDivider = TERMINAL_HISTORY_DIVIDER
+      .replace('\x1b[90m', '\x1b[38;5;8m')
+      .replace('\x1b[0m', '\x1b[39m');
+    const serialized = `before${serializedDivider}after`;
 
     expect(stripTerminalHistoryDividers(serialized)).toBe('before\r\nafter');
   });
 
-  it('keeps terminal output that merely mentions the divider text', () => {
-    const output = 'echo [end of restored output]\r\n[end of restored output] from remote';
+  it('keeps genuine terminal output equal to the divider text', () => {
+    const output =
+      'echo "[end of restored output]"\r\n' +
+      '[end of restored output]\r\n' +
+      '\x1b[90m[end of restored output]\r\n' +
+      '[end of restored output] from remote';
 
     expect(stripTerminalHistoryDividers(output)).toBe(output);
+  });
+
+  it('only migrates unmarked dividers with the legacy client styling', () => {
+    const stored =
+      'before\r\n' +
+      '\x1b[90m[end of restored output]\r\n' +
+      '\x1b[38;5;8m[end of restored output]\x1b[39m\r\n' +
+      'after';
+
+    expect(stripTerminalHistoryDividers(stored, { includeLegacy: true })).toBe(
+      'before\r\nafter',
+    );
   });
 });
 
 describe('snapshot size budgeting', () => {
   it('measures the JSON body, not the buffer — escapes inflate ESC sixfold', () => {
-    expect(snapshotBodyBytes('ab')).toBe('{"data":"ab"}'.length);
+    expect(snapshotBodyBytes('ab')).toBe(
+      '{"data":"ab","formatVersion":2}'.length,
+    );
     // One ESC becomes the six characters \u001b in the JSON body.
-    expect(snapshotBodyBytes('\u001b')).toBe('{"data":""}'.length + 6);
+    expect(snapshotBodyBytes('\u001b')).toBe(
+      '{"data":"","formatVersion":2}'.length + 6,
+    );
   });
 
   it('serializes at the deepest scrollback that fits the wire budget', () => {

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -22,6 +22,7 @@ describe('MuxusDatabase migrations', () => {
       { version: 8, name: 'named-workspace-session-sets' },
       { version: 9, name: 'drop-favorites' },
       { version: 10, name: 'terminal-scrollback-snapshots' },
+      { version: 11, name: 'version-terminal-scrollback-snapshots' },
     ]);
   });
 });
@@ -47,9 +48,14 @@ describe('terminal scrollback snapshots', () => {
   it('stores and replaces one snapshot per tab', () => {
     database = new MuxusDatabase(':memory:');
     database.saveTerminalSnapshot('tab-1', 'first');
-    database.saveTerminalSnapshot('tab-1', 'second');
+    expect(database.terminalSnapshot('tab-1')).toMatchObject({ formatVersion: 1 });
 
-    expect(database.terminalSnapshot('tab-1')).toMatchObject({ tabId: 'tab-1', data: 'second' });
+    database.saveTerminalSnapshot('tab-1', 'second', 2);
+    expect(database.terminalSnapshot('tab-1')).toMatchObject({
+      tabId: 'tab-1',
+      data: 'second',
+      formatVersion: 2,
+    });
     expect(database.terminalSnapshot('tab-2')).toBeUndefined();
   });
 

--- a/tests/unit/server/terminal-snapshot-routes.test.ts
+++ b/tests/unit/server/terminal-snapshot-routes.test.ts
@@ -31,7 +31,10 @@ describe('terminal snapshot routes', () => {
       method: 'PUT',
       url: '/api/terminal-snapshots/tab-1',
       headers: auth(),
-      payload: { data: 'deploy@web-01:~$ uptime\r\n 09:15 up 42 days' },
+      payload: {
+        data: 'deploy@web-01:~$ uptime\r\n 09:15 up 42 days',
+        formatVersion: 2,
+      },
     });
     expect(put.statusCode).toBe(200);
     expect(put.json()).toEqual({ saved: true });
@@ -45,6 +48,7 @@ describe('terminal snapshot routes', () => {
     expect(get.json().snapshot).toMatchObject({
       tabId: 'tab-1',
       data: 'deploy@web-01:~$ uptime\r\n 09:15 up 42 days',
+      formatVersion: 2,
     });
   });
 


### PR DESCRIPTION
## Summary

- Strip the UI-only restore divider before saving terminal scrollback snapshots.
- Sanitize previously saved snapshots when they are loaded.
- Preserve genuine terminal output that only mentions the divider text.

## Root cause

The divider was written into the terminal buffer after replaying a snapshot. The next scrollback serialization stored that divider as ordinary terminal content, so each subsequent restore accumulated another copy.

## Impact

Restored terminals now show a single boundary between restored and live output. Copies already present in stored snapshots are removed when those snapshots are replayed.

## Validation

- `pnpm --filter @muxus/tests test` — 543 tests passed
- `pnpm lint`
- `pnpm typecheck`