### PR TITLE
Bump Muxus to v0.2.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -46,7 +46,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.2.1',
+      currentVersion: '0.2.2',
       latestVersion: '0.3.0',
       releaseName: 'Muxus 0.3',
       releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.3.0',
@@ -56,7 +56,7 @@ describe('app routes', () => {
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.2.1' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.2.2' },
     });
   });
 
@@ -83,7 +83,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.2.1',
+      currentVersion: '0.2.2',
       latestVersion: '0.3.0',
       reason: 'missing-release-url',
     });


### PR DESCRIPTION
## Summary

Bump Muxus from v0.2.1 to v0.2.2 across all workspace package manifests.

Update the server update-check expectations so the reported current version and request user agent remain aligned with the release version.

## Impact

Release builds and update checks now identify the application as v0.2.2.

## Validation

- `pnpm --filter @muxus/tests test -- unit/server/app-routes.test.ts` (551 tests passed)
- `pnpm lint`
- `git diff --check`