### PR TITLE
Add MobaXterm session import

### DIFF
--- a/client/src/components/DataTransferSection.tsx
+++ b/client/src/components/DataTransferSection.tsx
@@ -30,6 +30,7 @@ import CloudDoneOutlinedIcon from '@mui/icons-material/CloudDoneOutlined';
 import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
+import LaptopWindowsOutlinedIcon from '@mui/icons-material/LaptopWindowsOutlined';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined';
@@ -61,7 +62,11 @@ interface PendingFile {
   filename: string;
 }
 
-export function DataTransferSection() {
+export function DataTransferSection({
+  onImportMobaXterm,
+}: {
+  onImportMobaXterm: () => void;
+}) {
   const queryClient = useQueryClient();
   const { data: appInfo } = useAppInfo();
   const { data: summary, isLoading: summaryLoading } = useQuery({
@@ -385,6 +390,32 @@ export function DataTransferSection() {
             embedded. Key file paths are retained so profiles still know where
             to look.
           </Typography>
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined">
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          sx={{ alignItems: { sm: 'center' }, p: 2.25 }}
+        >
+          <IconTile icon={LaptopWindowsOutlinedIcon} tone="primary" />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+              MobaXterm import
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+              Review and import SSH sessions from a local Windows installation
+              or a MobaXterm session file.
+            </Typography>
+          </Box>
+          <Button
+            variant="outlined"
+            startIcon={<LaptopWindowsOutlinedIcon />}
+            onClick={onImportMobaXterm}
+          >
+            Import sessions
+          </Button>
         </Stack>
       </Paper>
 

--- a/client/src/components/MobaXtermImportDialog.tsx
+++ b/client/src/components/MobaXtermImportDialog.tsx
@@ -69,7 +69,7 @@ export function MobaXtermImportDialog({
     typeof window.muxusDesktop.readMobaXtermSessions === 'function';
 
   const existingAliases = useMemo(
-    () => new Set(sshConfig?.hosts.map((host) => host.alias) ?? []),
+    () => new Set(sshConfig?.hosts.flatMap((host) => host.aliases) ?? []),
     [sshConfig?.hosts],
   );
   const conflictingSessions = useMemo(

--- a/client/src/components/MobaXtermImportDialog.tsx
+++ b/client/src/components/MobaXtermImportDialog.tsx
@@ -1,0 +1,491 @@
+import { useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import ArrowBackOutlinedIcon from '@mui/icons-material/ArrowBackOutlined';
+import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import LaptopWindowsOutlinedIcon from '@mui/icons-material/LaptopWindowsOutlined';
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined';
+import { useSshConfig } from '../api/queries.js';
+import {
+  restoreImportedConnections,
+  type TransferConflictStrategy,
+} from '../data-transfer.js';
+import {
+  MAX_MOBAXTERM_IMPORT_BYTES,
+  mobaXtermConnections,
+  parseMobaXtermSessions,
+  type MobaXtermParseResult,
+  type MobaXtermSession,
+} from '../mobaxterm-import.js';
+import { errorDetails, showToast } from '../state/toast.js';
+
+interface PendingImport {
+  source: string;
+  parsed: MobaXtermParseResult;
+}
+
+export function MobaXtermImportDialog({
+  onClose,
+}: {
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { data: sshConfig } = useSshConfig();
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [pending, setPending] = useState<PendingImport | null>(null);
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [conflicts, setConflicts] =
+    useState<TransferConflictStrategy>('keep');
+  const [search, setSearch] = useState('');
+  const [busy, setBusy] = useState<'detect' | 'file' | 'import' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const canAutoDetect =
+    window.muxusDesktop?.platform === 'win32' &&
+    typeof window.muxusDesktop.readMobaXtermSessions === 'function';
+
+  const existingAliases = useMemo(
+    () => new Set(sshConfig?.hosts.map((host) => host.alias) ?? []),
+    [sshConfig?.hosts],
+  );
+  const conflictingSessions = useMemo(
+    () =>
+      pending?.parsed.sessions.filter((session) =>
+        existingAliases.has(session.alias),
+      ) ?? [],
+    [existingAliases, pending?.parsed.sessions],
+  );
+  const filteredSessions = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!pending || !needle) return pending?.parsed.sessions ?? [];
+    return pending.parsed.sessions.filter((session) =>
+      [
+        session.name,
+        session.alias,
+        session.host,
+        session.username,
+        session.folder,
+      ].some((value) => value?.toLowerCase().includes(needle)),
+    );
+  }, [pending, search]);
+
+  const review = (content: string, source: string) => {
+    const parsed = parseMobaXtermSessions(content);
+    setPending({ source, parsed });
+    setSelected(new Set(parsed.sessions.map((session) => session.id)));
+    setSearch('');
+    setError(null);
+  };
+
+  const detectLocal = async () => {
+    const desktop = window.muxusDesktop;
+    if (!desktop?.readMobaXtermSessions) return;
+    setBusy('detect');
+    setError(null);
+    try {
+      const source = await desktop.readMobaXtermSessions();
+      if (source) review(source.content, source.source);
+    } catch (detectError) {
+      setError(messageFrom(detectError, 'Could not read local MobaXterm sessions.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const readFile = async (file: File) => {
+    if (file.size > MAX_MOBAXTERM_IMPORT_BYTES) {
+      setError('That MobaXterm file is larger than 10 MB.');
+      return;
+    }
+    setBusy('file');
+    setError(null);
+    try {
+      review(await file.text(), file.name);
+    } catch (fileError) {
+      setError(messageFrom(fileError, 'Could not read that MobaXterm file.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const toggleSession = (session: MobaXtermSession) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(session.id)) next.delete(session.id);
+      else next.add(session.id);
+      return next;
+    });
+  };
+
+  const importSessions = async () => {
+    if (!pending) return;
+    const included = pending.parsed.sessions.filter((session) =>
+      selected.has(session.id),
+    );
+    if (included.length === 0) return;
+    setBusy('import');
+    setError(null);
+    try {
+      const result = await restoreImportedConnections(
+        mobaXtermConnections(included),
+        conflicts,
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['ssh-config'] }),
+        queryClient.invalidateQueries({ queryKey: ['data-transfer-summary'] }),
+      ]);
+      const summary = [
+        result.added ? `${result.added} added` : '',
+        result.updated ? `${result.updated} replaced` : '',
+        result.skipped ? `${result.skipped} kept` : '',
+      ]
+        .filter(Boolean)
+        .join(' · ');
+      showToast('success', `MobaXterm import complete${summary ? ` — ${summary}` : ''}.`);
+      onClose();
+    } catch (importError) {
+      setError(messageFrom(importError, 'The MobaXterm sessions could not be imported.'));
+      showToast(
+        'error',
+        messageFrom(importError, 'The MobaXterm sessions could not be imported.'),
+        errorDetails(importError),
+      );
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const selectedCount = selected.size;
+  const close = busy ? undefined : onClose;
+
+  return (
+    <Dialog open onClose={close} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center' }}>
+          {pending ? (
+            <Button
+              size="small"
+              startIcon={<ArrowBackOutlinedIcon />}
+              onClick={() => {
+                setPending(null);
+                setError(null);
+              }}
+              disabled={busy !== null}
+            >
+              Back
+            </Button>
+          ) : (
+            <LaptopWindowsOutlinedIcon color="primary" />
+          )}
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              Import from MobaXterm
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {pending
+                ? `${pending.parsed.sessions.length} SSH sessions from ${pending.source}`
+                : 'Bring your saved SSH sessions and folders into Muxus.'}
+            </Typography>
+          </Box>
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {pending ? (
+          <Stack spacing={2}>
+            <Alert severity="info">
+              Passwords and private key files are not copied. Muxus will use your
+              SSH agent or ask for credentials when you connect.
+            </Alert>
+            {pending.parsed.ignoredCount > 0 ? (
+              <Alert severity="warning">
+                {pending.parsed.ignoredCount} unsupported or incomplete{' '}
+                {pending.parsed.ignoredCount === 1 ? 'bookmark was' : 'bookmarks were'} skipped.
+              </Alert>
+            ) : null}
+
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <TextField
+                size="small"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Filter sessions"
+                sx={{ flex: 1 }}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <SearchOutlinedIcon
+                        sx={{ mr: 1, fontSize: 19, color: 'text.secondary' }}
+                      />
+                    ),
+                  },
+                }}
+              />
+              <Button
+                size="small"
+                onClick={() =>
+                  setSelected(
+                    selected.size === pending.parsed.sessions.length
+                      ? new Set()
+                      : new Set(pending.parsed.sessions.map((session) => session.id)),
+                  )
+                }
+              >
+                {selected.size === pending.parsed.sessions.length
+                  ? 'Clear selection'
+                  : 'Select all'}
+              </Button>
+            </Stack>
+
+            <Paper variant="outlined" sx={{ maxHeight: 330, overflowY: 'auto' }}>
+              <List disablePadding>
+                {filteredSessions.map((session, index) => (
+                  <Box key={session.id}>
+                    {index > 0 ? <Divider /> : null}
+                    <ListItem
+                      secondaryAction={
+                        existingAliases.has(session.alias) ? (
+                          <Chip size="small" color="warning" label="Already exists" />
+                        ) : null
+                      }
+                      sx={{
+                        pr: existingAliases.has(session.alias) ? 16 : 2,
+                        contentVisibility: 'auto',
+                        containIntrinsicSize: '56px',
+                      }}
+                    >
+                      <ListItemIcon sx={{ minWidth: 38 }}>
+                        <Checkbox
+                          edge="start"
+                          checked={selected.has(session.id)}
+                          onChange={() => toggleSession(session)}
+                          slotProps={{
+                            input: { 'aria-label': `Import ${session.name}` },
+                          }}
+                        />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={
+                          <Stack
+                            component="span"
+                            direction="row"
+                            spacing={1}
+                            sx={{ alignItems: 'center' }}
+                          >
+                            <Typography component="span" variant="body2" sx={{ fontWeight: 650 }}>
+                              {session.name}
+                            </Typography>
+                            {session.folder ? (
+                              <Chip
+                                size="small"
+                                variant="outlined"
+                                icon={<FolderOutlinedIcon />}
+                                label={session.folder}
+                              />
+                            ) : null}
+                          </Stack>
+                        }
+                        secondary={`${session.username ? `${session.username}@` : ''}${session.host}:${session.port} · ${session.authMode === 'password' ? 'password prompt' : 'SSH key / agent'}`}
+                      />
+                    </ListItem>
+                  </Box>
+                ))}
+              </List>
+              {filteredSessions.length === 0 ? (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ p: 3, textAlign: 'center' }}
+                >
+                  No sessions match that filter.
+                </Typography>
+              ) : null}
+            </Paper>
+
+            {conflictingSessions.length > 0 ? (
+              <FormControl>
+                <FormLabel>When a Muxus host already uses the same alias</FormLabel>
+                <RadioGroup
+                  row
+                  value={conflicts}
+                  onChange={(event) =>
+                    setConflicts(event.target.value as TransferConflictStrategy)
+                  }
+                >
+                  <FormControlLabel
+                    value="keep"
+                    control={<Radio />}
+                    label={`Keep existing (${conflictingSessions.length})`}
+                  />
+                  <FormControlLabel
+                    value="replace"
+                    control={<Radio />}
+                    label="Replace existing"
+                  />
+                </RadioGroup>
+              </FormControl>
+            ) : null}
+          </Stack>
+        ) : (
+          <Stack spacing={2}>
+            <Typography variant="body2" color="text.secondary">
+              On Windows, Muxus can find bookmark data from the installed or
+              portable edition. You can also choose an exported file on any
+              platform.
+            </Typography>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: canAutoDetect ? 'repeat(2, minmax(0, 1fr))' : '1fr',
+                gap: 1.5,
+              }}
+            >
+              {canAutoDetect ? (
+                <SourceCard
+                  icon={<LaptopWindowsOutlinedIcon color="primary" />}
+                  title="Local MobaXterm"
+                  description="Read SSH bookmark names, hosts and folders from this Windows account."
+                  action={
+                    <Button
+                      variant="contained"
+                      disabled={busy !== null}
+                      startIcon={
+                        busy === 'detect' ? (
+                          <CircularProgress size={15} color="inherit" />
+                        ) : (
+                          <SearchOutlinedIcon />
+                        )
+                      }
+                      onClick={() => void detectLocal()}
+                    >
+                      {busy === 'detect' ? 'Looking…' : 'Find sessions'}
+                    </Button>
+                  }
+                />
+              ) : null}
+              <SourceCard
+                icon={<UploadFileOutlinedIcon color="secondary" />}
+                title="MobaXterm file"
+                description="Choose MobaXterm.ini, .mxtsessions, .mobaconf or a text export."
+                action={
+                  <Button
+                    variant="outlined"
+                    disabled={busy !== null}
+                    startIcon={
+                      busy === 'file' ? (
+                        <CircularProgress size={15} color="inherit" />
+                      ) : (
+                        <UploadFileOutlinedIcon />
+                      )
+                    }
+                    onClick={() => fileInput.current?.click()}
+                  >
+                    Choose file
+                  </Button>
+                }
+              />
+            </Box>
+            <input
+              ref={fileInput}
+              hidden
+              type="file"
+              accept=".ini,.mxtsessions,.mobaconf,.txt,text/plain"
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (file) void readFile(file);
+                event.target.value = '';
+              }}
+            />
+            <Alert severity="info">
+              Muxus only reads connection metadata. It never imports MobaXterm
+              passwords or writes secrets into your SSH config.
+            </Alert>
+          </Stack>
+        )}
+
+        {error ? (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        ) : null}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={close} disabled={busy !== null}>
+          Cancel
+        </Button>
+        {pending ? (
+          <Button
+            variant="contained"
+            startIcon={
+              busy === 'import' ? (
+                <CircularProgress size={15} color="inherit" />
+              ) : (
+                <DnsOutlinedIcon />
+              )
+            }
+            disabled={busy !== null || selectedCount === 0}
+            onClick={() => void importSessions()}
+          >
+            {busy === 'import'
+              ? 'Importing…'
+              : `Import ${selectedCount} ${selectedCount === 1 ? 'session' : 'sessions'}`}
+          </Button>
+        ) : null}
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+function SourceCard({
+  icon,
+  title,
+  description,
+  action,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  action: React.ReactNode;
+}) {
+  return (
+    <Paper variant="outlined" sx={{ p: 2, display: 'flex', flexDirection: 'column', minHeight: 180 }}>
+      {icon}
+      <Typography variant="subtitle1" sx={{ mt: 1.5, fontWeight: 700 }}>
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 2, flex: 1 }}>
+        {description}
+      </Typography>
+      <Box>{action}</Box>
+    </Paper>
+  );
+}
+
+function messageFrom(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -68,6 +68,7 @@ import { chordSx } from './chord-style.js';
 import { KeywordHighlightRulesEditor } from './KeywordHighlightRulesEditor.js';
 import { SessionLoggingPolicyFields } from './SessionLoggingPolicyFields.js';
 import { DataTransferSection } from './DataTransferSection.js';
+import { MobaXtermImportDialog } from './MobaXtermImportDialog.js';
 
 type Section =
   | 'appearance'
@@ -121,6 +122,7 @@ export function SettingsDialog() {
   const setOpen = useUiStore((s) => s.setSettingsOpen);
   const [section, setSection] = useState<Section>('appearance');
   const [loggingDirty, setLoggingDirty] = useState(false);
+  const [mobaXtermImportOpen, setMobaXtermImportOpen] = useState(false);
 
   /** Nothing leaves the logging section behind without the user's say-so. */
   const leaveSection = (run: () => void) => {
@@ -140,6 +142,10 @@ export function SettingsDialog() {
       run();
     });
   };
+
+  if (mobaXtermImportOpen) {
+    return <MobaXtermImportDialog onClose={() => setMobaXtermImportOpen(false)} />;
+  }
 
   return (
     <Dialog
@@ -182,7 +188,11 @@ export function SettingsDialog() {
             {section === 'highlighting' && <HighlightingSection />}
             {section === 'behavior' && <BehaviorSection />}
             {section === 'keyboard' && <KeyboardSection />}
-            {section === 'data' && <DataTransferSection />}
+            {section === 'data' && (
+              <DataTransferSection
+                onImportMobaXterm={() => setMobaXtermImportOpen(true)}
+              />
+            )}
             {section === 'about' && <AboutSection />}
           </Box>
           <DialogActions sx={{ borderTop: 1, borderColor: 'divider' }}>

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -335,6 +335,16 @@ export async function restoreTransferDocument(
   return result;
 }
 
+/** Restore a reviewed third-party connection set through the same conflict-safe path as backups. */
+export async function restoreImportedConnections(
+  data: PortableConnections,
+  conflicts: TransferConflictStrategy,
+): Promise<RestoreResult> {
+  const result: RestoreResult = { added: 0, updated: 0, skipped: 0 };
+  await restoreConnections(data, conflicts, result);
+  return result;
+}
+
 function fetchBaseSnapshot(): Promise<BaseSnapshot> {
   return Promise.all([
     apiFetch<SshConfigResponse>('/api/ssh/config'),

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -458,9 +458,10 @@ async function restoreConnections(
     apiFetch<SshConfigResponse>('/api/ssh/config'),
     apiFetch<SavedHostProfilesResponse>('/api/profiles'),
   ]);
-  const sshByAlias = new Map(
-    sshConfig.hosts.map((host) => [host.alias, host]),
-  );
+  const sshByAlias = new Map<string, SshHostEntry>();
+  for (const host of sshConfig.hosts) {
+    for (const alias of host.aliases) sshByAlias.set(alias, host);
+  }
   const savedIds = new Set(savedResponse.profiles.map((profile) => profile.id));
 
   // OpenSSH config edits intentionally stay sequential: every request

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -1,4 +1,9 @@
-import type { AppInfo, AppWindowLaunch, UpdateCheckResult } from '@muxus/shared';
+import type {
+  AppInfo,
+  AppWindowLaunch,
+  MobaXtermSessionSource,
+  UpdateCheckResult,
+} from '@muxus/shared';
 
 declare global {
   /** Bridge exposed by the Electron preload (absent in regular browsers). */
@@ -22,6 +27,8 @@ declare global {
       checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult>;
       /** Choose an SSH private key with the operating system's file picker. */
       selectPrivateKey(): Promise<string | undefined>;
+      /** Read bookmark-only sessions from the current Windows user's MobaXterm install. */
+      readMobaXtermSessions(): Promise<MobaXtermSessionSource | undefined>;
       /** Open a secondary native application window. */
       openWindow(launch: AppWindowLaunch): void;
       /** Subscribe to the OS close-window chord (Cmd/Ctrl+W); returns unsubscribe. */

--- a/client/src/mobaxterm-import.ts
+++ b/client/src/mobaxterm-import.ts
@@ -1,0 +1,169 @@
+import type { HostBlockOptions } from '@muxus/shared';
+import type {
+  PortableConnections,
+  PortableHostMetadata,
+  PortableSshHost,
+} from './data-transfer.js';
+
+const MOBAXTERM_SSH_SESSION_TYPE = 109;
+const BOOKMARK_SECTION_RE = /^Bookmarks(?:_\d+)?$/i;
+const SESSION_TYPE_RE = /^#(\d+)#/;
+const INVALID_ALIAS_CHARS_RE = /[\s#*?!]+/g;
+
+export const MAX_MOBAXTERM_IMPORT_BYTES = 10 * 1024 * 1024;
+
+export interface MobaXtermSession {
+  /** Stable inside one parsed file and used by review selection controls. */
+  id: string;
+  name: string;
+  alias: string;
+  host: string;
+  port: number;
+  username?: string;
+  folder?: string;
+  authMode: 'key' | 'password';
+}
+
+export interface MobaXtermParseResult {
+  sessions: MobaXtermSession[];
+  /** Recognizable bookmark entries that were unsupported or incomplete. */
+  ignoredCount: number;
+}
+
+/**
+ * Parse SSH bookmarks from MobaXterm.ini or an .mxtsessions export.
+ *
+ * Session values use `#TYPE#flags%host%port%username%auth%...`; SSH is type
+ * 109. This intentionally reads bookmark structure only—no P/C secret stores.
+ */
+export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
+  if (new TextEncoder().encode(text).byteLength > MAX_MOBAXTERM_IMPORT_BYTES) {
+    throw new Error('That MobaXterm file is larger than 10 MB.');
+  }
+
+  const sessions: MobaXtermSession[] = [];
+  const aliases = new Set<string>();
+  let inBookmarks = false;
+  let currentFolder: string | undefined;
+  let ignoredCount = 0;
+
+  for (const [lineIndex, rawLine] of text.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith(';')) continue;
+
+    const section = /^\[([^\]]+)\]$/.exec(line);
+    if (section) {
+      inBookmarks = BOOKMARK_SECTION_RE.test(section[1]?.trim() ?? '');
+      currentFolder = undefined;
+      continue;
+    }
+    if (!inBookmarks) continue;
+
+    const separator = line.indexOf('=');
+    if (separator < 0) continue;
+    const name = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+
+    if (name.toLowerCase() === 'subrep') {
+      currentFolder = normalizeFolder(value);
+      continue;
+    }
+
+    const typeMatch = SESSION_TYPE_RE.exec(value);
+    if (!typeMatch) continue;
+    const type = Number.parseInt(typeMatch[1] ?? '', 10);
+    if (type !== MOBAXTERM_SSH_SESSION_TYPE) {
+      ignoredCount++;
+      continue;
+    }
+
+    const fields = value.slice(typeMatch[0].length).split('%');
+    const host = fields[1]?.trim();
+    if (!name || !host) {
+      ignoredCount++;
+      continue;
+    }
+    const parsedPort = Number.parseInt(fields[2]?.trim() ?? '', 10);
+    const port = parsedPort >= 1 && parsedPort <= 65_535 ? parsedPort : 22;
+    const username = fields[3]?.trim() || undefined;
+    const authMode = fields[4]?.trim() === '3' ? 'key' : 'password';
+    const alias = uniqueAlias(name, host, aliases);
+    aliases.add(alias);
+    sessions.push({
+      id: `${lineIndex}:${alias}`,
+      name,
+      alias,
+      host,
+      port,
+      username,
+      folder: currentFolder,
+      authMode,
+    });
+  }
+
+  if (sessions.length === 0) {
+    throw new Error('No SSH sessions were found in this MobaXterm file.');
+  }
+  return { sessions, ignoredCount };
+}
+
+/** Convert reviewed MobaXterm rows into the existing portable restore pipeline. */
+export function mobaXtermConnections(
+  sessions: readonly MobaXtermSession[],
+): PortableConnections {
+  const sshHosts = sessions.map((session): PortableSshHost => {
+    const options: HostBlockOptions = {
+      hostname: session.host,
+      ...(session.username ? { user: session.username } : {}),
+      ...(session.port === 22 ? {} : { port: session.port }),
+      ...(session.authMode === 'password' ? { passwordOnly: true } : {}),
+    };
+    const metadata: PortableHostMetadata = {
+      displayName: session.name,
+      ...(session.folder ? { group: session.folder } : {}),
+    };
+    return {
+      alias: session.alias,
+      aliases: [session.alias],
+      description: 'Imported from MobaXterm.',
+      options,
+      metadata,
+    };
+  });
+  return { sshHosts, savedHosts: [], hostOrder: [] };
+}
+
+function normalizeFolder(value: string): string | undefined {
+  const parts = value
+    .replace(/\\/g, '/')
+    .split('/')
+    .map((part) => stripControlCharacters(part).trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join('/') : undefined;
+}
+
+function stripControlCharacters(value: string): string {
+  let cleaned = '';
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint >= 0x20 && codePoint !== 0x7f) cleaned += character;
+  }
+  return cleaned;
+}
+
+function uniqueAlias(name: string, host: string, used: ReadonlySet<string>): string {
+  const cleanedName = cleanAlias(name);
+  const base = cleanedName || cleanAlias(host) || 'mobaxterm-host';
+  if (!used.has(base)) return base;
+  let suffix = 2;
+  while (used.has(`${base}-${suffix}`)) suffix++;
+  return `${base}-${suffix}`;
+}
+
+function cleanAlias(value: string): string {
+  return value
+    .trim()
+    .replace(INVALID_ALIAS_CHARS_RE, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 240);
+}

--- a/docs/guide/hosts.md
+++ b/docs/guide/hosts.md
@@ -10,6 +10,21 @@ pulled in with `Include`, together with the Telnet and serial hosts stored by Mu
 Muxus does not import the configuration. It reads `~/.ssh/config` directly and writes edits
 back to the same file in place.
 
+## Import from MobaXterm
+
+Open **Settings → Backup & data → Import sessions** to bring MobaXterm SSH bookmarks into
+Muxus. On Windows, **Find sessions** reads bookmarks from the current user's local
+MobaXterm installation. On every platform, you can choose `MobaXterm.ini`, `.mxtsessions`,
+`.mobaconf` or a text export instead.
+
+The review lists every detected SSH session and flags aliases that already exist. Choose
+which sessions to include and whether existing aliases should be kept or replaced. Muxus
+preserves the display name, host, port, username, password-vs-key authentication intent and
+the `SubRep` folder hierarchy.
+
+Passwords and private key files are not copied. They remain outside `ssh_config`; Muxus
+uses your SSH agent or asks for credentials when you connect.
+
 <figure markdown="span">
   ![The hosts sidebar with folders and colours](../assets/screenshots/sidebar.png#only-light){ .shadow }
   ![The hosts sidebar with folders and colours](../assets/screenshots/sidebar-dark.png#only-dark){ .shadow }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -16,7 +16,12 @@ import {
 import fixPath from 'fix-path';
 import { startServer, type RunningServer } from '@muxus/server';
 import { isNewerVersion } from '@muxus/shared';
-import type { AppWindowLaunch, UpdateCheckResult } from '@muxus/shared';
+import type {
+  AppWindowLaunch,
+  MobaXtermSessionSource,
+  UpdateCheckResult,
+} from '@muxus/shared';
+import { readLocalMobaXtermSessions } from './mobaxterm.js';
 
 // GUI apps on macOS/Linux don't inherit the shell PATH; ssh-agent sockets
 // and the user's login shell tooling need it.
@@ -483,6 +488,14 @@ ipcMain.handle('muxus:select-private-key', async (event): Promise<string | undef
   });
   return result.canceled ? undefined : result.filePaths[0];
 });
+
+ipcMain.handle(
+  'muxus:read-mobaxterm-sessions',
+  async (event): Promise<MobaXtermSessionSource | undefined> => {
+    if (!isManagedWindowSender(event)) return undefined;
+    return readLocalMobaXtermSessions();
+  },
+);
 
 function parseWindowLaunch(value: unknown): AppWindowLaunch | undefined {
   if (!value || typeof value !== 'object') return undefined;

--- a/electron/src/mobaxterm.ts
+++ b/electron/src/mobaxterm.ts
@@ -1,0 +1,90 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { MobaXtermSessionSource } from '@muxus/shared';
+
+const MAX_MOBAXTERM_FILE_BYTES = 10 * 1024 * 1024;
+
+// Only bookmark values are read. Password and credential registry subkeys are
+// deliberately excluded: Muxus prompts for secrets and never persists them.
+const READ_BOOKMARKS_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+$base = Get-Item -LiteralPath 'Registry::HKEY_CURRENT_USER\Software\Mobatek\MobaXterm'
+$sections = @(
+  Get-ChildItem -LiteralPath $base.PSPath |
+    Where-Object { $_.PSChildName -match '^Bookmarks(?:_\d+)?$' } |
+    Sort-Object -Property PSChildName
+)
+if ($sections.Count -eq 0) { exit 2 }
+$builder = [System.Text.StringBuilder]::new()
+foreach ($section in $sections) {
+  $values = Get-ItemProperty -LiteralPath $section.PSPath
+  [void]$builder.AppendLine("[$($section.PSChildName)]")
+  if ($null -ne $values.SubRep) {
+    [void]$builder.AppendLine("SubRep=$($values.SubRep)")
+  }
+  foreach ($property in $values.PSObject.Properties) {
+    if ($property.Name -eq 'SubRep' -or $property.Name -like 'PS*') { continue }
+    [void]$builder.AppendLine("$($property.Name)=$($property.Value)")
+  }
+  [void]$builder.AppendLine()
+}
+$bytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
+[Console]::Out.Write([Convert]::ToBase64String($bytes))
+`;
+
+function runPowerShell(script: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'powershell.exe',
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
+      {
+        encoding: 'utf8',
+        maxBuffer: MAX_MOBAXTERM_FILE_BYTES * 2,
+        timeout: 15_000,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      },
+    );
+  });
+}
+
+async function readRegistryBookmarks(): Promise<MobaXtermSessionSource | undefined> {
+  try {
+    const encoded = (await runPowerShell(READ_BOOKMARKS_SCRIPT)).trim();
+    if (!encoded) return undefined;
+    const content = Buffer.from(encoded, 'base64').toString('utf8');
+    if (!content.trim() || Buffer.byteLength(content) > MAX_MOBAXTERM_FILE_BYTES) return undefined;
+    return { source: 'MobaXterm Windows registry', content };
+  } catch {
+    return undefined;
+  }
+}
+
+async function readPortableIni(): Promise<MobaXtermSessionSource | undefined> {
+  const appData = process.env.APPDATA;
+  if (!appData) return undefined;
+  const filename = path.join(appData, 'MobaXterm', 'MobaXterm.ini');
+  try {
+    const content = await readFile(filename, 'utf8');
+    if (!content.trim() || Buffer.byteLength(content) > MAX_MOBAXTERM_FILE_BYTES) return undefined;
+    return { source: filename, content };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Discover local installer bookmarks first, then the conventional portable INI. */
+export async function readLocalMobaXtermSessions(): Promise<MobaXtermSessionSource> {
+  if (process.platform !== 'win32') {
+    throw new Error('Automatic MobaXterm discovery is only available on Windows.');
+  }
+  const source = (await readRegistryBookmarks()) ?? (await readPortableIni());
+  if (source) return source;
+  throw new Error(
+    'No local MobaXterm bookmarks were found. Choose MobaXterm.ini or an .mxtsessions export instead.',
+  );
+}

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { AppWindowLaunch } from '@muxus/shared';
+import type { AppWindowLaunch, MobaXtermSessionSource } from '@muxus/shared';
 
 // Client state is mirrored here and persisted with fire-and-forget messages.
 // sendSync is deliberately avoided for the steady-state path: it parks the
@@ -78,6 +78,10 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   /** Open a native single-file picker and return only the user-selected path. */
   selectPrivateKey(): Promise<string | undefined> {
     return ipcRenderer.invoke('muxus:select-private-key');
+  },
+  /** Read bookmark-only session data from the current Windows user's MobaXterm install. */
+  readMobaXtermSessions(): Promise<MobaXtermSessionSource | undefined> {
+    return ipcRenderer.invoke('muxus:read-mobaxterm-sessions');
   },
   openWindow(launch: AppWindowLaunch): void {
     ipcRenderer.send('muxus:open-window', launch);

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -21,6 +21,14 @@ export interface AppInfo {
   sshAlgorithms: Record<string, string[]>;
 }
 
+/** Raw bookmark data discovered from a local Windows MobaXterm installation. */
+export interface MobaXtermSessionSource {
+  /** Human-readable origin shown before the user confirms the import. */
+  source: string;
+  /** Reconstructed MobaXterm INI bookmark sections. Never contains passwords. */
+  content: string;
+}
+
 /**
  * ssh_config keywords the dialer applies even though they have no editor
  * field of their own (they are edited under Advanced). Everything else in

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -1,11 +1,23 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiFetch } from '../../../client/src/api/http.js';
 import {
   BACKUP_FORMAT,
   TRANSFER_VERSION,
   parseTransferDocument,
+  restoreImportedConnections,
   sanitizePreferences,
   type BackupPreferences,
 } from '../../../client/src/data-transfer.js';
+
+vi.mock('../../../client/src/api/http.js', () => ({
+  apiFetch: vi.fn(),
+}));
+
+const apiFetchMock = vi.mocked(apiFetch);
+
+beforeEach(() => {
+  apiFetchMock.mockReset();
+});
 
 const connections = {
   sshHosts: [
@@ -19,6 +31,22 @@ const connections = {
   savedHosts: [],
   hostOrder: [{ kind: 'ssh', alias: 'production' }],
 };
+
+function mockExistingMultiAliasHost(): void {
+  apiFetchMock
+    .mockResolvedValueOnce({
+      path: '/home/test/.ssh/config',
+      files: ['/home/test/.ssh/config'],
+      hosts: [
+        {
+          alias: 'production',
+          aliases: ['production', 'prod-alt'],
+          file: '/home/test/.ssh/config',
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ profiles: [] });
+}
 
 describe('Muxus transfer file parsing', () => {
   it('accepts a versioned full backup', () => {
@@ -85,6 +113,52 @@ describe('Muxus transfer file parsing', () => {
         }),
       ),
     ).toThrow('The connection data in this file is incomplete or too large.');
+  });
+});
+
+describe('restoring SSH hosts', () => {
+  const importedSecondaryAlias = {
+    sshHosts: [
+      {
+        alias: 'prod-alt',
+        aliases: ['prod-alt'],
+        options: { hostname: 'new.example.com' },
+      },
+    ],
+    savedHosts: [],
+    hostOrder: [],
+  };
+
+  it('keeps a host when an imported alias matches one of its secondary aliases', async () => {
+    mockExistingMultiAliasHost();
+
+    await expect(
+      restoreImportedConnections(importedSecondaryAlias, 'keep'),
+    ).resolves.toEqual({ added: 0, updated: 0, skipped: 1 });
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the owning primary alias when replacing through a secondary alias', async () => {
+    mockExistingMultiAliasHost();
+    apiFetchMock.mockResolvedValueOnce({ file: '/home/test/.ssh/config' });
+
+    await expect(
+      restoreImportedConnections(importedSecondaryAlias, 'replace'),
+    ).resolves.toEqual({ added: 0, updated: 1, skipped: 0 });
+
+    expect(apiFetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/ssh/config/hosts',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          aliases: ['prod-alt'],
+          options: { hostname: 'new.example.com' },
+          previousAlias: 'production',
+          file: '/home/test/.ssh/config',
+        }),
+      }),
+    );
   });
 });
 

--- a/tests/unit/client/mobaxterm-import.test.ts
+++ b/tests/unit/client/mobaxterm-import.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mobaXtermConnections,
+  parseMobaXtermSessions,
+} from '../../../client/src/mobaxterm-import.js';
+
+describe('MobaXterm session parsing', () => {
+  it('reads SSH fields, nested folders and authentication intent', () => {
+    const parsed = parseMobaXtermSessions(`
+[Misc]
+LastSession=Do not import|#109#0%ignored.example.com%22%root%%rest
+
+[Bookmarks]
+SubRep=Production\\Europe
+Prod SSH=#109#0%prod.example.com%2222%deploy%%rest
+
+[Bookmarks_1]
+SubRep=Lab
+Key box=#109#0%key.example.com%22%root%3%rest
+`);
+
+    expect(parsed).toEqual({
+      ignoredCount: 0,
+      sessions: [
+        {
+          id: expect.any(String),
+          name: 'Prod SSH',
+          alias: 'Prod-SSH',
+          host: 'prod.example.com',
+          port: 2222,
+          username: 'deploy',
+          folder: 'Production/Europe',
+          authMode: 'password',
+        },
+        {
+          id: expect.any(String),
+          name: 'Key box',
+          alias: 'Key-box',
+          host: 'key.example.com',
+          port: 22,
+          username: 'root',
+          folder: 'Lab',
+          authMode: 'key',
+        },
+      ],
+    });
+  });
+
+  it('makes duplicate and OpenSSH-invalid names safe without losing display names', () => {
+    const parsed = parseMobaXtermSessions(`
+[Bookmarks]
+SubRep=
+My host!=#109#0%one.example.com%not-a-port%%%rest
+My host!=#109#0%two.example.com%22%%%rest
+`);
+
+    expect(parsed.sessions.map(({ alias, port, username }) => ({ alias, port, username }))).toEqual([
+      { alias: 'My-host', port: 22, username: undefined },
+      { alias: 'My-host-2', port: 22, username: undefined },
+    ]);
+  });
+
+  it('counts unsupported and malformed bookmark entries', () => {
+    const parsed = parseMobaXtermSessions(`
+[Bookmarks]
+RDP=#91#0%desktop.example.com
+Broken SSH=#109#0%%22%root%%
+Valid=#109#0%valid.example.com%22%root%%
+`);
+
+    expect(parsed.sessions).toHaveLength(1);
+    expect(parsed.ignoredCount).toBe(2);
+  });
+
+  it('rejects files with no SSH bookmarks', () => {
+    expect(() =>
+      parseMobaXtermSessions(`
+[Bookmarks]
+SubRep=
+RDP=#91#0%desktop.example.com
+`),
+    ).toThrow('No SSH sessions were found');
+  });
+});
+
+describe('MobaXterm connection conversion', () => {
+  it('maps sessions into Muxus hosts without copying secrets', () => {
+    const parsed = parseMobaXtermSessions(`
+[Bookmarks]
+SubRep=Customers\\Acme
+Password host=#109#0%pw.example.com%2200%alice%%rest
+Key host=#109#0%key.example.com%22%bob%3%rest
+`);
+    const portable = mobaXtermConnections(parsed.sessions);
+
+    expect(portable.savedHosts).toEqual([]);
+    expect(portable.hostOrder).toEqual([]);
+    expect(portable.sshHosts).toEqual([
+      {
+        alias: 'Password-host',
+        aliases: ['Password-host'],
+        description: 'Imported from MobaXterm.',
+        options: {
+          hostname: 'pw.example.com',
+          user: 'alice',
+          port: 2200,
+          passwordOnly: true,
+        },
+        metadata: {
+          displayName: 'Password host',
+          group: 'Customers/Acme',
+        },
+      },
+      {
+        alias: 'Key-host',
+        aliases: ['Key-host'],
+        description: 'Imported from MobaXterm.',
+        options: {
+          hostname: 'key.example.com',
+          user: 'bob',
+        },
+        metadata: {
+          displayName: 'Key host',
+          group: 'Customers/Acme',
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add MobaXterm session import to Settings
- parse SSH bookmarks from exported configuration files
- discover local bookmarks automatically on Windows
- provide preview, filtering, selection, folder preservation, and conflict handling
- preserve authentication intent without copying passwords or private-key material

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:bundle`
- `pnpm test` (549 tests)
- browser-based UI review