### PR TITLE
Add automatic encrypted password vault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            pack_args: ""
+          - os: macos-latest
+            # Build universal like the release job so both per-arch
+            # @napi-rs/keyring packages are exercised on every change.
+            pack_args: "--universal"
+          - os: windows-latest
+            pack_args: ""
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -74,8 +79,38 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Runner login keychains are not reliably unlocked; give the keyring
+      # roundtrip test a dedicated unlocked default keychain instead.
+      - name: Prepare macOS CI keychain
+        if: runner.os == 'macOS'
+        run: |
+          security create-keychain -p muxus-ci muxus-ci.keychain
+          security list-keychains -d user -s muxus-ci.keychain
+          security default-keychain -s muxus-ci.keychain
+          security unlock-keychain -p muxus-ci muxus-ci.keychain
+          security set-keychain-settings muxus-ci.keychain
+
+      - name: Test OS credential-store roundtrip
+        if: runner.os != 'Linux'
+        env:
+          MUXUS_OS_KEYRING_SMOKE: "1"
+        run: pnpm --filter @muxus/tests exec vitest run unit/server/vault-key-store.os.test.ts
+
       - name: Build workspace
         run: pnpm build
 
       - name: Build unpacked desktop application
-        run: pnpm --filter @muxus/electron pack:dir
+        run: pnpm --filter @muxus/electron pack:dir ${{ matrix.pack_args }}
+
+      - name: Verify universal keyring binaries
+        if: runner.os == 'macOS'
+        run: |
+          app="electron/release/mac-universal/Muxus.app"
+          if [ ! -d "$app" ]; then
+            echo "Universal app bundle not found; release contents:" >&2
+            ls electron/release >&2
+            exit 1
+          fi
+          for arch in x64 arm64; do
+            ls "$app/Contents/Resources/app.asar.unpacked/node_modules/@napi-rs/keyring-darwin-$arch/"*.node
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,19 @@ jobs:
       - name: Build installers
         run: pnpm --filter @muxus/electron exec electron-builder ${{ matrix.build_args }} --publish never
 
+      - name: Verify universal keyring binaries
+        if: runner.os == 'macOS'
+        run: |
+          app="electron/release/mac-universal/Muxus.app"
+          if [ ! -d "$app" ]; then
+            echo "Universal app bundle not found; release contents:" >&2
+            ls electron/release >&2
+            exit 1
+          fi
+          for arch in x64 arm64; do
+            ls "$app/Contents/Resources/app.asar.unpacked/node_modules/@napi-rs/keyring-darwin-$arch/"*.node
+          done
+
       - name: Store installers
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
             os: macos-latest
             # These overrides also backfill tags created before the universal
             # native-module rules were added to electron-builder.yml.
-            build_args: --mac dmg --universal -c.mac.x64ArchFiles="**/prebuilds/darwin*/**" -c.mac.singleArchFiles="**/node_modules/@napi-rs/keyring-darwin-*{,/**}"
+            build_args: --mac dmg --universal -c.mac.x64ArchFiles="{**/prebuilds/darwin*/**,**/node_modules/@napi-rs/keyring-darwin-*/**}" -c.mac.singleArchFiles="**/node_modules/@napi-rs/keyring-darwin-*{,/**}"
             artifact_name: macos-universal
             artifact_path: electron/release/*.dmg
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,9 @@ jobs:
             artifact_path: electron/release/*.exe
           - name: macOS universal
             os: macos-latest
-            # The override also backfills tags created before x64ArchFiles was added
-            # to electron-builder.yml, including v0.1.0.
-            build_args: --mac dmg --universal -c.mac.x64ArchFiles="**/prebuilds/darwin*/**"
+            # These overrides also backfill tags created before the universal
+            # native-module rules were added to electron-builder.yml.
+            build_args: --mac dmg --universal -c.mac.x64ArchFiles="**/prebuilds/darwin*/**" -c.mac.singleArchFiles="**/node_modules/@napi-rs/keyring-darwin-*{,/**}"
             artifact_name: macos-universal
             artifact_path: electron/release/*.dmg
     runs-on: ${{ matrix.os }}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,12 @@
-import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AppWindowLaunch } from '@muxus/shared';
@@ -8,11 +16,11 @@ import { setTitleBarMode } from './titlebar-overlay.js';
 import { usePrefsStore } from './state/prefs.js';
 import { useUiStore } from './state/ui.js';
 import { AppShell } from './layout/AppShell.js';
-import { DialogHost } from './components/DialogHost.js';
 import { ErrorBoundary } from './components/ErrorBoundary.js';
-import { ToastHost } from './components/ToastHost.js';
 import { BackendStatusBanner } from './components/BackendStatusBanner.js';
 import { UpdateNotification } from './components/UpdateNotification.js';
+import { useDialogStore } from './state/dialogs.js';
+import { useToastStore } from './state/toast.js';
 import {
   loadHostEditorDialog,
   loadFolderDialog,
@@ -36,6 +44,21 @@ const FolderDialog = lazy(() =>
 );
 const SettingsDialog = lazy(() =>
   loadSettingsDialog().then((module) => ({ default: module.SettingsDialog })),
+);
+const PasswordVaultStartupUnlock = lazy(() =>
+  import('./components/PasswordVaultStartupUnlock.js').then((module) => ({
+    default: module.PasswordVaultStartupUnlock,
+  })),
+);
+const DialogHost = lazy(() =>
+  import('./components/DialogHost.js').then((module) => ({
+    default: module.DialogHost,
+  })),
+);
+const ToastHost = lazy(() =>
+  import('./components/ToastHost.js').then((module) => ({
+    default: module.ToastHost,
+  })),
 );
 const CommandButtonsDialog = lazy(() =>
   loadCommandButtonsDialog().then((module) => ({ default: module.CommandButtonsDialog })),
@@ -68,9 +91,13 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const historyOpen = useUiStore((s) => s.historyOpen);
   const quickLauncherOpen = useUiStore((s) => s.quickLauncherOpen);
   const workspacesOpen = useUiStore((s) => s.workspacesOpen);
+  const dialogOpen = useDialogStore((s) => s.queue.length > 0);
+  const toastOpen = useToastStore((s) => !!s.toast);
+  const [startupReady, setStartupReady] = useState(false);
   const [osTheme, setOsTheme] = useState<'light' | 'dark'>(() =>
     window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
   );
+  const finishStartup = useCallback(() => setStartupReady(true), []);
   const effectiveMode = themeMode === 'os' ? osTheme : themeMode;
   const theme = useMemo(() => buildTheme(effectiveMode), [effectiveMode]);
   useLayoutEffect(() => {
@@ -95,7 +122,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
             <SftpWindow launch={launch} />
           </Suspense>
         ) : (
-          <AppShell persistWorkspace={!launch} />
+          <AppShell persistWorkspace={!launch && startupReady} />
         )}
       </ErrorBoundary>
       <Suspense fallback={null}>
@@ -108,9 +135,10 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
         {historyOpen ? <SessionHistoryDialog /> : null}
         {quickLauncherOpen ? <QuickLauncherDialog /> : null}
         {workspacesOpen ? <WorkspaceDialog /> : null}
+        {!launch ? <PasswordVaultStartupUnlock onReady={finishStartup} /> : null}
+        {dialogOpen ? <DialogHost /> : null}
+        {toastOpen ? <ToastHost /> : null}
       </Suspense>
-      <DialogHost />
-      <ToastHost />
       <BackendStatusBanner />
       {!launch ? <UpdateNotification /> : null}
     </ThemeProvider>

--- a/client/src/api/dial.ts
+++ b/client/src/api/dial.ts
@@ -1,13 +1,16 @@
 import type { TerminalServerMessage, TunnelSshOptions } from '@muxus/shared';
-import type { AuthPromptRequest } from '../components/AuthPromptDialog.js';
+import type {
+  AuthPromptRequest,
+  AuthPromptResult,
+} from '../components/AuthPromptDialog.js';
 import type { HostKeyRequest } from '../components/HostKeyDialog.js';
 import { wsProtocols, wsUrl } from './http.js';
 
 /** Interactive hooks a shell-less dial needs from the UI. */
 export interface DialHandlers {
   onStatus?(message: string): void;
-  /** Resolve with answers, or null to cancel the connection attempt. */
-  onAuthPrompt(request: AuthPromptRequest): Promise<string[] | null>;
+  /** Resolve with answers and prompt options, or null to cancel the connection attempt. */
+  onAuthPrompt(request: AuthPromptRequest): Promise<AuthPromptResult | null>;
   onHostKey(request: HostKeyRequest): Promise<boolean>;
 }
 
@@ -71,11 +74,19 @@ export function dialConnection(
           break;
         case 'auth-prompt':
           void handlers
-            .onAuthPrompt({ name: msg.name, instructions: msg.instructions, host: msg.host, prompts: msg.prompts })
-            .then((answers) => {
+            .onAuthPrompt({
+              name: msg.name,
+              instructions: msg.instructions,
+              host: msg.host,
+              prompts: msg.prompts,
+              purpose: msg.purpose,
+              rememberPassword: msg.rememberPassword,
+              skipLabel: msg.skipLabel,
+            })
+            .then((response) => {
               if (ws.readyState !== WebSocket.OPEN) return;
-              if (answers === null) ws.close();
-              else ws.send(JSON.stringify({ op: 'auth-response', answers }));
+              if (response === null) ws.close();
+              else ws.send(JSON.stringify({ op: 'auth-response', ...response }));
             });
           break;
         case 'host-key':

--- a/client/src/api/password-vault-queries.ts
+++ b/client/src/api/password-vault-queries.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import type { PasswordVaultStatus } from '@muxus/shared';
+import { fetchPasswordVaultStatus } from './password-vault.js';
+
+/** Feature-local so password-vault code stays out of the initial bundle. */
+export function usePasswordVaultStatus() {
+  return useQuery<PasswordVaultStatus>({
+    queryKey: ['password-vault'],
+    queryFn: fetchPasswordVaultStatus,
+  });
+}

--- a/client/src/api/password-vault.ts
+++ b/client/src/api/password-vault.ts
@@ -1,4 +1,7 @@
-import type { PasswordVaultStatus } from '@muxus/shared';
+import type {
+  PasswordVaultStatus,
+  PasswordVaultUnlockPolicy,
+} from '@muxus/shared';
 import { apiFetch } from './http.js';
 
 const JSON_HEADERS = { 'content-type': 'application/json' };
@@ -9,12 +12,37 @@ export function fetchPasswordVaultStatus(): Promise<PasswordVaultStatus> {
 
 export function createPasswordVault(
   password: string,
+  unlockPolicy: PasswordVaultUnlockPolicy,
 ): Promise<PasswordVaultStatus> {
   return apiFetch<PasswordVaultStatus>('/api/password-vault/create', {
     method: 'POST',
     headers: JSON_HEADERS,
-    body: JSON.stringify({ password }),
+    body: JSON.stringify({ password, unlockPolicy }),
   });
+}
+
+export function unlockPasswordVault(
+  masterPassword: string,
+): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>('/api/password-vault/unlock', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ masterPassword }),
+  });
+}
+
+export function changePasswordVaultUnlockPolicy(
+  masterPassword: string,
+  unlockPolicy: PasswordVaultUnlockPolicy,
+): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>(
+    '/api/password-vault/unlock-policy',
+    {
+      method: 'PUT',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ masterPassword, unlockPolicy }),
+    },
+  );
 }
 
 export function repairPasswordVaultAutomaticAccess(

--- a/client/src/api/password-vault.ts
+++ b/client/src/api/password-vault.ts
@@ -1,0 +1,89 @@
+import type { PasswordVaultStatus } from '@muxus/shared';
+import { apiFetch } from './http.js';
+
+const JSON_HEADERS = { 'content-type': 'application/json' };
+
+export function fetchPasswordVaultStatus(): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>('/api/password-vault');
+}
+
+export function createPasswordVault(
+  password: string,
+): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>('/api/password-vault/create', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ password }),
+  });
+}
+
+export function repairPasswordVaultAutomaticAccess(
+  masterPassword: string,
+): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>(
+    '/api/password-vault/repair-automatic-access',
+    {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ masterPassword }),
+    },
+  );
+}
+
+export function revealSavedPassword(
+  id: string,
+  masterPassword: string,
+): Promise<{ password: string }> {
+  return apiFetch<{ password: string }>(
+    `/api/password-vault/credentials/${encodeURIComponent(id)}/reveal`,
+    {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ masterPassword }),
+    },
+  );
+}
+
+export function updateSavedPassword(
+  id: string,
+  masterPassword: string,
+  password: string,
+): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>(
+    `/api/password-vault/credentials/${encodeURIComponent(id)}`,
+    {
+      method: 'PUT',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ masterPassword, password }),
+    },
+  );
+}
+
+export function changeMasterPassword(
+  currentPassword: string,
+  nextPassword: string,
+): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>(
+    '/api/password-vault/change-master-password',
+    {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ currentPassword, nextPassword }),
+    },
+  );
+}
+
+export function forgetSavedPassword(
+  id: string,
+): Promise<{ deleted: boolean }> {
+  return apiFetch<{ deleted: boolean }>(
+    `/api/password-vault/credentials/${encodeURIComponent(id)}`,
+    { method: 'DELETE' },
+  );
+}
+
+export function deletePasswordVault(): Promise<PasswordVaultStatus> {
+  return apiFetch<PasswordVaultStatus>('/api/password-vault', {
+    method: 'DELETE',
+  });
+}

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -4,7 +4,6 @@ import type {
   AppInfo,
   ConnectionsResponse,
   ForwardInfo,
-  PasswordVaultStatus,
   SerialPortsResponse,
   SavedHostProfilesResponse,
   SessionHistoryResponse,
@@ -17,20 +16,12 @@ import type {
   TunnelsResponse,
 } from '@muxus/shared';
 import { apiFetch } from './http.js';
-import { fetchPasswordVaultStatus } from './password-vault.js';
 
 export function useAppInfo() {
   return useQuery({
     queryKey: ['app-info'],
     queryFn: () => apiFetch<AppInfo>('/api/app/info'),
     staleTime: Infinity,
-  });
-}
-
-export function usePasswordVaultStatus() {
-  return useQuery<PasswordVaultStatus>({
-    queryKey: ['password-vault'],
-    queryFn: fetchPasswordVaultStatus,
   });
 }
 

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -4,6 +4,7 @@ import type {
   AppInfo,
   ConnectionsResponse,
   ForwardInfo,
+  PasswordVaultStatus,
   SerialPortsResponse,
   SavedHostProfilesResponse,
   SessionHistoryResponse,
@@ -16,12 +17,20 @@ import type {
   TunnelsResponse,
 } from '@muxus/shared';
 import { apiFetch } from './http.js';
+import { fetchPasswordVaultStatus } from './password-vault.js';
 
 export function useAppInfo() {
   return useQuery({
     queryKey: ['app-info'],
     queryFn: () => apiFetch<AppInfo>('/api/app/info'),
     staleTime: Infinity,
+  });
+}
+
+export function usePasswordVaultStatus() {
+  return useQuery<PasswordVaultStatus>({
+    queryKey: ['password-vault'],
+    queryFn: fetchPasswordVaultStatus,
   });
 }
 

--- a/client/src/components/AuthPromptDialog.tsx
+++ b/client/src/components/AuthPromptDialog.tsx
@@ -46,8 +46,8 @@ export function AuthPromptDialog({
 
   const submit = () => {
     if (request.purpose === 'vault-create') {
-      if (Array.from(answers[0] ?? '').length < 8) {
-        setError('Use at least 8 characters for the master password.');
+      if (Array.from(answers[0] ?? '').length < 12) {
+        setError('Use at least 12 characters for the master password.');
         return;
       }
       if (new TextEncoder().encode(answers[0] ?? '').byteLength > 1024) {
@@ -66,7 +66,18 @@ export function AuthPromptDialog({
   };
 
   return (
-    <Dialog open onClose={() => finish(null)} maxWidth="xs" fullWidth>
+    <Dialog
+      open
+      onClose={() =>
+        finish(
+          request.skipLabel
+            ? { answers: [], skipped: true }
+            : null,
+        )
+      }
+      maxWidth="xs"
+      fullWidth
+    >
       <DialogTitle>
         {request.name || 'Authentication'}
         {request.host && (
@@ -114,7 +125,7 @@ export function AuthPromptDialog({
                       : 'Remember this password'}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
-                    Encrypted locally and available automatically for SSH.
+                    Encrypted locally under your password-vault policy.
                   </Typography>
                 </Stack>
               }

--- a/client/src/components/AuthPromptDialog.tsx
+++ b/client/src/components/AuthPromptDialog.tsx
@@ -1,32 +1,72 @@
 import { useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import type {
+  AuthPromptInfo,
+  AuthPromptResponse,
+} from '@muxus/shared';
 
-export interface AuthPromptRequest {
-  name?: string;
-  instructions?: string;
-  /** Which host in the connection chain is asking ("bastion", "web"). */
-  host?: string;
-  prompts: Array<{ prompt: string; echo: boolean }>;
-}
+export type AuthPromptRequest = AuthPromptInfo;
+export type AuthPromptResult = AuthPromptResponse;
 
 /** Interactive SSH auth: passwords, key passphrases, 2FA codes. */
-export function AuthPromptDialog({ request, onSubmit }: { request: AuthPromptRequest | null; onSubmit: (answers: string[] | null) => void }) {
+export function AuthPromptDialog({
+  request,
+  onSubmit,
+}: {
+  request: AuthPromptRequest | null;
+  onSubmit: (result: AuthPromptResult | null) => void;
+}) {
   const [answers, setAnswers] = useState<string[]>([]);
+  const [rememberPassword, setRememberPassword] = useState(false);
+  const [error, setError] = useState<string>();
   useEffect(() => {
     setAnswers(request ? request.prompts.map(() => '') : []);
+    setRememberPassword(false);
+    setError(undefined);
   }, [request]);
 
   if (!request) return null;
-  const submit = () => onSubmit(answers);
+
+  const finish = (result: AuthPromptResult | null) => {
+    setAnswers((current) => current.map(() => ''));
+    setRememberPassword(false);
+    setError(undefined);
+    onSubmit(result);
+  };
+
+  const submit = () => {
+    if (request.purpose === 'vault-create') {
+      if (Array.from(answers[0] ?? '').length < 8) {
+        setError('Use at least 8 characters for the master password.');
+        return;
+      }
+      if (new TextEncoder().encode(answers[0] ?? '').byteLength > 1024) {
+        setError('The master password is too long.');
+        return;
+      }
+      if ((answers[0] ?? '') !== (answers[1] ?? '')) {
+        setError('The master-password confirmation does not match.');
+        return;
+      }
+    }
+    finish({
+      answers: [...answers],
+      ...(request.rememberPassword ? { rememberPassword } : {}),
+    });
+  };
+
   return (
-    <Dialog open onClose={() => onSubmit(null)} maxWidth="xs" fullWidth>
+    <Dialog open onClose={() => finish(null)} maxWidth="xs" fullWidth>
       <DialogTitle>
         {request.name || 'Authentication'}
         {request.host && (
@@ -42,6 +82,7 @@ export function AuthPromptDialog({ request, onSubmit }: { request: AuthPromptReq
               {request.instructions}
             </Typography>
           )}
+          {error ? <Alert severity="error">{error}</Alert> : null}
           {request.prompts.map((p, i) => (
             <TextField
               key={`${p.prompt}-${i}`}
@@ -57,12 +98,40 @@ export function AuthPromptDialog({ request, onSubmit }: { request: AuthPromptReq
               autoComplete="off"
             />
           ))}
+          {request.rememberPassword ? (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={rememberPassword}
+                  onChange={(event) => setRememberPassword(event.target.checked)}
+                />
+              }
+              label={
+                <Stack spacing={0}>
+                  <Typography variant="body2">
+                    {request.rememberPassword.existing
+                      ? 'Update the saved password'
+                      : 'Remember this password'}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Encrypted locally and available automatically for SSH.
+                  </Typography>
+                </Stack>
+              }
+            />
+          ) : null}
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => onSubmit(null)}>Cancel</Button>
+        {request.skipLabel ? (
+          <Button onClick={() => finish({ answers: [], skipped: true })}>
+            {request.skipLabel}
+          </Button>
+        ) : (
+          <Button onClick={() => finish(null)}>Cancel</Button>
+        )}
         <Button variant="contained" onClick={submit}>
-          Continue
+          {request.purpose === 'vault-create' ? 'Create vault' : 'Continue'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/client/src/components/ForwardingPanel.tsx
+++ b/client/src/components/ForwardingPanel.tsx
@@ -35,7 +35,11 @@ import { confirmAction } from '../state/dialogs.js';
 import { showErrorToast, showToast } from '../state/toast.js';
 import { useUiStore } from '../state/ui.js';
 import { layout, statusTextColor } from '../theme.js';
-import { AuthPromptDialog, type AuthPromptRequest } from './AuthPromptDialog.js';
+import {
+  AuthPromptDialog,
+  type AuthPromptRequest,
+  type AuthPromptResult,
+} from './AuthPromptDialog.js';
 import { HostKeyDialog, type HostKeyRequest } from './HostKeyDialog.js';
 import { FORWARD_FLAG, ForwardRuleForm, describeForward } from './ForwardRuleForm.js';
 import { TunnelEditorDialog, type TunnelEditorState } from './TunnelEditorDialog.js';
@@ -65,7 +69,10 @@ export function ForwardingPanel() {
   const [tunnelMenu, setTunnelMenu] = useState<{ anchor: HTMLElement; tunnel: TunnelRecord } | null>(null);
   /** tunnelId → progress message while a start (dial + forward) is in flight. */
   const [starting, setStarting] = useState<Record<string, string>>({});
-  const [dialAuth, setDialAuth] = useState<{ request: AuthPromptRequest; resolve: (answers: string[] | null) => void } | null>(null);
+  const [dialAuth, setDialAuth] = useState<{
+    request: AuthPromptRequest;
+    resolve: (result: AuthPromptResult | null) => void;
+  } | null>(null);
   const [dialHostKey, setDialHostKey] = useState<{ request: HostKeyRequest; resolve: (accept: boolean) => void } | null>(null);
 
   const anyStarting = Object.keys(starting).length > 0;
@@ -382,8 +389,8 @@ export function ForwardingPanel() {
 
       <AuthPromptDialog
         request={dialAuth?.request ?? null}
-        onSubmit={(answers) => {
-          dialAuth?.resolve(answers);
+        onSubmit={(result) => {
+          dialAuth?.resolve(result);
           setDialAuth(null);
         }}
       />

--- a/client/src/components/PasswordVaultSection.tsx
+++ b/client/src/components/PasswordVaultSection.tsx
@@ -12,6 +12,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
@@ -22,24 +23,33 @@ import PasswordOutlinedIcon from '@mui/icons-material/PasswordOutlined';
 import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import { useQueryClient } from '@tanstack/react-query';
-import type {
-  PasswordVaultCredential,
-  PasswordVaultStatus,
+import {
+  DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY,
+  type PasswordVaultCredential,
+  type PasswordVaultStatus,
+  type PasswordVaultUnlockPolicy,
 } from '@muxus/shared';
 import {
   changeMasterPassword,
+  changePasswordVaultUnlockPolicy,
   createPasswordVault,
   deletePasswordVault,
   forgetSavedPassword,
   repairPasswordVaultAutomaticAccess,
   revealSavedPassword,
+  unlockPasswordVault,
   updateSavedPassword,
 } from '../api/password-vault.js';
-import { usePasswordVaultStatus } from '../api/queries.js';
+import { usePasswordVaultStatus } from '../api/password-vault-queries.js';
 import { confirmAction } from '../state/dialogs.js';
 import { showErrorToast, showToast } from '../state/toast.js';
 
-type MasterDialogMode = 'create' | 'change' | 'repair';
+type MasterDialogMode =
+  | 'create'
+  | 'change'
+  | 'repair'
+  | 'unlock'
+  | 'policy';
 
 export function PasswordVaultSection() {
   const queryClient = useQueryClient();
@@ -74,7 +84,7 @@ export function PasswordVaultSection() {
     const confirmed = await confirmAction({
       title: 'Delete the password vault?',
       description:
-        'Every saved SSH password will be permanently removed. Connection profiles and SSH keys are not affected.',
+        'Every saved SSH password will be securely removed from the active database and OS credential store. Existing backups or filesystem snapshots are not affected. Connection profiles and SSH keys are not affected.',
       confirmLabel: 'Delete vault',
       destructive: true,
     });
@@ -121,15 +131,25 @@ export function PasswordVaultSection() {
             Password saving is off. Create a master password to protect viewing
             and editing saved SSH passwords.
           </Alert>
-        ) : status.automaticAccess ? (
+        ) : status.unlockPolicy === 'credential' ? (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Muxus will ask for the master password whenever a saved credential
+            is needed.
+          </Alert>
+        ) : !status.locked ? (
           <Alert severity="success" sx={{ mb: 2 }}>
-            Automatic access is ready. SSH connections can use saved passwords
-            without asking for the master password.
+            {status.unlockPolicy === 'never'
+              ? 'OS credential-store access is ready. Saved passwords can be used without a master-password prompt.'
+              : 'The vault is unlocked for this app session.'}
           </Alert>
         ) : (
-          <Alert severity="error" sx={{ mb: 2 }}>
-            Automatic access needs repair. This can happen when the database is
-            restored without its companion device-key file.
+          <Alert
+            severity={status.unlockPolicy === 'never' ? 'error' : 'warning'}
+            sx={{ mb: 2 }}
+          >
+            {status.unlockPolicy === 'never'
+              ? 'The OS credential-store key is unavailable. Enter the master password to restore it.'
+              : 'The vault needs the master password for this app session.'}
           </Alert>
         )}
 
@@ -144,14 +164,28 @@ export function PasswordVaultSection() {
             </Button>
           ) : (
             <>
-              {!status.automaticAccess ? (
+              {status.locked && status.unlockPolicy === 'never' ? (
                 <Button
                   variant="contained"
                   onClick={() => setDialogMode('repair')}
                 >
-                  Repair automatic access
+                  Restore OS access
                 </Button>
               ) : null}
+              {status.locked && status.unlockPolicy === 'startup' ? (
+                <Button
+                  variant="contained"
+                  onClick={() => setDialogMode('unlock')}
+                >
+                  Unlock now
+                </Button>
+              ) : null}
+              <Button
+                variant="outlined"
+                onClick={() => setDialogMode('policy')}
+              >
+                Change prompt policy
+              </Button>
               <Button
                 variant="outlined"
                 onClick={() => setDialogMode('change')}
@@ -224,17 +258,17 @@ export function PasswordVaultSection() {
       ) : null}
 
       <Typography variant="caption" color="text.secondary">
-        Your master password is required to view or edit saved values. Routine
-        SSH connections use a separate local device key automatically. The
-        device key is stored beside the database, so protect your operating
-        system account and application-data directory. Two-factor codes and
-        private-key passphrases are never remembered.
+        Your master password is always required to view or edit saved values.
+        “Never” stores the vault key in the operating-system credential store;
+        the other policies keep no usable vault key on disk. Two-factor codes
+        and private-key passphrases are never remembered.
       </Typography>
 
       {dialogMode ? (
         <MasterPasswordDialog
           key={dialogMode}
           mode={dialogMode}
+          initialUnlockPolicy={status.unlockPolicy}
           onClose={() => setDialogMode(undefined)}
           onSaved={(next) => {
             acceptStatus(next);
@@ -244,8 +278,12 @@ export function PasswordVaultSection() {
               dialogMode === 'create'
                 ? 'Password vault created.'
                 : dialogMode === 'repair'
-                  ? 'Automatic password access repaired.'
-                  : 'Master password changed.',
+                  ? 'OS credential-store access restored.'
+                  : dialogMode === 'unlock'
+                    ? 'Password vault unlocked.'
+                    : dialogMode === 'policy'
+                      ? 'Master-password prompt policy changed.'
+                      : 'Master password changed.',
             );
           }}
         />
@@ -268,16 +306,22 @@ export function PasswordVaultSection() {
 
 function MasterPasswordDialog({
   mode,
+  initialUnlockPolicy,
   onClose,
   onSaved,
 }: {
   mode: MasterDialogMode;
+  initialUnlockPolicy?: PasswordVaultUnlockPolicy;
   onClose: () => void;
   onSaved: (status: PasswordVaultStatus) => void;
 }) {
   const [currentPassword, setCurrentPassword] = useState('');
   const [nextPassword, setNextPassword] = useState('');
   const [confirmation, setConfirmation] = useState('');
+  const [unlockPolicy, setUnlockPolicy] =
+    useState<PasswordVaultUnlockPolicy>(
+      initialUnlockPolicy ?? DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY,
+    );
   const [error, setError] = useState<string>();
   const [saving, setSaving] = useState(false);
 
@@ -286,8 +330,8 @@ function MasterPasswordDialog({
   const proposed = creating ? currentPassword : nextPassword;
 
   const submit = async () => {
-    if ((creating || changing) && Array.from(proposed).length < 8) {
-      setError('Use at least 8 characters for the master password.');
+    if ((creating || changing) && Array.from(proposed).length < 12) {
+      setError('Use at least 12 characters for the master password.');
       return;
     }
     if (
@@ -306,10 +350,20 @@ function MasterPasswordDialog({
     try {
       const status =
         mode === 'create'
-          ? await createPasswordVault(currentPassword)
+          ? await createPasswordVault(currentPassword, unlockPolicy)
           : mode === 'repair'
             ? await repairPasswordVaultAutomaticAccess(currentPassword)
-            : await changeMasterPassword(currentPassword, nextPassword);
+            : mode === 'unlock'
+              ? await unlockPasswordVault(currentPassword)
+              : mode === 'policy'
+                ? await changePasswordVaultUnlockPolicy(
+                    currentPassword,
+                    unlockPolicy,
+                  )
+                : await changeMasterPassword(
+                    currentPassword,
+                    nextPassword,
+                  );
       setCurrentPassword('');
       setNextPassword('');
       setConfirmation('');
@@ -325,8 +379,12 @@ function MasterPasswordDialog({
     mode === 'create'
       ? 'Create password vault'
       : mode === 'repair'
-        ? 'Repair automatic access'
-        : 'Change master password';
+        ? 'Restore OS credential-store access'
+        : mode === 'unlock'
+          ? 'Unlock password vault'
+          : mode === 'policy'
+            ? 'Master-password prompt policy'
+            : 'Change master password';
 
   return (
     <Dialog open onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
@@ -335,29 +393,61 @@ function MasterPasswordDialog({
         <Stack spacing={2} sx={{ mt: 0.5 }}>
           {creating ? (
             <Typography variant="body2" color="text.secondary">
-              Use at least 8 characters. This password will be required to view
-              or edit saved values, but not for routine SSH connections.
+              Use at least 12 characters. This password is always required to
+              view or edit saved values.
             </Typography>
           ) : null}
           {mode === 'repair' ? (
             <Typography variant="body2" color="text.secondary">
-              Enter the master password to link this database to a new local
-              device key.
+              Enter the master password to restore the vault key in the
+              operating-system credential store.
+            </Typography>
+          ) : null}
+          {mode === 'unlock' ? (
+            <Typography variant="body2" color="text.secondary">
+              The decrypted vault key remains in memory until Muxus exits.
             </Typography>
           ) : null}
           {error ? <Alert severity="error">{error}</Alert> : null}
           <TextField
             label={
-              changing ? 'Current master password' : 'Master password'
+              changing || mode === 'policy'
+                ? 'Current master password'
+                : 'Master password'
             }
             type="password"
             autoComplete="off"
             value={currentPassword}
             onChange={(event) => setCurrentPassword(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && mode === 'repair') void submit();
+              if (
+                event.key === 'Enter' &&
+                (mode === 'repair' || mode === 'unlock')
+              ) {
+                void submit();
+              }
             }}
           />
+          {creating || mode === 'policy' ? (
+            <TextField
+              select
+              label="Ask for master password"
+              value={unlockPolicy}
+              onChange={(event) =>
+                setUnlockPolicy(
+                  event.target.value as PasswordVaultUnlockPolicy,
+                )
+              }
+            >
+              <MenuItem value="never">
+                Never for saved credentials (OS keyring)
+              </MenuItem>
+              <MenuItem value="startup">When Muxus starts</MenuItem>
+              <MenuItem value="credential">
+                Whenever a saved credential is needed
+              </MenuItem>
+            </TextField>
+          ) : null}
           {changing ? (
             <TextField
               label="New master password"
@@ -395,8 +485,12 @@ function MasterPasswordDialog({
             : mode === 'create'
               ? 'Create vault'
               : mode === 'repair'
-                ? 'Repair'
-                : 'Change password'}
+                ? 'Restore'
+                : mode === 'unlock'
+                  ? 'Unlock'
+                  : mode === 'policy'
+                    ? 'Save policy'
+                    : 'Change password'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/client/src/components/PasswordVaultSection.tsx
+++ b/client/src/components/PasswordVaultSection.tsx
@@ -1,0 +1,542 @@
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import PasswordOutlinedIcon from '@mui/icons-material/PasswordOutlined';
+import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
+import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
+import { useQueryClient } from '@tanstack/react-query';
+import type {
+  PasswordVaultCredential,
+  PasswordVaultStatus,
+} from '@muxus/shared';
+import {
+  changeMasterPassword,
+  createPasswordVault,
+  deletePasswordVault,
+  forgetSavedPassword,
+  repairPasswordVaultAutomaticAccess,
+  revealSavedPassword,
+  updateSavedPassword,
+} from '../api/password-vault.js';
+import { usePasswordVaultStatus } from '../api/queries.js';
+import { confirmAction } from '../state/dialogs.js';
+import { showErrorToast, showToast } from '../state/toast.js';
+
+type MasterDialogMode = 'create' | 'change' | 'repair';
+
+export function PasswordVaultSection() {
+  const queryClient = useQueryClient();
+  const result = usePasswordVaultStatus();
+  const status = result.data;
+  const [dialogMode, setDialogMode] = useState<MasterDialogMode>();
+  const [editing, setEditing] = useState<PasswordVaultCredential>();
+  const [busy, setBusy] = useState(false);
+
+  const acceptStatus = (next: PasswordVaultStatus) => {
+    queryClient.setQueryData(['password-vault'], next);
+  };
+
+  const forget = async (id: string, label: string) => {
+    const confirmed = await confirmAction({
+      title: 'Forget saved password?',
+      description: `Muxus will ask for the password to ${label} next time.`,
+      confirmLabel: 'Forget password',
+      destructive: true,
+    });
+    if (!confirmed) return;
+    try {
+      await forgetSavedPassword(id);
+      await queryClient.invalidateQueries({ queryKey: ['password-vault'] });
+      showToast('success', `Forgot the password for ${label}.`);
+    } catch (error) {
+      showErrorToast(error);
+    }
+  };
+
+  const removeVault = async () => {
+    const confirmed = await confirmAction({
+      title: 'Delete the password vault?',
+      description:
+        'Every saved SSH password will be permanently removed. Connection profiles and SSH keys are not affected.',
+      confirmLabel: 'Delete vault',
+      destructive: true,
+    });
+    if (!confirmed) return;
+    setBusy(true);
+    try {
+      acceptStatus(await deletePasswordVault());
+      showToast('success', 'Password vault deleted.');
+    } catch (error) {
+      showErrorToast(error);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (result.isError) {
+    return (
+      <Alert severity="error">
+        {result.error instanceof Error
+          ? result.error.message
+          : 'Could not read password-vault status.'}
+      </Alert>
+    );
+  }
+
+  if (result.isLoading || !status) {
+    return (
+      <Stack
+        sx={{ minHeight: 180, alignItems: 'center', justifyContent: 'center' }}
+      >
+        <CircularProgress size={24} />
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+          Password vault
+        </Typography>
+        {!status.configured ? (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Password saving is off. Create a master password to protect viewing
+            and editing saved SSH passwords.
+          </Alert>
+        ) : status.automaticAccess ? (
+          <Alert severity="success" sx={{ mb: 2 }}>
+            Automatic access is ready. SSH connections can use saved passwords
+            without asking for the master password.
+          </Alert>
+        ) : (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Automatic access needs repair. This can happen when the database is
+            restored without its companion device-key file.
+          </Alert>
+        )}
+
+        <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>
+          {!status.configured ? (
+            <Button
+              variant="contained"
+              startIcon={<PasswordOutlinedIcon />}
+              onClick={() => setDialogMode('create')}
+            >
+              Create password vault
+            </Button>
+          ) : (
+            <>
+              {!status.automaticAccess ? (
+                <Button
+                  variant="contained"
+                  onClick={() => setDialogMode('repair')}
+                >
+                  Repair automatic access
+                </Button>
+              ) : null}
+              <Button
+                variant="outlined"
+                onClick={() => setDialogMode('change')}
+              >
+                Change master password
+              </Button>
+              <Button
+                color="error"
+                disabled={busy}
+                onClick={() => void removeVault()}
+              >
+                Delete vault
+              </Button>
+            </>
+          )}
+        </Stack>
+      </Box>
+
+      {status.configured ? (
+        <Box>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+            Saved SSH passwords
+          </Typography>
+          {status.credentials.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              None yet. Select “Remember this password” the next time SSH asks
+              for one.
+            </Typography>
+          ) : (
+            <List disablePadding>
+              {status.credentials.map((credential) => (
+                <ListItem
+                  key={credential.id}
+                  divider
+                  disableGutters
+                  secondaryAction={
+                    <Stack direction="row">
+                      <Tooltip title="View or edit password">
+                        <IconButton
+                          edge="end"
+                          aria-label={`View or edit password for ${credential.label}`}
+                          onClick={() => setEditing(credential)}
+                        >
+                          <EditOutlinedIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Forget password">
+                        <IconButton
+                          edge="end"
+                          aria-label={`Forget password for ${credential.label}`}
+                          onClick={() =>
+                            void forget(credential.id, credential.label)
+                          }
+                        >
+                          <DeleteOutlineIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </Stack>
+                  }
+                >
+                  <ListItemText
+                    primary={credential.label}
+                    secondary={`Updated ${new Date(credential.updatedAt).toLocaleString()}`}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+      ) : null}
+
+      <Typography variant="caption" color="text.secondary">
+        Your master password is required to view or edit saved values. Routine
+        SSH connections use a separate local device key automatically. The
+        device key is stored beside the database, so protect your operating
+        system account and application-data directory. Two-factor codes and
+        private-key passphrases are never remembered.
+      </Typography>
+
+      {dialogMode ? (
+        <MasterPasswordDialog
+          key={dialogMode}
+          mode={dialogMode}
+          onClose={() => setDialogMode(undefined)}
+          onSaved={(next) => {
+            acceptStatus(next);
+            setDialogMode(undefined);
+            showToast(
+              'success',
+              dialogMode === 'create'
+                ? 'Password vault created.'
+                : dialogMode === 'repair'
+                  ? 'Automatic password access repaired.'
+                  : 'Master password changed.',
+            );
+          }}
+        />
+      ) : null}
+
+      {editing ? (
+        <EditSavedPasswordDialog
+          credential={editing}
+          onClose={() => setEditing(undefined)}
+          onSaved={(next) => {
+            acceptStatus(next);
+            setEditing(undefined);
+            showToast('success', `Updated the password for ${editing.label}.`);
+          }}
+        />
+      ) : null}
+    </Stack>
+  );
+}
+
+function MasterPasswordDialog({
+  mode,
+  onClose,
+  onSaved,
+}: {
+  mode: MasterDialogMode;
+  onClose: () => void;
+  onSaved: (status: PasswordVaultStatus) => void;
+}) {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [nextPassword, setNextPassword] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const [error, setError] = useState<string>();
+  const [saving, setSaving] = useState(false);
+
+  const creating = mode === 'create';
+  const changing = mode === 'change';
+  const proposed = creating ? currentPassword : nextPassword;
+
+  const submit = async () => {
+    if ((creating || changing) && Array.from(proposed).length < 8) {
+      setError('Use at least 8 characters for the master password.');
+      return;
+    }
+    if (
+      (creating || changing) &&
+      new TextEncoder().encode(proposed).byteLength > 1024
+    ) {
+      setError('The master password is too long.');
+      return;
+    }
+    if ((creating || changing) && proposed !== confirmation) {
+      setError('The master-password confirmation does not match.');
+      return;
+    }
+    setSaving(true);
+    setError(undefined);
+    try {
+      const status =
+        mode === 'create'
+          ? await createPasswordVault(currentPassword)
+          : mode === 'repair'
+            ? await repairPasswordVaultAutomaticAccess(currentPassword)
+            : await changeMasterPassword(currentPassword, nextPassword);
+      setCurrentPassword('');
+      setNextPassword('');
+      setConfirmation('');
+      onSaved(status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const title =
+    mode === 'create'
+      ? 'Create password vault'
+      : mode === 'repair'
+        ? 'Repair automatic access'
+        : 'Change master password';
+
+  return (
+    <Dialog open onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          {creating ? (
+            <Typography variant="body2" color="text.secondary">
+              Use at least 8 characters. This password will be required to view
+              or edit saved values, but not for routine SSH connections.
+            </Typography>
+          ) : null}
+          {mode === 'repair' ? (
+            <Typography variant="body2" color="text.secondary">
+              Enter the master password to link this database to a new local
+              device key.
+            </Typography>
+          ) : null}
+          {error ? <Alert severity="error">{error}</Alert> : null}
+          <TextField
+            label={
+              changing ? 'Current master password' : 'Master password'
+            }
+            type="password"
+            autoComplete="off"
+            value={currentPassword}
+            onChange={(event) => setCurrentPassword(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && mode === 'repair') void submit();
+            }}
+          />
+          {changing ? (
+            <TextField
+              label="New master password"
+              type="password"
+              autoComplete="off"
+              value={nextPassword}
+              onChange={(event) => setNextPassword(event.target.value)}
+            />
+          ) : null}
+          {creating || changing ? (
+            <TextField
+              label="Confirm master password"
+              type="password"
+              autoComplete="off"
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') void submit();
+              }}
+            />
+          ) : null}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button disabled={saving} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          disabled={saving}
+          onClick={() => void submit()}
+        >
+          {saving
+            ? 'Working…'
+            : mode === 'create'
+              ? 'Create vault'
+              : mode === 'repair'
+                ? 'Repair'
+                : 'Change password'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+function EditSavedPasswordDialog({
+  credential,
+  onClose,
+  onSaved,
+}: {
+  credential: PasswordVaultCredential;
+  onClose: () => void;
+  onSaved: (status: PasswordVaultStatus) => void;
+}) {
+  const [masterPassword, setMasterPassword] = useState('');
+  const [password, setPassword] = useState('');
+  const [revealed, setRevealed] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [error, setError] = useState<string>();
+  const [saving, setSaving] = useState(false);
+
+  const close = () => {
+    setMasterPassword('');
+    setPassword('');
+    setVisible(false);
+    onClose();
+  };
+
+  const reveal = async () => {
+    if (Array.from(masterPassword).length < 8) {
+      setError('Enter the master password.');
+      return;
+    }
+    setSaving(true);
+    setError(undefined);
+    try {
+      const result = await revealSavedPassword(
+        credential.id,
+        masterPassword,
+      );
+      setPassword(result.password);
+      setRevealed(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const save = async () => {
+    if (new TextEncoder().encode(password).byteLength > 8192) {
+      setError('The SSH password is too long to save.');
+      return;
+    }
+    setSaving(true);
+    setError(undefined);
+    try {
+      const status = await updateSavedPassword(
+        credential.id,
+        masterPassword,
+        password,
+      );
+      setMasterPassword('');
+      setPassword('');
+      onSaved(status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open onClose={saving ? undefined : close} maxWidth="xs" fullWidth>
+      <DialogTitle>View or edit saved password</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            {credential.label}
+          </Typography>
+          {error ? <Alert severity="error">{error}</Alert> : null}
+          {!revealed ? (
+            <TextField
+              label="Master password"
+              type="password"
+              autoComplete="off"
+              value={masterPassword}
+              onChange={(event) => setMasterPassword(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') void reveal();
+              }}
+            />
+          ) : (
+            <TextField
+              label="SSH password"
+              type={visible ? 'text' : 'password'}
+              autoComplete="off"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        aria-label={
+                          visible ? 'Hide saved password' : 'Show saved password'
+                        }
+                        edge="end"
+                        onClick={() => setVisible((current) => !current)}
+                      >
+                        {visible ? (
+                          <VisibilityOffOutlinedIcon />
+                        ) : (
+                          <VisibilityOutlinedIcon />
+                        )}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') void save();
+              }}
+            />
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button disabled={saving} onClick={close}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          disabled={saving}
+          onClick={() => void (revealed ? save() : reveal())}
+        >
+          {saving ? 'Working…' : revealed ? 'Save password' : 'Continue'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/PasswordVaultSection.tsx
+++ b/client/src/components/PasswordVaultSection.tsx
@@ -84,7 +84,7 @@ export function PasswordVaultSection() {
     const confirmed = await confirmAction({
       title: 'Delete the password vault?',
       description:
-        'Every saved SSH password will be securely removed from the active database and OS credential store. Existing backups or filesystem snapshots are not affected. Connection profiles and SSH keys are not affected.',
+        'Every saved SSH password will be securely removed from the active database. Muxus also removes the OS credential-store copy when that store is available. No master password is required, so deletion remains possible if it is forgotten. Existing backups or filesystem snapshots are not affected. Connection profiles and SSH keys are not affected.',
       confirmLabel: 'Delete vault',
       destructive: true,
     });
@@ -521,7 +521,9 @@ function EditSavedPasswordDialog({
   };
 
   const reveal = async () => {
-    if (Array.from(masterPassword).length < 8) {
+    // Legacy v2 vaults accepted eight-character passwords. Let the server
+    // apply the format-specific minimum instead of duplicating it here.
+    if (masterPassword.length === 0) {
       setError('Enter the master password.');
       return;
     }

--- a/client/src/components/PasswordVaultStartupUnlock.tsx
+++ b/client/src/components/PasswordVaultStartupUnlock.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useQueryClient } from '@tanstack/react-query';
+import { unlockPasswordVault } from '../api/password-vault.js';
+import { usePasswordVaultStatus } from '../api/password-vault-queries.js';
+import { shouldDelayWorkspaceRestoreForVault } from '../password-vault-startup.js';
+
+/** Resolve the startup vault policy before persisted sessions are restored. */
+export function PasswordVaultStartupUnlock({
+  onReady,
+}: {
+  onReady: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const result = usePasswordVaultStatus();
+  const [dismissed, setDismissed] = useState(false);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string>();
+  const [busy, setBusy] = useState(false);
+  const status = result.data;
+  const delayRestore = shouldDelayWorkspaceRestoreForVault({
+    status,
+    pending: result.isPending,
+    failed: result.isError,
+  });
+  const ready = dismissed || !delayRestore;
+
+  useEffect(() => {
+    if (ready) onReady();
+  }, [onReady, ready]);
+
+  if (ready || !status) return null;
+
+  const unlock = async () => {
+    setBusy(true);
+    setError(undefined);
+    try {
+      const next = await unlockPasswordVault(password);
+      setPassword('');
+      queryClient.setQueryData(['password-vault'], next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const dismiss = () => {
+    setPassword('');
+    setError(undefined);
+    setDismissed(true);
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={busy ? undefined : dismiss}
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle>Unlock password vault</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Enter the master password once to use saved SSH passwords until
+            Muxus exits.
+          </Typography>
+          {error ? <Alert severity="error">{error}</Alert> : null}
+          <TextField
+            label="Master password"
+            type="password"
+            autoComplete="off"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') void unlock();
+            }}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button disabled={busy} onClick={dismiss}>
+          Not now
+        </Button>
+        <Button
+          variant="contained"
+          disabled={busy || password.length === 0}
+          onClick={() => void unlock()}
+        >
+          {busy ? 'Unlocking…' : 'Unlock'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/QuickLauncherDialog.tsx
+++ b/client/src/components/QuickLauncherDialog.tsx
@@ -82,7 +82,11 @@ import { useWorkspacesStore } from '../state/workspaces.js';
 import { terminalHandle } from '../terminal/terminal-registry.js';
 import { formatTimestamp } from '../time-format.js';
 import { openWorkspace } from '../workspace-persistence.js';
-import { AuthPromptDialog, type AuthPromptRequest } from './AuthPromptDialog.js';
+import {
+  AuthPromptDialog,
+  type AuthPromptRequest,
+  type AuthPromptResult,
+} from './AuthPromptDialog.js';
 import { chordSx } from './chord-style.js';
 import { HostKeyDialog, type HostKeyRequest } from './HostKeyDialog.js';
 
@@ -150,7 +154,7 @@ export function QuickLauncherDialog() {
   const [busyResultId, setBusyResultId] = useState<string>();
   const [dialAuth, setDialAuth] = useState<{
     request: AuthPromptRequest;
-    resolve: (answers: string[] | null) => void;
+    resolve: (result: AuthPromptResult | null) => void;
   } | null>(null);
   const [dialHostKey, setDialHostKey] = useState<{
     request: HostKeyRequest;
@@ -691,10 +695,10 @@ export function QuickLauncherDialog() {
 
       <AuthPromptDialog
         request={dialAuth?.request ?? null}
-        onSubmit={(answers) => {
+        onSubmit={(result) => {
           const pending = dialAuth;
           setDialAuth(null);
-          pending?.resolve(answers);
+          pending?.resolve(result);
         }}
       />
       <HostKeyDialog

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -34,6 +34,7 @@ import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import KeyboardOutlinedIcon from '@mui/icons-material/KeyboardOutlined';
 import BackupOutlinedIcon from '@mui/icons-material/BackupOutlined';
 import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
+import PasswordOutlinedIcon from '@mui/icons-material/PasswordOutlined';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
 import type { UpdateCheckResult } from '@muxus/shared';
@@ -69,6 +70,7 @@ import { KeywordHighlightRulesEditor } from './KeywordHighlightRulesEditor.js';
 import { SessionLoggingPolicyFields } from './SessionLoggingPolicyFields.js';
 import { DataTransferSection } from './DataTransferSection.js';
 import { MobaXtermImportDialog } from './MobaXtermImportDialog.js';
+import { PasswordVaultSection } from './PasswordVaultSection.js';
 
 type Section =
   | 'appearance'
@@ -77,6 +79,7 @@ type Section =
   | 'highlighting'
   | 'behavior'
   | 'keyboard'
+  | 'passwords'
   | 'data'
   | 'about';
 
@@ -87,6 +90,7 @@ const SECTIONS: Array<{ id: Section; label: string; icon: React.ReactNode }> = [
   { id: 'highlighting', label: 'Highlighting', icon: <HighlightOutlinedIcon fontSize="small" /> },
   { id: 'behavior', label: 'Behavior', icon: <TuneOutlinedIcon fontSize="small" /> },
   { id: 'keyboard', label: 'Keyboard', icon: <KeyboardOutlinedIcon fontSize="small" /> },
+  { id: 'passwords', label: 'Passwords', icon: <PasswordOutlinedIcon fontSize="small" /> },
   { id: 'data', label: 'Backup & data', icon: <BackupOutlinedIcon fontSize="small" /> },
   { id: 'about', label: 'About', icon: <InfoOutlinedIcon fontSize="small" /> },
 ];
@@ -188,6 +192,7 @@ export function SettingsDialog() {
             {section === 'highlighting' && <HighlightingSection />}
             {section === 'behavior' && <BehaviorSection />}
             {section === 'keyboard' && <KeyboardSection />}
+            {section === 'passwords' && <PasswordVaultSection />}
             {section === 'data' && (
               <DataTransferSection
                 onImportMobaXterm={() => setMobaXtermImportOpen(true)}

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -53,7 +53,11 @@ import {
 import { registerTerminal } from '../terminal/terminal-registry.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
-import { AuthPromptDialog, type AuthPromptRequest } from './AuthPromptDialog.js';
+import {
+  AuthPromptDialog,
+  type AuthPromptRequest,
+  type AuthPromptResult,
+} from './AuthPromptDialog.js';
 import { HostKeyDialog, type HostKeyRequest } from './HostKeyDialog.js';
 import { PasteConfirmDialog } from './PasteConfirmDialog.js';
 import {
@@ -596,7 +600,15 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             break;
           case 'auth-prompt':
             sawAuthPrompt = true;
-            setAuthPrompt({ name: ctl.name, instructions: ctl.instructions, host: ctl.host, prompts: ctl.prompts });
+            setAuthPrompt({
+              name: ctl.name,
+              instructions: ctl.instructions,
+              host: ctl.host,
+              prompts: ctl.prompts,
+              purpose: ctl.purpose,
+              rememberPassword: ctl.rememberPassword,
+              skipLabel: ctl.skipLabel,
+            });
             break;
           case 'host-key':
             setHostKey(ctl);
@@ -915,12 +927,12 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     }
   }, [active, generation]);
 
-  const answerAuth = (answers: string[] | null) => {
+  const answerAuth = (response: AuthPromptResult | null) => {
     setAuthPrompt(null);
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    if (answers === null) ws.close();
-    else ws.send(JSON.stringify({ op: 'auth-response', answers }));
+    if (response === null) ws.close();
+    else ws.send(JSON.stringify({ op: 'auth-response', ...response }));
   };
 
   const answerHostKey = (accept: boolean) => {

--- a/client/src/components/TunnelEditorDialog.tsx
+++ b/client/src/components/TunnelEditorDialog.tsx
@@ -277,8 +277,9 @@ function TunnelEditorForm({
                   />
                 </ProfileAccordion>
                 <Typography variant="caption" color="text.secondary">
-                  Passwords and key passphrases are never saved; Muxus asks for
-                  them when the tunnel starts.
+                  Muxus asks when the tunnel starts. SSH password prompts can
+                  save an accepted password in the password vault; key
+                  passphrases and 2FA answers remain transient.
                 </Typography>
               </Stack>
             )}

--- a/client/src/password-vault-startup.ts
+++ b/client/src/password-vault-startup.ts
@@ -1,0 +1,24 @@
+import type { PasswordVaultStatus } from '@muxus/shared';
+
+/**
+ * Restored remote sessions must not dial while the startup-policy prompt is
+ * unresolved. Otherwise the session and the app-level prompt both ask for the
+ * same master password.
+ */
+export function shouldDelayWorkspaceRestoreForVault({
+  status,
+  pending,
+  failed,
+}: {
+  status: PasswordVaultStatus | undefined;
+  pending: boolean;
+  failed: boolean;
+}): boolean {
+  if (failed) return false;
+  if (pending || !status) return true;
+  return (
+    status.configured &&
+    status.unlockPolicy === 'startup' &&
+    status.locked
+  );
+}

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -46,9 +46,10 @@ The application database is in the platform data directory (`~/.local/share/muxu
 
 Not by default. Passwords are transient unless **Remember this password** is selected on
 an SSH password prompt. Remembering creates the platform-independent password vault and
-writes authenticated ciphertext to the local database. A companion local device key lets
-SSH use the password automatically after future launches; the master password is required
-to view or edit the saved value and is never stored. Private-key passphrases, 2FA codes
+writes authenticated ciphertext to the local database. The prompt policy can use the OS
+credential store (the default), ask once at startup, or ask whenever a credential is
+needed. The master password is always required to view or edit the saved value and is
+never stored. Private-key passphrases, 2FA codes
 and keyboard-interactive answers are never remembered. See the
 [security model](../reference/security.md#password-vault).
 

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -44,9 +44,13 @@ The application database is in the platform data directory (`~/.local/share/muxu
 
 ### Are my passwords stored anywhere?
 
-No. They exist only for the duration of an authentication attempt. The persistence layer
-rejects fields that look like credentials, so a password cannot be written to the database
-by accident.
+Not by default. Passwords are transient unless **Remember this password** is selected on
+an SSH password prompt. Remembering creates the platform-independent password vault and
+writes authenticated ciphertext to the local database. A companion local device key lets
+SSH use the password automatically after future launches; the master password is required
+to view or edit the saved value and is never stored. Private-key passphrases, 2FA codes
+and keyboard-interactive answers are never remembered. See the
+[security model](../reference/security.md#password-vault).
 
 ### Why is session logging off by default?
 

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -65,10 +65,11 @@ so routine SSH use does not prompt for the master password. In **Settings → Pa
 the policy can instead ask once when Muxus starts or whenever a saved credential is
 needed. The master password is always required to view or edit saved values.
 
-If a never-prompt vault is restored without its OS credential-store entry, automatic use
-pauses until **Restore OS access** is completed with the master password. Private-key
-passphrases, keyboard-interactive answers and 2FA codes remain transient and are never
-remembered. See the
+If a never-prompt vault is restored without its OS credential-store entry, the next saved
+password use asks for the master password and attempts to restore automatic access. The
+credential can still be used for that connection if the OS store remains unavailable;
+the prompt policy can also be changed or the vault reset. Private-key passphrases,
+keyboard-interactive answers and 2FA codes remain transient and are never remembered. See the
 [security model](../reference/security.md#password-vault).
 
 ## Jump chains and ProxyCommand

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -58,9 +58,16 @@ succeeds:
   <figcaption>Each prompt names the hop that issued it, which identifies the hop in a jump chain.</figcaption>
 </figure>
 
-Passwords and passphrases are transient. They exist only for the duration of the
-authentication attempt, and the persistence layer refuses to store them. See the
-[security model](../reference/security.md).
+An SSH password prompt offers **Remember this password**. The password is saved only after
+authentication succeeds. The first save creates a vault and asks for a master password of
+at least eight characters. Later launches use the saved password automatically; the master
+password is required only to view or edit saved values in **Settings → Passwords**.
+
+If the database is restored without its companion device-key file, automatic use pauses
+until **Repair automatic access** is completed with the master password. Private-key
+passphrases, keyboard-interactive answers and 2FA codes remain transient and are never
+remembered. See the
+[security model](../reference/security.md#password-vault).
 
 ## Jump chains and ProxyCommand
 

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -60,11 +60,13 @@ succeeds:
 
 An SSH password prompt offers **Remember this password**. The password is saved only after
 authentication succeeds. The first save creates a vault and asks for a master password of
-at least eight characters. Later launches use the saved password automatically; the master
-password is required only to view or edit saved values in **Settings → Passwords**.
+at least twelve characters. By default, the vault key is kept in the OS credential store,
+so routine SSH use does not prompt for the master password. In **Settings → Passwords**,
+the policy can instead ask once when Muxus starts or whenever a saved credential is
+needed. The master password is always required to view or edit saved values.
 
-If the database is restored without its companion device-key file, automatic use pauses
-until **Repair automatic access** is completed with the master password. Private-key
+If a never-prompt vault is restored without its OS credential-store entry, automatic use
+pauses until **Restore OS access** is completed with the master password. Private-key
 passphrases, keyboard-interactive answers and 2FA codes remain transient and are never
 remembered. See the
 [security model](../reference/security.md#password-vault).

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -94,24 +94,25 @@ second chord, and defaults are restored in one click. The sheet is also reachabl
 
 ## Passwords
 
-The password vault is optional and works the same way on Windows, macOS and Linux;
-it does not depend on an operating-system keyring.
+The password vault is optional. New vaults default to the never-prompt policy, which uses
+the operating-system credential store.
 
-- **Create password vault** sets a master password of at least 8 characters.
-- SSH connections use saved passwords automatically, including after restarting Muxus.
+- **Create password vault** sets a master password of at least 12 characters.
+- **Change prompt policy** chooses when routine SSH use needs the master password:
+  **Never for saved credentials** stores the vault key in the OS credential store,
+  **When Muxus starts** unlocks it into memory once, and **Whenever a saved credential is
+  needed** prompts for each use.
 - **View or edit password** asks for the master password before revealing the saved value.
 - **Change master password** changes that management password without rewriting every
   credential.
-- **Repair automatic access** appears if a database was restored without its companion
-  device-key file.
+- **Restore OS access** appears if the never-prompt policy is selected but the credential
+  store entry is missing.
 - Saved-password rows can be forgotten individually. **Delete vault** forgets all of them
   without removing hosts, keys or other settings.
 
 The master password cannot be recovered. Saved-password ciphertext is local to the
-application database, while the automatic-access device key is stored beside it. Neither
-is included in Muxus backups. Anyone who can copy the complete application-data directory
-can obtain both, so the master password protects the management interface rather than
-full-directory theft.
+application database and is not included in Muxus backups. The raw vault key is never
+stored in the application-data directory.
 
 ## Backup & data
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -11,7 +11,7 @@ because storage policy should not change under a running recorder.
 <figure markdown="span">
   ![The settings dialog](../assets/screenshots/settings.png#only-light){ .shadow }
   ![The settings dialog](../assets/screenshots/settings-dark.png#only-dark){ .shadow }
-  <figcaption>Eight sections, listed on the left. The footer states when changes apply.</figcaption>
+  <figcaption>Nine sections, listed on the left. The footer states when changes apply.</figcaption>
 </figure>
 
 ## Appearance
@@ -91,6 +91,27 @@ second chord, and defaults are restored in one click. The sheet is also reachabl
 ++ctrl+shift+slash++.
 
 [Every default chord :octicons-arrow-right-24:](../reference/keyboard-shortcuts.md)
+
+## Passwords
+
+The password vault is optional and works the same way on Windows, macOS and Linux;
+it does not depend on an operating-system keyring.
+
+- **Create password vault** sets a master password of at least 8 characters.
+- SSH connections use saved passwords automatically, including after restarting Muxus.
+- **View or edit password** asks for the master password before revealing the saved value.
+- **Change master password** changes that management password without rewriting every
+  credential.
+- **Repair automatic access** appears if a database was restored without its companion
+  device-key file.
+- Saved-password rows can be forgotten individually. **Delete vault** forgets all of them
+  without removing hosts, keys or other settings.
+
+The master password cannot be recovered. Saved-password ciphertext is local to the
+application database, while the automatic-access device key is stored beside it. Neither
+is included in Muxus backups. Anyone who can copy the complete application-data directory
+can obtain both, so the master password protects the management interface rather than
+full-directory theft.
 
 ## Backup & data
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -108,7 +108,8 @@ the operating-system credential store.
 - **Restore OS access** appears if the never-prompt policy is selected but the credential
   store entry is missing.
 - Saved-password rows can be forgotten individually. **Delete vault** forgets all of them
-  without removing hosts, keys or other settings.
+  without removing hosts, keys or other settings. Reset intentionally needs no master
+  password, so a forgotten password cannot make the vault impossible to remove.
 
 The master password cannot be recovered. Saved-password ciphertext is local to the
 application database and is not included in Muxus backups. The raw vault key is never

--- a/docs/install/desktop.md
+++ b/docs/install/desktop.md
@@ -85,8 +85,8 @@ The desktop app keeps its data in Electron's per-app directory:
 Session history, when enabled, is stored alongside it or at the location set in
 [Settings](../guide/settings.md). SSH connection settings still come from `~/.ssh/config`.
 Passwords you explicitly choose to remember are encrypted in the application database by
-the password vault. Its automatic-access device key is stored as
-`muxus-vault-device.key` in the same directory; see the
+the password vault. The raw vault key is never stored in this directory; the default
+never-prompt policy uses the OS credential store. See the
 [security model](../reference/security.md).
 
 Uninstalling the app leaves `~/.ssh` untouched.

--- a/docs/install/desktop.md
+++ b/docs/install/desktop.md
@@ -76,14 +76,17 @@ Installers are published on the
 
 The desktop app keeps its data in Electron's per-app directory:
 
-| Platform | Application database (folders, colours, workspaces, tunnels, saved Telnet/serial hosts) |
+| Platform | Application database (folders, colours, workspaces, tunnels, saved hosts, optional encrypted passwords) |
 | --- | --- |
 | :material-microsoft-windows: Windows | `%APPDATA%\Muxus\muxus.sqlite3` |
 | :material-apple: macOS | `~/Library/Application Support/Muxus/muxus.sqlite3` |
 | :material-linux: Linux | `~/.config/Muxus/muxus.sqlite3` |
 
 Session history, when enabled, is stored alongside it or at the location set in
-[Settings](../guide/settings.md). Connection settings are not stored there; they remain in
-`~/.ssh/config`.
+[Settings](../guide/settings.md). SSH connection settings still come from `~/.ssh/config`.
+Passwords you explicitly choose to remember are encrypted in the application database by
+the password vault. Its automatic-access device key is stored as
+`muxus-vault-device.key` in the same directory; see the
+[security model](../reference/security.md).
 
 Uninstalling the app leaves `~/.ssh` untouched.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -35,17 +35,58 @@ and history.
 ## What is stored, and what is refused
 
 The local SQLite database holds folders, colours, display names, sidebar order, workspaces,
-saved tunnels, saved Telnet/serial hosts, per-host highlighting and logging policy, and
-connection timestamps. It is created `0600` in a `0700` directory.
+saved tunnels, saved Telnet/serial hosts, per-host highlighting and logging policy,
+connection timestamps, and—only when the user opts in—encrypted SSH passwords. It is
+created `0600` in a `0700` directory.
 
-**Credential material is rejected at the persistence boundary.** Any object whose field
-names include `password`, `passphrase`, `secret`, `token` or `privateKey` is refused before
-it can be written. A field may hold a reference such as `identityFile` or `credentialId`,
-but not the secret itself. Passwords and passphrases exist in memory only for the duration
-of an authentication attempt.
+**Credential material is rejected from ordinary profile, tunnel and workspace data.**
+Objects whose field names include `password`, `passphrase`, `secret`, `token` or
+`privateKey` are refused at those persistence boundaries. The dedicated password-vault
+tables are the only place credential ciphertext can be written.
 
 Connection settings are not in the database. They remain in
 [`~/.ssh/config`](ssh-config.md).
+
+## Password vault
+
+Password saving is off until a vault is created. On a normal SSH password
+prompt, **Remember this password** saves the password only after the server accepts it.
+Private-key passphrases, keyboard-interactive answers and 2FA codes are never remembered.
+
+The vault is platform-independent:
+
+- a random 256-bit vault key encrypts each password with AES-256-GCM and a fresh nonce;
+- a random local device key wraps the vault key so SSH connections can use saved passwords
+  automatically, without a master-password prompt;
+- the master password is processed with scrypt (`N=32768`, `r=8`, `p=1`, and a random
+  128-bit salt) to create a second, independent wrap of the vault key;
+- revealing or editing a saved value, changing the master password, or repairing a missing
+  device-key association requires the master password;
+- changing the master password re-wraps the random vault key without decrypting and
+  rewriting every saved password;
+- the master password itself is never stored. It cannot be recovered; resetting the vault
+  deletes every saved password.
+
+The device key is stored in `muxus-vault-device.key` beside the database. On Unix it is
+created with mode `0600`; on Windows it inherits the protection of the user's application
+data directory. A copied database **without** that companion file does not provide
+automatic decryption and can be relinked only with the master password.
+
+!!! warning "Automatic use changes the threat model"
+
+    Someone who obtains the complete Muxus application-data directory—including both the
+    database and device-key file—can decrypt saved passwords without the master password.
+    The master password protects the normal **view and edit** interface; it is not a defence
+    against full local-account or application-data compromise. Protect the operating-system
+    account and disk accordingly.
+
+Vault and device keys are cleared from process memory at shutdown. JavaScript strings
+cannot be reliably erased, so a password may remain in garbage-collected memory for an
+unspecified short period after use. Malware controlling the logged-in session or Muxus can
+capture automatically used credentials.
+
+The portable Muxus backup format deliberately excludes the vault and all password
+ciphertext.
 
 ## Host keys
 
@@ -96,7 +137,9 @@ the window loads is served from the local server.
   installed version in its user agent and can only direct downloads to the Muxus GitHub
   releases page.
 - It does not proxy traffic through anything.
-- It does not store passwords.
+- It does not store a password unless the user explicitly selects **Remember this
+  password**. A master password protects viewing and editing; a local device key permits
+  automatic SSH use.
 - It does not run as a service or accept connections from other machines.
 
 ## Reporting a problem

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -53,37 +53,46 @@ Password saving is off until a vault is created. On a normal SSH password
 prompt, **Remember this password** saves the password only after the server accepts it.
 Private-key passphrases, keyboard-interactive answers and 2FA codes are never remembered.
 
-The vault is platform-independent:
+New vaults default to **Never**, using the platform credential store. The vault works as
+follows:
 
 - a random 256-bit vault key encrypts each password with AES-256-GCM and a fresh nonce;
-- a random local device key wraps the vault key so SSH connections can use saved passwords
-  automatically, without a master-password prompt;
-- the master password is processed with scrypt (`N=32768`, `r=8`, `p=1`, and a random
-  128-bit salt) to create a second, independent wrap of the vault key;
-- revealing or editing a saved value, changing the master password, or repairing a missing
-  device-key association requires the master password;
+- the master password is processed with scrypt (`N=131072`, `r=8`, `p=1`, and a random
+  128-bit salt) to wrap the vault key in the database;
+- **Never** stores the raw vault key in Windows Credential Manager, macOS Keychain, or
+  Linux Secret Service/kernel keyring;
+- **When Muxus starts** keeps the unwrapped key only in process memory after one prompt;
+- **Whenever a saved credential is needed** unwraps the key for one operation and then
+  clears it;
+- revealing or editing a saved value and changing the master password always require the
+  master password;
 - changing the master password re-wraps the random vault key without decrypting and
   rewriting every saved password;
 - the master password itself is never stored. It cannot be recovered; resetting the vault
   deletes every saved password.
 
-The device key is stored in `muxus-vault-device.key` beside the database. On Unix it is
-created with mode `0600`; on Windows it inherits the protection of the user's application
-data directory. A copied database **without** that companion file does not provide
-automatic decryption and can be relinked only with the master password.
+There is no application-owned key file. A copied database does not contain a directly
+usable vault key and can be unlocked only with the master password. On Linux, **Never**
+requires an available OS keyring implementation; desktop environments commonly provide
+one through GNOME Keyring, KWallet or another Secret Service-compatible daemon. Muxus does
+not fall back to a plaintext or application-owned key file.
 
-!!! warning "Automatic use changes the threat model"
+!!! warning "Never-prompt use changes the threat model"
 
-    Someone who obtains the complete Muxus application-data directory—including both the
-    database and device-key file—can decrypt saved passwords without the master password.
-    The master password protects the normal **view and edit** interface; it is not a defence
-    against full local-account or application-data compromise. Protect the operating-system
-    account and disk accordingly.
+    Software running as the same logged-in user may be able to ask the OS credential store
+    for the vault key. The master password protects the normal **view and edit** interface;
+    it is not a defence against malware controlling the user session or Muxus itself.
+    Choose a prompt policy that matches the local-account threat model.
 
-Vault and device keys are cleared from process memory at shutdown. JavaScript strings
-cannot be reliably erased, so a password may remain in garbage-collected memory for an
-unspecified short period after use. Malware controlling the logged-in session or Muxus can
-capture automatically used credentials.
+Vault keys are cleared from process memory at shutdown and after each operation under the
+per-credential policy. JavaScript strings cannot be reliably erased, so a password may
+remain in garbage-collected memory for an unspecified short period after use. Malware
+controlling the logged-in session or Muxus can capture credentials while they are used.
+
+Deleting a credential enables SQLite secure deletion, checkpoints and truncates the WAL.
+Deleting the whole vault additionally compacts the active database and removes its OS
+credential-store entry. Existing backups, filesystem snapshots, storage-device remapping
+and forensic copies are outside that guarantee.
 
 The portable Muxus backup format deliberately excludes the vault and all password
 ciphertext.
@@ -138,8 +147,8 @@ the window loads is served from the local server.
   releases page.
 - It does not proxy traffic through anything.
 - It does not store a password unless the user explicitly selects **Remember this
-  password**. A master password protects viewing and editing; a local device key permits
-  automatic SSH use.
+  password**. A master password protects viewing and editing, and the configured prompt
+  policy controls routine SSH use.
 - It does not run as a service or accept connections from other machines.
 
 ## Reporting a problem

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -69,7 +69,7 @@ follows:
 - changing the master password re-wraps the random vault key without decrypting and
   rewriting every saved password;
 - the master password itself is never stored. It cannot be recovered; resetting the vault
-  deletes every saved password.
+  deliberately requires no master password and deletes every saved password.
 
 There is no application-owned key file. A copied database does not contain a directly
 usable vault key and can be unlocked only with the master password. On Linux, **Never**
@@ -90,9 +90,12 @@ remain in garbage-collected memory for an unspecified short period after use. Ma
 controlling the logged-in session or Muxus can capture credentials while they are used.
 
 Deleting a credential enables SQLite secure deletion, checkpoints and truncates the WAL.
-Deleting the whole vault additionally compacts the active database and removes its OS
-credential-store entry. Existing backups, filesystem snapshots, storage-device remapping
-and forensic copies are outside that guarantee.
+Deleting the whole vault additionally compacts the active database and attempts to remove
+its OS credential-store entry. Reset still completes if the credential store is
+unavailable, because the orphaned random key has no ciphertext or vault metadata to open.
+An existing backup paired with an entry that could not be removed may still be usable;
+backups, filesystem snapshots, storage-device remapping and forensic copies are outside
+the deletion guarantee.
 
 The portable Muxus backup format deliberately excludes the vault and all password
 ciphertext.

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -105,7 +105,10 @@ Its own database holds only what OpenSSH has no field for:
 - display name, folder, colour and sidebar order;
 - per-host keyword-highlighting rules and session-logging policy;
 - last-connected timestamps and connection counts;
-- workspaces, saved tunnels, and saved Telnet/serial hosts.
+- workspaces, saved tunnels, and saved Telnet/serial hosts;
+- opt-in SSH password ciphertext in the password vault.
 
-Passwords, passphrases and private keys are **never** stored. The persistence layer rejects
-them. See the [security model](security.md).
+Unencrypted passwords, passphrases and private keys are never stored. Private-key
+passphrases and 2FA answers are always transient; an SSH password is persisted only when
+**Remember this password** is selected. See the
+[security model](security.md#password-vault).

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -32,6 +32,9 @@ mac:
   # Native modules ship both Darwin prebuilds in each architecture package.
   # They are already architecture-specific (or universal), so do not lipo them again.
   x64ArchFiles: "**/prebuilds/darwin*/**"
+  # The keyring binding uses separate package names for Darwin x64 and arm64.
+  # Preserve both architecture-only package trees when merging their ASARs.
+  singleArchFiles: "**/node_modules/@napi-rs/keyring-darwin-*{,/**}"
   target:
     - target: dmg
       arch: [universal]

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -29,9 +29,11 @@ mac:
   category: public.app-category.developer-tools
   identity: null
   notarize: false
-  # Native modules ship both Darwin prebuilds in each architecture package.
-  # They are already architecture-specific (or universal), so do not lipo them again.
-  x64ArchFiles: "**/prebuilds/darwin*/**"
+  # Native modules ship both Darwin prebuilds in each architecture package,
+  # and the keyring binding ships one single-arch package per CPU with both
+  # bundled into each slice. All are already architecture-specific, so do not
+  # lipo them again.
+  x64ArchFiles: "{**/prebuilds/darwin*/**,**/node_modules/@napi-rs/keyring-darwin-*/**}"
   # The keyring binding uses separate package names for Darwin x64 and arm64.
   # Preserve both architecture-only package trees when merging their ASARs.
   singleArchFiles: "**/node_modules/@napi-rs/keyring-darwin-*{,/**}"

--- a/electron/esbuild.config.mjs
+++ b/electron/esbuild.config.mjs
@@ -15,7 +15,16 @@ await build({
   sourcemap: true,
   // bufferutil/utf-8-validate are optional ws natives we don't install;
   // cpu-features/sshcrypto are ssh2's optional native accelerators.
-  external: ['electron', 'node-pty', 'serialport', 'bufferutil', 'utf-8-validate', 'cpu-features', './crypto/build/Release/sshcrypto.node'],
+  external: [
+    'electron',
+    '@napi-rs/keyring',
+    'node-pty',
+    'serialport',
+    'bufferutil',
+    'utf-8-validate',
+    'cpu-features',
+    './crypto/build/Release/sshcrypto.node',
+  ],
   define: { 'process.env.NODE_ENV': '"production"' },
   banner: {
     // CJS deps converted into the ESM bundle still call require() and read

--- a/electron/package.json
+++ b/electron/package.json
@@ -22,8 +22,22 @@
   },
   "dependencies": {
     "@muxus/shared": "workspace:*",
+    "@napi-rs/keyring": "^1.3.0",
     "node-pty": "^1.1.0",
     "serialport": "^13.0.0"
+  },
+  "optionalDependencies": {
+    "@napi-rs/keyring-darwin-arm64": "1.3.0",
+    "@napi-rs/keyring-darwin-x64": "1.3.0",
+    "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+    "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+    "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+    "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+    "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+    "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+    "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+    "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+    "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
+  dompurify@>=3.4.0 <3.4.12: 3.4.12
+
 importers:
 
   .:
@@ -108,6 +112,9 @@ importers:
       '@muxus/shared':
         specifier: workspace:*
         version: link:../shared
+      '@napi-rs/keyring':
+        specifier: ^1.3.0
+        version: 1.3.0
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -142,18 +149,55 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-darwin-x64':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-linux-x64-musl':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc':
+        specifier: 1.3.0
+        version: 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc':
+        specifier: 1.3.0
+        version: 1.3.0
 
   server:
     dependencies:
       '@fastify/static':
-        specifier: ^10.1.0
-        version: 10.1.1
+        specifier: ^10.1.2
+        version: 10.1.2
       '@fastify/websocket':
         specifier: ^11.3.0
         version: 11.3.0
       '@muxus/shared':
         specifier: workspace:*
         version: link:../shared
+      '@napi-rs/keyring':
+        specifier: ^1.3.0
+        version: 1.3.0
       fastify:
         specifier: ^5.10.0
         version: 5.10.0
@@ -582,8 +626,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@10.1.1':
-    resolution: {integrity: sha512-ZQnXbBrI7FMUVpKGi00nVe86K17aAliC1Cyqt2UAe9ugYGW7itatVjx79d0jAjnY0HuEpoRwGTkYx/40rAugOw==}
+  '@fastify/static@10.1.2':
+    resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
 
   '@fastify/websocket@11.3.0':
     resolution: {integrity: sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==}
@@ -885,6 +929,87 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1643,9 +1768,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1865,8 +1990,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -3689,7 +3814,7 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@10.1.1':
+  '@fastify/static@10.1.2':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       '@fastify/error': 4.2.0
@@ -3948,6 +4073,57 @@ snapshots:
       react-is: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -4547,7 +4723,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4762,7 +4938,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.8:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5426,7 +5602,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -5454,7 +5630,7 @@ snapshots:
 
   monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.4.12
       marked: 14.0.0
 
   ms@2.1.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ packages:
   - tests
 # Keep local lockfile updates aligned with pnpm 11's CI supply-chain policy.
 minimumReleaseAge: 1440
+overrides:
+  'brace-expansion@>=5.0.0 <5.0.8': 5.0.8
+  'dompurify@>=3.4.0 <3.4.12': 3.4.12
 allowBuilds:
   esbuild: true
   electron: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,12 @@ packages:
   - tests
 # Keep local lockfile updates aligned with pnpm 11's CI supply-chain policy.
 minimumReleaseAge: 1440
+# Install per-arch native prebuilds (notably @napi-rs/keyring-darwin-*) for
+# both desktop CPUs so the macOS universal build can bundle the x64 slice
+# even though release runners are arm64.
+supportedArchitectures:
+  os: [current]
+  cpu: [current, x64, arm64]
 overrides:
   'brace-expansion@>=5.0.0 <5.0.8': 5.0.8
   'dompurify@>=3.4.0 <3.4.12': 3.4.12

--- a/server/package.json
+++ b/server/package.json
@@ -13,9 +13,10 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@fastify/static": "^10.1.0",
+    "@fastify/static": "^10.1.2",
     "@fastify/websocket": "^11.3.0",
     "@muxus/shared": "workspace:*",
+    "@napi-rs/keyring": "^1.3.0",
     "fastify": "^5.10.0",
     "nanoid": "^6.0.0",
     "node-pty": "^1.1.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -66,6 +66,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
 
   const database = new MuxusDatabase(config.databasePath);
   const vault = new PasswordVault(database);
+  await vault.initialize();
   const connections = new SshConnectionManager(app.log, { vault });
   const forwards = new ForwardManager(connections, app.log);
   const historySettings = database.sessionHistorySettings();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -23,10 +23,12 @@ import { registerSerialRoutes } from './routes/serial.js';
 import { registerProfileRoutes } from './routes/profiles.js';
 import { registerHostOrderRoutes } from './routes/host-order.js';
 import { registerSessionHistoryRoutes } from './routes/session-history.js';
+import { registerPasswordVaultRoutes } from './routes/password-vault.js';
 import {
   defaultHistoryRoot,
   SessionHistoryStore,
 } from './session-logging/history-store.js';
+import { PasswordVault } from './security/password-vault.js';
 
 export interface AppContext {
   config: ServerConfig;
@@ -34,6 +36,7 @@ export interface AppContext {
   forwards: ForwardManager;
   database: MuxusDatabase;
   history: SessionHistoryStore;
+  vault: PasswordVault;
 }
 
 // Not named __dirname: the Electron esbuild bundle defines that identifier
@@ -61,9 +64,10 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
     },
   });
 
-  const connections = new SshConnectionManager(app.log);
-  const forwards = new ForwardManager(connections, app.log);
   const database = new MuxusDatabase(config.databasePath);
+  const vault = new PasswordVault(database);
+  const connections = new SshConnectionManager(app.log, { vault });
+  const forwards = new ForwardManager(connections, app.log);
   const historySettings = database.sessionHistorySettings();
   const configuredHistoryRoot =
     config.historyPath ??
@@ -78,7 +82,14 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
     legacyDatabasePath: hadLegacyHistory ? config.databasePath : undefined,
   });
   database.finalizeSessionHistorySeparation(hadLegacyHistory);
-  const ctx: AppContext = { config, connections, forwards, database, history };
+  const ctx: AppContext = {
+    config,
+    connections,
+    forwards,
+    database,
+    history,
+    vault,
+  };
   database.pruneTerminalSnapshots();
 
   // SFTP uploads stream through as-is — no buffering, no size limit.
@@ -142,6 +153,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   registerProfileRoutes(app, ctx);
   registerHostOrderRoutes(app, ctx);
   registerSessionHistoryRoutes(app, ctx);
+  registerPasswordVaultRoutes(app, ctx);
   registerTerminalSocket(app, ctx);
   registerSftpLeaseSocket(app, ctx);
 
@@ -161,6 +173,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   app.addHook('onClose', async () => {
     forwards.stopAll();
     connections.closeAll();
+    vault.dispose();
     await history.close();
     database.close();
   });

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -327,6 +327,11 @@ const MIGRATIONS = [
     name: 'password-vault-os-keystore',
     run: migrateDraftPasswordVault,
   },
+  {
+    version: 15,
+    name: 'password-vault-key-check',
+    run: addPasswordVaultKeyCheck,
+  },
 ] as const;
 
 function migrateDraftPasswordVault(db: DatabaseSync): void {
@@ -374,6 +379,21 @@ function migrateDraftPasswordVault(db: DatabaseSync): void {
     FROM password_vault_draft_v13
   `).run(nanoid());
   db.exec('DROP TABLE password_vault_draft_v13');
+}
+
+function addPasswordVaultKeyCheck(db: DatabaseSync): void {
+  const columns = new Set(
+    db
+      .prepare('PRAGMA table_info(password_vault)')
+      .all()
+      .map((row) => String(row.name)),
+  );
+  if (columns.has('key_check')) return;
+  db.exec(`
+    ALTER TABLE password_vault
+      ADD COLUMN key_check BLOB
+      CHECK(key_check IS NULL OR length(key_check) = 32);
+  `);
 }
 
 const DEFAULT_SESSION_LOGGING_POLICY: SessionLoggingPolicyInput = {
@@ -428,6 +448,8 @@ export interface PasswordVaultConfigInput {
   masterKeyNonce: Buffer;
   masterKeyCiphertext: Buffer;
   masterKeyTag: Buffer;
+  /** HMAC proof for rejecting stale or corrupted OS credential-store keys. */
+  keyCheck?: Buffer;
 }
 
 export interface PasswordVaultConfigRecord extends PasswordVaultConfigInput {
@@ -441,6 +463,11 @@ export interface EncryptedCredentialInput extends CredentialRefInput {
   ciphertext: Buffer;
   authTag: Buffer;
 }
+
+export type EncryptedCredentialSecretInput = Omit<
+  EncryptedCredentialInput,
+  keyof CredentialRefInput
+>;
 
 export interface EncryptedCredentialRecord extends EncryptedCredentialInput {
   id: string;
@@ -744,8 +771,8 @@ export class MuxusDatabase {
           singleton, format_version, vault_id, unlock_policy,
           kdf_algorithm, kdf_salt, kdf_cost,
           kdf_block_size, kdf_parallelism, master_key_nonce,
-          master_key_ciphertext, master_key_tag
-        ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          master_key_ciphertext, master_key_tag, key_check
+        ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `)
       .run(
         input.formatVersion,
@@ -759,6 +786,7 @@ export class MuxusDatabase {
         input.masterKeyNonce,
         input.masterKeyCiphertext,
         input.masterKeyTag,
+        input.keyCheck ?? null,
       );
   }
 
@@ -770,7 +798,7 @@ export class MuxusDatabase {
             kdf_algorithm = ?, kdf_salt = ?,
             kdf_cost = ?, kdf_block_size = ?, kdf_parallelism = ?,
             master_key_nonce = ?, master_key_ciphertext = ?,
-            master_key_tag = ?,
+            master_key_tag = ?, key_check = ?,
             updated_at = CURRENT_TIMESTAMP
         WHERE singleton = 1
       `)
@@ -786,6 +814,7 @@ export class MuxusDatabase {
         input.masterKeyNonce,
         input.masterKeyCiphertext,
         input.masterKeyTag,
+        input.keyCheck ?? null,
       );
     if (Number(changed.changes) !== 1) throw new Error('password vault is not configured');
     this.flushSensitivePages();
@@ -842,9 +871,21 @@ export class MuxusDatabase {
   }
 
   upsertEncryptedCredential(input: EncryptedCredentialInput): EncryptedCredentialRecord {
+    return this.upsertEncryptedCredentialAtomically(input, () => input);
+  }
+
+  /**
+   * Reserve the credential reference and create its authenticated ciphertext
+   * in one transaction. If sealing throws, no reference-only row survives.
+   */
+  upsertEncryptedCredentialAtomically(
+    input: CredentialRefInput,
+    seal: (ref: CredentialRefRecord) => EncryptedCredentialSecretInput,
+  ): EncryptedCredentialRecord {
     this.db.exec('BEGIN IMMEDIATE');
     try {
       const ref = this.upsertCredentialRef(input);
+      const encrypted = seal(ref);
       this.db
         .prepare(`
           INSERT INTO credential_secrets(
@@ -859,10 +900,10 @@ export class MuxusDatabase {
         `)
         .run(
           ref.id,
-          input.formatVersion,
-          input.nonce,
-          input.ciphertext,
-          input.authTag,
+          encrypted.formatVersion,
+          encrypted.nonce,
+          encrypted.ciphertext,
+          encrypted.authTag,
         );
       this.db.exec('COMMIT');
     } catch (err) {
@@ -1549,6 +1590,10 @@ function passwordVaultConfigFromRow(row: SqlRow): PasswordVaultConfigRecord {
     masterKeyNonce: blob(row, 'master_key_nonce'),
     masterKeyCiphertext: blob(row, 'master_key_ciphertext'),
     masterKeyTag: blob(row, 'master_key_tag'),
+    keyCheck:
+      row.key_check instanceof Uint8Array
+        ? Buffer.from(row.key_check)
+        : undefined,
     createdAt: String(row.created_at),
     updatedAt: String(row.updated_at),
   };

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -11,6 +11,7 @@ import type {
   HostKeywordHighlightConfig,
   ManagedHostRef,
   OpenSshMetadataPatch,
+  PasswordVaultUnlockPolicy,
   SavedHostProfile,
   SavedHostProfileInput,
   SessionHistorySettings,
@@ -281,19 +282,22 @@ const MIGRATIONS = [
   },
   {
     version: 12,
-    name: 'master-password-vault',
+    name: 'password-vault',
     sql: `
       CREATE TABLE password_vault (
         singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
-        format_version INTEGER NOT NULL CHECK(format_version = 1),
-        kdf_algorithm TEXT NOT NULL CHECK(kdf_algorithm = 'argon2id'),
+        format_version INTEGER NOT NULL CHECK(format_version IN (2, 3)),
+        vault_id TEXT NOT NULL UNIQUE CHECK(length(vault_id) BETWEEN 16 AND 64),
+        unlock_policy TEXT NOT NULL
+          CHECK(unlock_policy IN ('never', 'startup', 'credential')),
+        kdf_algorithm TEXT NOT NULL CHECK(kdf_algorithm = 'scrypt'),
         kdf_salt BLOB NOT NULL CHECK(length(kdf_salt) = 16),
-        kdf_memory INTEGER NOT NULL CHECK(kdf_memory BETWEEN 8192 AND 1048576),
-        kdf_passes INTEGER NOT NULL CHECK(kdf_passes BETWEEN 2 AND 10),
-        kdf_parallelism INTEGER NOT NULL CHECK(kdf_parallelism BETWEEN 2 AND 16),
-        wrapped_key_nonce BLOB NOT NULL CHECK(length(wrapped_key_nonce) = 12),
-        wrapped_key_ciphertext BLOB NOT NULL CHECK(length(wrapped_key_ciphertext) = 32),
-        wrapped_key_tag BLOB NOT NULL CHECK(length(wrapped_key_tag) = 16),
+        kdf_cost INTEGER NOT NULL CHECK(kdf_cost BETWEEN 1024 AND 1048576),
+        kdf_block_size INTEGER NOT NULL CHECK(kdf_block_size BETWEEN 1 AND 32),
+        kdf_parallelism INTEGER NOT NULL CHECK(kdf_parallelism BETWEEN 1 AND 16),
+        master_key_nonce BLOB NOT NULL CHECK(length(master_key_nonce) = 12),
+        master_key_ciphertext BLOB NOT NULL CHECK(length(master_key_ciphertext) = 32),
+        master_key_tag BLOB NOT NULL CHECK(length(master_key_tag) = 16),
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
       ) STRICT;
@@ -311,34 +315,66 @@ const MIGRATIONS = [
     `,
   },
   {
+    // Version 13 existed briefly on the feature branch. Keep the number
+    // reserved so fresh databases and databases created by that draft can
+    // converge on the same migration history.
     version: 13,
     name: 'automatic-password-vault',
-    sql: `
-      DELETE FROM credential_refs
-      WHERE provider = 'muxus-master-vault';
-
-      DROP TABLE password_vault;
-
-      CREATE TABLE password_vault (
-        singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
-        format_version INTEGER NOT NULL CHECK(format_version = 2),
-        kdf_algorithm TEXT NOT NULL CHECK(kdf_algorithm = 'scrypt'),
-        kdf_salt BLOB NOT NULL CHECK(length(kdf_salt) = 16),
-        kdf_cost INTEGER NOT NULL CHECK(kdf_cost BETWEEN 1024 AND 1048576),
-        kdf_block_size INTEGER NOT NULL CHECK(kdf_block_size BETWEEN 1 AND 32),
-        kdf_parallelism INTEGER NOT NULL CHECK(kdf_parallelism BETWEEN 1 AND 16),
-        master_key_nonce BLOB NOT NULL CHECK(length(master_key_nonce) = 12),
-        master_key_ciphertext BLOB NOT NULL CHECK(length(master_key_ciphertext) = 32),
-        master_key_tag BLOB NOT NULL CHECK(length(master_key_tag) = 16),
-        device_key_nonce BLOB NOT NULL CHECK(length(device_key_nonce) = 12),
-        device_key_ciphertext BLOB NOT NULL CHECK(length(device_key_ciphertext) = 32),
-        device_key_tag BLOB NOT NULL CHECK(length(device_key_tag) = 16),
-        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-      ) STRICT;
-    `,
+    sql: 'SELECT 1;',
+  },
+  {
+    version: 14,
+    name: 'password-vault-os-keystore',
+    run: migrateDraftPasswordVault,
   },
 ] as const;
+
+function migrateDraftPasswordVault(db: DatabaseSync): void {
+  const columns = new Set(
+    db
+      .prepare('PRAGMA table_info(password_vault)')
+      .all()
+      .map((row) => String(row.name)),
+  );
+  if (!columns.has('device_key_nonce')) return;
+
+  db.exec(`
+    ALTER TABLE password_vault RENAME TO password_vault_draft_v13;
+
+    CREATE TABLE password_vault (
+      singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+      format_version INTEGER NOT NULL CHECK(format_version IN (2, 3)),
+      vault_id TEXT NOT NULL UNIQUE CHECK(length(vault_id) BETWEEN 16 AND 64),
+      unlock_policy TEXT NOT NULL
+        CHECK(unlock_policy IN ('never', 'startup', 'credential')),
+      kdf_algorithm TEXT NOT NULL CHECK(kdf_algorithm = 'scrypt'),
+      kdf_salt BLOB NOT NULL CHECK(length(kdf_salt) = 16),
+      kdf_cost INTEGER NOT NULL CHECK(kdf_cost BETWEEN 1024 AND 1048576),
+      kdf_block_size INTEGER NOT NULL CHECK(kdf_block_size BETWEEN 1 AND 32),
+      kdf_parallelism INTEGER NOT NULL CHECK(kdf_parallelism BETWEEN 1 AND 16),
+      master_key_nonce BLOB NOT NULL CHECK(length(master_key_nonce) = 12),
+      master_key_ciphertext BLOB NOT NULL CHECK(length(master_key_ciphertext) = 32),
+      master_key_tag BLOB NOT NULL CHECK(length(master_key_tag) = 16),
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) STRICT;
+  `);
+  db.prepare(`
+    INSERT INTO password_vault(
+      singleton, format_version, vault_id, unlock_policy,
+      kdf_algorithm, kdf_salt, kdf_cost, kdf_block_size,
+      kdf_parallelism, master_key_nonce, master_key_ciphertext,
+      master_key_tag, created_at, updated_at
+    )
+    SELECT
+      singleton, format_version, ?, 'startup',
+      kdf_algorithm, kdf_salt, kdf_cost, kdf_block_size,
+      kdf_parallelism, master_key_nonce, master_key_ciphertext,
+      master_key_tag, created_at, updated_at
+    FROM password_vault_draft_v13
+  `).run(nanoid());
+  db.exec('DROP TABLE password_vault_draft_v13');
+}
 
 const DEFAULT_SESSION_LOGGING_POLICY: SessionLoggingPolicyInput = {
   enabled: false,
@@ -381,7 +417,9 @@ export interface CredentialRefRecord extends CredentialRefInput {
 }
 
 export interface PasswordVaultConfigInput {
-  formatVersion: 2;
+  formatVersion: 2 | 3;
+  vaultId: string;
+  unlockPolicy: PasswordVaultUnlockPolicy;
   kdfAlgorithm: 'scrypt';
   kdfSalt: Buffer;
   kdfCost: number;
@@ -390,9 +428,6 @@ export interface PasswordVaultConfigInput {
   masterKeyNonce: Buffer;
   masterKeyCiphertext: Buffer;
   masterKeyTag: Buffer;
-  deviceKeyNonce: Buffer;
-  deviceKeyCiphertext: Buffer;
-  deviceKeyTag: Buffer;
 }
 
 export interface PasswordVaultConfigRecord extends PasswordVaultConfigInput {
@@ -495,7 +530,9 @@ export class MuxusDatabase {
         /* permissions may be controlled by the platform/filesystem */
       }
     }
-    this.db.exec('PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000;');
+    this.db.exec(
+      'PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000; PRAGMA secure_delete = ON;',
+    );
     if (filename !== ':memory:') this.db.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;');
     this.migrate();
     this.metadataByAlias = this.db.prepare(`
@@ -704,14 +741,16 @@ export class MuxusDatabase {
     this.db
       .prepare(`
         INSERT INTO password_vault(
-          singleton, format_version, kdf_algorithm, kdf_salt, kdf_cost,
+          singleton, format_version, vault_id, unlock_policy,
+          kdf_algorithm, kdf_salt, kdf_cost,
           kdf_block_size, kdf_parallelism, master_key_nonce,
-          master_key_ciphertext, master_key_tag, device_key_nonce,
-          device_key_ciphertext, device_key_tag
-        ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          master_key_ciphertext, master_key_tag
+        ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `)
       .run(
         input.formatVersion,
+        input.vaultId,
+        input.unlockPolicy,
         input.kdfAlgorithm,
         input.kdfSalt,
         input.kdfCost,
@@ -720,9 +759,6 @@ export class MuxusDatabase {
         input.masterKeyNonce,
         input.masterKeyCiphertext,
         input.masterKeyTag,
-        input.deviceKeyNonce,
-        input.deviceKeyCiphertext,
-        input.deviceKeyTag,
       );
   }
 
@@ -730,16 +766,18 @@ export class MuxusDatabase {
     const changed = this.db
       .prepare(`
         UPDATE password_vault
-        SET format_version = ?, kdf_algorithm = ?, kdf_salt = ?,
+        SET format_version = ?, vault_id = ?, unlock_policy = ?,
+            kdf_algorithm = ?, kdf_salt = ?,
             kdf_cost = ?, kdf_block_size = ?, kdf_parallelism = ?,
             master_key_nonce = ?, master_key_ciphertext = ?,
-            master_key_tag = ?, device_key_nonce = ?,
-            device_key_ciphertext = ?, device_key_tag = ?,
+            master_key_tag = ?,
             updated_at = CURRENT_TIMESTAMP
         WHERE singleton = 1
       `)
       .run(
         input.formatVersion,
+        input.vaultId,
+        input.unlockPolicy,
         input.kdfAlgorithm,
         input.kdfSalt,
         input.kdfCost,
@@ -748,11 +786,9 @@ export class MuxusDatabase {
         input.masterKeyNonce,
         input.masterKeyCiphertext,
         input.masterKeyTag,
-        input.deviceKeyNonce,
-        input.deviceKeyCiphertext,
-        input.deviceKeyTag,
       );
     if (Number(changed.changes) !== 1) throw new Error('password vault is not configured');
+    this.flushSensitivePages();
   }
 
   encryptedCredential(
@@ -829,21 +865,23 @@ export class MuxusDatabase {
           input.authTag,
         );
       this.db.exec('COMMIT');
-      return this.encryptedCredential(input.provider, input.service, input.account)!;
     } catch (err) {
       this.db.exec('ROLLBACK');
       throw err;
     }
+    this.flushSensitivePages();
+    return this.encryptedCredential(input.provider, input.service, input.account)!;
   }
 
   deleteEncryptedCredential(id: string, provider: string): boolean {
-    return (
+    const deleted =
       Number(
         this.db
           .prepare('DELETE FROM credential_refs WHERE id = ? AND provider = ?')
           .run(id, provider).changes,
-      ) === 1
-    );
+      ) === 1;
+    if (deleted) this.flushSensitivePages();
+    return deleted;
   }
 
   deletePasswordVaultData(provider: string): void {
@@ -855,6 +893,16 @@ export class MuxusDatabase {
     } catch (err) {
       this.db.exec('ROLLBACK');
       throw err;
+    }
+    this.flushSensitivePages(true);
+  }
+
+  private flushSensitivePages(compact = false): void {
+    if (this.filename === ':memory:') return;
+    this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    if (compact) {
+      this.db.exec('VACUUM');
+      this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
     }
   }
 
@@ -1463,7 +1511,8 @@ export class MuxusDatabase {
       if (applied.has(migration.version)) continue;
       this.db.exec('BEGIN IMMEDIATE');
       try {
-        this.db.exec(migration.sql);
+        if ('sql' in migration) this.db.exec(migration.sql);
+        else migration.run(this.db);
         this.db
           .prepare('INSERT INTO schema_migrations(version, name) VALUES (?, ?)')
           .run(migration.version, migration.name);
@@ -1487,7 +1536,11 @@ function blob(row: SqlRow, key: string): Buffer {
 
 function passwordVaultConfigFromRow(row: SqlRow): PasswordVaultConfigRecord {
   return {
-    formatVersion: Number(row.format_version) as 2,
+    formatVersion: Number(row.format_version) as 2 | 3,
+    vaultId: String(row.vault_id),
+    unlockPolicy: String(
+      row.unlock_policy,
+    ) as PasswordVaultConfigRecord['unlockPolicy'],
     kdfAlgorithm: String(row.kdf_algorithm) as 'scrypt',
     kdfSalt: blob(row, 'kdf_salt'),
     kdfCost: Number(row.kdf_cost),
@@ -1496,9 +1549,6 @@ function passwordVaultConfigFromRow(row: SqlRow): PasswordVaultConfigRecord {
     masterKeyNonce: blob(row, 'master_key_nonce'),
     masterKeyCiphertext: blob(row, 'master_key_ciphertext'),
     masterKeyTag: blob(row, 'master_key_tag'),
-    deviceKeyNonce: blob(row, 'device_key_nonce'),
-    deviceKeyCiphertext: blob(row, 'device_key_ciphertext'),
-    deviceKeyTag: blob(row, 'device_key_tag'),
     createdAt: String(row.created_at),
     updatedAt: String(row.updated_at),
   };

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -279,6 +279,65 @@ const MIGRATIONS = [
         CHECK(format_version >= 1);
     `,
   },
+  {
+    version: 12,
+    name: 'master-password-vault',
+    sql: `
+      CREATE TABLE password_vault (
+        singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+        format_version INTEGER NOT NULL CHECK(format_version = 1),
+        kdf_algorithm TEXT NOT NULL CHECK(kdf_algorithm = 'argon2id'),
+        kdf_salt BLOB NOT NULL CHECK(length(kdf_salt) = 16),
+        kdf_memory INTEGER NOT NULL CHECK(kdf_memory BETWEEN 8192 AND 1048576),
+        kdf_passes INTEGER NOT NULL CHECK(kdf_passes BETWEEN 2 AND 10),
+        kdf_parallelism INTEGER NOT NULL CHECK(kdf_parallelism BETWEEN 2 AND 16),
+        wrapped_key_nonce BLOB NOT NULL CHECK(length(wrapped_key_nonce) = 12),
+        wrapped_key_ciphertext BLOB NOT NULL CHECK(length(wrapped_key_ciphertext) = 32),
+        wrapped_key_tag BLOB NOT NULL CHECK(length(wrapped_key_tag) = 16),
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      ) STRICT;
+
+      CREATE TABLE credential_secrets (
+        credential_ref_id TEXT PRIMARY KEY
+          REFERENCES credential_refs(id) ON DELETE CASCADE,
+        format_version INTEGER NOT NULL CHECK(format_version = 1),
+        nonce BLOB NOT NULL CHECK(length(nonce) = 12),
+        ciphertext BLOB NOT NULL,
+        auth_tag BLOB NOT NULL CHECK(length(auth_tag) = 16),
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      ) STRICT;
+    `,
+  },
+  {
+    version: 13,
+    name: 'automatic-password-vault',
+    sql: `
+      DELETE FROM credential_refs
+      WHERE provider = 'muxus-master-vault';
+
+      DROP TABLE password_vault;
+
+      CREATE TABLE password_vault (
+        singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+        format_version INTEGER NOT NULL CHECK(format_version = 2),
+        kdf_algorithm TEXT NOT NULL CHECK(kdf_algorithm = 'scrypt'),
+        kdf_salt BLOB NOT NULL CHECK(length(kdf_salt) = 16),
+        kdf_cost INTEGER NOT NULL CHECK(kdf_cost BETWEEN 1024 AND 1048576),
+        kdf_block_size INTEGER NOT NULL CHECK(kdf_block_size BETWEEN 1 AND 32),
+        kdf_parallelism INTEGER NOT NULL CHECK(kdf_parallelism BETWEEN 1 AND 16),
+        master_key_nonce BLOB NOT NULL CHECK(length(master_key_nonce) = 12),
+        master_key_ciphertext BLOB NOT NULL CHECK(length(master_key_ciphertext) = 32),
+        master_key_tag BLOB NOT NULL CHECK(length(master_key_tag) = 16),
+        device_key_nonce BLOB NOT NULL CHECK(length(device_key_nonce) = 12),
+        device_key_ciphertext BLOB NOT NULL CHECK(length(device_key_ciphertext) = 32),
+        device_key_tag BLOB NOT NULL CHECK(length(device_key_tag) = 16),
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      ) STRICT;
+    `,
+  },
 ] as const;
 
 const DEFAULT_SESSION_LOGGING_POLICY: SessionLoggingPolicyInput = {
@@ -308,17 +367,50 @@ export interface NativeConnectionInput {
 }
 
 export interface CredentialRefInput {
-  /** Logical OS store adapter, for example "os-keychain". */
+  /** Logical credential provider, for example "muxus-master-vault". */
   provider: string;
-  /** Stable application/service namespace in that store. */
+  /** Stable application/service namespace in that provider. */
   service: string;
-  /** Account/key used to retrieve the secret from the OS store. */
+  /** Account/key used to retrieve the secret from the provider. */
   account: string;
   label?: string;
 }
 
 export interface CredentialRefRecord extends CredentialRefInput {
   id: string;
+}
+
+export interface PasswordVaultConfigInput {
+  formatVersion: 2;
+  kdfAlgorithm: 'scrypt';
+  kdfSalt: Buffer;
+  kdfCost: number;
+  kdfBlockSize: number;
+  kdfParallelism: number;
+  masterKeyNonce: Buffer;
+  masterKeyCiphertext: Buffer;
+  masterKeyTag: Buffer;
+  deviceKeyNonce: Buffer;
+  deviceKeyCiphertext: Buffer;
+  deviceKeyTag: Buffer;
+}
+
+export interface PasswordVaultConfigRecord extends PasswordVaultConfigInput {
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EncryptedCredentialInput extends CredentialRefInput {
+  formatVersion: 1;
+  nonce: Buffer;
+  ciphertext: Buffer;
+  authTag: Buffer;
+}
+
+export interface EncryptedCredentialRecord extends EncryptedCredentialInput {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface WorkspaceRecord {
@@ -379,7 +471,9 @@ export function assertSecretFree(value: unknown, location = 'config'): void {
     const referenceOnly =
       ['path', 'file', 'filename', 'ref', 'reference', 'id'].includes(words.at(-1) ?? '');
     if (sensitive && !referenceOnly) {
-      throw new Error(`${location}.${key} must be stored in the OS credential store, not the Muxus database`);
+      throw new Error(
+        `${location}.${key} must not be stored in profile or workspace data; use the encrypted password vault`,
+      );
     }
     assertSecretFree(child, `${location}.${key}`);
   }
@@ -598,6 +692,170 @@ export class MuxusDatabase {
       `)
       .run(id, input.provider, input.service, input.account, input.label?.trim() || null);
     return { id, ...input, label: input.label?.trim() || undefined };
+  }
+
+  passwordVaultConfig(): PasswordVaultConfigRecord | undefined {
+    const row = this.db.prepare('SELECT * FROM password_vault WHERE singleton = 1').get();
+    if (!row) return undefined;
+    return passwordVaultConfigFromRow(row);
+  }
+
+  createPasswordVaultConfig(input: PasswordVaultConfigInput): void {
+    this.db
+      .prepare(`
+        INSERT INTO password_vault(
+          singleton, format_version, kdf_algorithm, kdf_salt, kdf_cost,
+          kdf_block_size, kdf_parallelism, master_key_nonce,
+          master_key_ciphertext, master_key_tag, device_key_nonce,
+          device_key_ciphertext, device_key_tag
+        ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        input.formatVersion,
+        input.kdfAlgorithm,
+        input.kdfSalt,
+        input.kdfCost,
+        input.kdfBlockSize,
+        input.kdfParallelism,
+        input.masterKeyNonce,
+        input.masterKeyCiphertext,
+        input.masterKeyTag,
+        input.deviceKeyNonce,
+        input.deviceKeyCiphertext,
+        input.deviceKeyTag,
+      );
+  }
+
+  updatePasswordVaultConfig(input: PasswordVaultConfigInput): void {
+    const changed = this.db
+      .prepare(`
+        UPDATE password_vault
+        SET format_version = ?, kdf_algorithm = ?, kdf_salt = ?,
+            kdf_cost = ?, kdf_block_size = ?, kdf_parallelism = ?,
+            master_key_nonce = ?, master_key_ciphertext = ?,
+            master_key_tag = ?, device_key_nonce = ?,
+            device_key_ciphertext = ?, device_key_tag = ?,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE singleton = 1
+      `)
+      .run(
+        input.formatVersion,
+        input.kdfAlgorithm,
+        input.kdfSalt,
+        input.kdfCost,
+        input.kdfBlockSize,
+        input.kdfParallelism,
+        input.masterKeyNonce,
+        input.masterKeyCiphertext,
+        input.masterKeyTag,
+        input.deviceKeyNonce,
+        input.deviceKeyCiphertext,
+        input.deviceKeyTag,
+      );
+    if (Number(changed.changes) !== 1) throw new Error('password vault is not configured');
+  }
+
+  encryptedCredential(
+    provider: string,
+    service: string,
+    account: string,
+  ): EncryptedCredentialRecord | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT refs.id, refs.provider, refs.service, refs.account, refs.label,
+               refs.created_at, secrets.updated_at, secrets.format_version,
+               secrets.nonce, secrets.ciphertext, secrets.auth_tag
+        FROM credential_refs AS refs
+        JOIN credential_secrets AS secrets ON secrets.credential_ref_id = refs.id
+        WHERE refs.provider = ? AND refs.service = ? AND refs.account = ?
+      `)
+      .get(provider, service, account);
+    return row ? encryptedCredentialFromRow(row) : undefined;
+  }
+
+  encryptedCredentialById(
+    id: string,
+    provider: string,
+  ): EncryptedCredentialRecord | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT refs.id, refs.provider, refs.service, refs.account, refs.label,
+               refs.created_at, secrets.updated_at, secrets.format_version,
+               secrets.nonce, secrets.ciphertext, secrets.auth_tag
+        FROM credential_refs AS refs
+        JOIN credential_secrets AS secrets ON secrets.credential_ref_id = refs.id
+        WHERE refs.id = ? AND refs.provider = ?
+      `)
+      .get(id, provider);
+    return row ? encryptedCredentialFromRow(row) : undefined;
+  }
+
+  listEncryptedCredentials(provider: string, service: string): EncryptedCredentialRecord[] {
+    return this.db
+      .prepare(`
+        SELECT refs.id, refs.provider, refs.service, refs.account, refs.label,
+               refs.created_at, secrets.updated_at, secrets.format_version,
+               secrets.nonce, secrets.ciphertext, secrets.auth_tag
+        FROM credential_refs AS refs
+        JOIN credential_secrets AS secrets ON secrets.credential_ref_id = refs.id
+        WHERE refs.provider = ? AND refs.service = ?
+        ORDER BY refs.label COLLATE NOCASE, refs.account
+      `)
+      .all(provider, service)
+      .map(encryptedCredentialFromRow);
+  }
+
+  upsertEncryptedCredential(input: EncryptedCredentialInput): EncryptedCredentialRecord {
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const ref = this.upsertCredentialRef(input);
+      this.db
+        .prepare(`
+          INSERT INTO credential_secrets(
+            credential_ref_id, format_version, nonce, ciphertext, auth_tag
+          ) VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(credential_ref_id) DO UPDATE SET
+            format_version = excluded.format_version,
+            nonce = excluded.nonce,
+            ciphertext = excluded.ciphertext,
+            auth_tag = excluded.auth_tag,
+            updated_at = CURRENT_TIMESTAMP
+        `)
+        .run(
+          ref.id,
+          input.formatVersion,
+          input.nonce,
+          input.ciphertext,
+          input.authTag,
+        );
+      this.db.exec('COMMIT');
+      return this.encryptedCredential(input.provider, input.service, input.account)!;
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+  }
+
+  deleteEncryptedCredential(id: string, provider: string): boolean {
+    return (
+      Number(
+        this.db
+          .prepare('DELETE FROM credential_refs WHERE id = ? AND provider = ?')
+          .run(id, provider).changes,
+      ) === 1
+    );
+  }
+
+  deletePasswordVaultData(provider: string): void {
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      this.db.prepare('DELETE FROM credential_refs WHERE provider = ?').run(provider);
+      this.db.prepare('DELETE FROM password_vault WHERE singleton = 1').run();
+      this.db.exec('COMMIT');
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
   }
 
   createNativeConnection(input: NativeConnectionInput): string {
@@ -1220,6 +1478,47 @@ export class MuxusDatabase {
 }
 
 type SqlRow = Record<string, SQLOutputValue>;
+
+function blob(row: SqlRow, key: string): Buffer {
+  const value = row[key];
+  if (!(value instanceof Uint8Array)) throw new Error(`invalid database blob: ${key}`);
+  return Buffer.from(value);
+}
+
+function passwordVaultConfigFromRow(row: SqlRow): PasswordVaultConfigRecord {
+  return {
+    formatVersion: Number(row.format_version) as 2,
+    kdfAlgorithm: String(row.kdf_algorithm) as 'scrypt',
+    kdfSalt: blob(row, 'kdf_salt'),
+    kdfCost: Number(row.kdf_cost),
+    kdfBlockSize: Number(row.kdf_block_size),
+    kdfParallelism: Number(row.kdf_parallelism),
+    masterKeyNonce: blob(row, 'master_key_nonce'),
+    masterKeyCiphertext: blob(row, 'master_key_ciphertext'),
+    masterKeyTag: blob(row, 'master_key_tag'),
+    deviceKeyNonce: blob(row, 'device_key_nonce'),
+    deviceKeyCiphertext: blob(row, 'device_key_ciphertext'),
+    deviceKeyTag: blob(row, 'device_key_tag'),
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+function encryptedCredentialFromRow(row: SqlRow): EncryptedCredentialRecord {
+  return {
+    id: String(row.id),
+    provider: String(row.provider),
+    service: String(row.service),
+    account: String(row.account),
+    label: nullableString(row.label) ?? undefined,
+    formatVersion: Number(row.format_version) as 1,
+    nonce: blob(row, 'nonce'),
+    ciphertext: blob(row, 'ciphertext'),
+    authTag: blob(row, 'auth_tag'),
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  };
+}
 
 /** Walk a stored layout tree defensively — its shape is `unknown` in the DB. */
 function collectLayoutTabIds(node: unknown, into: Set<string>): void {

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -332,6 +332,16 @@ const MIGRATIONS = [
     name: 'password-vault-key-check',
     run: addPasswordVaultKeyCheck,
   },
+  {
+    version: 16,
+    name: 'password-vault-key-cleanup',
+    sql: `
+      CREATE TABLE password_vault_key_cleanup (
+        vault_id TEXT PRIMARY KEY CHECK(length(vault_id) BETWEEN 16 AND 64),
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      ) STRICT;
+    `,
+  },
 ] as const;
 
 function migrateDraftPasswordVault(db: DatabaseSync): void {
@@ -818,6 +828,29 @@ export class MuxusDatabase {
       );
     if (Number(changed.changes) !== 1) throw new Error('password vault is not configured');
     this.flushSensitivePages();
+  }
+
+  pendingPasswordVaultKeyCleanup(): string[] {
+    return this.db
+      .prepare(
+        'SELECT vault_id FROM password_vault_key_cleanup ORDER BY created_at',
+      )
+      .all()
+      .map((row) => String(row.vault_id));
+  }
+
+  queuePasswordVaultKeyCleanup(vaultId: string): void {
+    this.db
+      .prepare(
+        'INSERT OR IGNORE INTO password_vault_key_cleanup(vault_id) VALUES (?)',
+      )
+      .run(vaultId);
+  }
+
+  finishPasswordVaultKeyCleanup(vaultId: string): void {
+    this.db
+      .prepare('DELETE FROM password_vault_key_cleanup WHERE vault_id = ?')
+      .run(vaultId);
   }
 
   encryptedCredential(

--- a/server/src/routes/password-vault.ts
+++ b/server/src/routes/password-vault.ts
@@ -1,6 +1,9 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { z } from 'zod';
-import type { PasswordVaultStatus } from '@muxus/shared';
+import {
+  DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY,
+  type PasswordVaultStatus,
+} from '@muxus/shared';
 import type { AppContext } from '../app.js';
 import {
   InvalidMasterPasswordError,
@@ -9,11 +12,16 @@ import {
   VaultAlreadyConfiguredError,
   VaultAutomaticAccessError,
   VaultNotConfiguredError,
+  VaultPolicyMismatchError,
 } from '../security/password-vault.js';
+import { VaultKeyStoreUnavailableError } from '../security/vault-key-store.js';
 import { HttpProblem, sendError } from '../util/errors.js';
 
 const passwordSchema = z.object({
   password: z.string().min(1).max(1024),
+  unlockPolicy: z
+    .enum(['never', 'startup', 'credential'])
+    .default(DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY),
 });
 
 const managementSchema = z.object({
@@ -29,6 +37,10 @@ const changePasswordSchema = z.object({
   nextPassword: z.string().min(1).max(1024),
 });
 
+const changeUnlockPolicySchema = managementSchema.extend({
+  unlockPolicy: z.enum(['never', 'startup', 'credential']),
+});
+
 /** Master-password lifecycle and saved-credential management. */
 export function registerPasswordVaultRoutes(
   app: FastifyInstance,
@@ -42,7 +54,10 @@ export function registerPasswordVaultRoutes(
       return reply.code(400).send({ message: 'A valid master password is required.' });
     }
     try {
-      await ctx.vault.create(parsed.data.password);
+      await ctx.vault.create(
+        parsed.data.password,
+        parsed.data.unlockPolicy,
+      );
       return ctx.vault.status();
     } catch (err) {
       return sendVaultError(reply, err);
@@ -56,6 +71,39 @@ export function registerPasswordVaultRoutes(
     }
     try {
       await ctx.vault.repairAutomaticAccess(parsed.data.masterPassword);
+      return ctx.vault.status();
+    } catch (err) {
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.post('/api/password-vault/unlock', async (req, reply) => {
+    const parsed = managementSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply
+        .code(400)
+        .send({ message: 'A valid master password is required.' });
+    }
+    try {
+      await ctx.vault.unlockForSession(parsed.data.masterPassword);
+      return ctx.vault.status();
+    } catch (err) {
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.put('/api/password-vault/unlock-policy', async (req, reply) => {
+    const parsed = changeUnlockPolicySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({
+        message: 'A valid master password and unlock policy are required.',
+      });
+    }
+    try {
+      await ctx.vault.changeUnlockPolicy(
+        parsed.data.masterPassword,
+        parsed.data.unlockPolicy,
+      );
       return ctx.vault.status();
     } catch (err) {
       return sendVaultError(reply, err);
@@ -129,8 +177,8 @@ export function registerPasswordVaultRoutes(
     };
   });
 
-  app.delete('/api/password-vault', (): PasswordVaultStatus => {
-    ctx.vault.deleteAll();
+  app.delete('/api/password-vault', async (): Promise<PasswordVaultStatus> => {
+    await ctx.vault.deleteAll();
     return ctx.vault.status();
   });
 }
@@ -152,11 +200,23 @@ function sendVaultError(reply: FastifyReply, err: unknown): Promise<void> {
   if (err instanceof VaultNotConfiguredError) {
     return sendError(reply, new HttpProblem(409, err.message, 'vault-not-configured'));
   }
+  if (err instanceof VaultPolicyMismatchError) {
+    return sendError(
+      reply,
+      new HttpProblem(409, err.message, 'vault-policy-mismatch'),
+    );
+  }
   if (err instanceof VaultAutomaticAccessError) {
     return sendError(reply, new HttpProblem(423, err.message, 'vault-automatic-access-unavailable'));
   }
   if (err instanceof InvalidSavedPasswordFormatError) {
     return sendError(reply, new HttpProblem(400, err.message, 'invalid-saved-password-format'));
+  }
+  if (err instanceof VaultKeyStoreUnavailableError) {
+    return sendError(
+      reply,
+      new HttpProblem(503, err.message, 'os-key-store-unavailable'),
+    );
   }
   return sendError(reply, err);
 }

--- a/server/src/routes/password-vault.ts
+++ b/server/src/routes/password-vault.ts
@@ -1,0 +1,162 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { z } from 'zod';
+import type { PasswordVaultStatus } from '@muxus/shared';
+import type { AppContext } from '../app.js';
+import {
+  InvalidMasterPasswordError,
+  InvalidMasterPasswordFormatError,
+  InvalidSavedPasswordFormatError,
+  VaultAlreadyConfiguredError,
+  VaultAutomaticAccessError,
+  VaultNotConfiguredError,
+} from '../security/password-vault.js';
+import { HttpProblem, sendError } from '../util/errors.js';
+
+const passwordSchema = z.object({
+  password: z.string().min(1).max(1024),
+});
+
+const managementSchema = z.object({
+  masterPassword: z.string().min(1).max(1024),
+});
+
+const updateCredentialSchema = managementSchema.extend({
+  password: z.string().max(8192),
+});
+
+const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1).max(1024),
+  nextPassword: z.string().min(1).max(1024),
+});
+
+/** Master-password lifecycle and saved-credential management. */
+export function registerPasswordVaultRoutes(
+  app: FastifyInstance,
+  ctx: AppContext,
+): void {
+  app.get('/api/password-vault', (): PasswordVaultStatus => ctx.vault.status());
+
+  app.post('/api/password-vault/create', async (req, reply) => {
+    const parsed = passwordSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ message: 'A valid master password is required.' });
+    }
+    try {
+      await ctx.vault.create(parsed.data.password);
+      return ctx.vault.status();
+    } catch (err) {
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.post('/api/password-vault/repair-automatic-access', async (req, reply) => {
+    const parsed = managementSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ message: 'A valid master password is required.' });
+    }
+    try {
+      await ctx.vault.repairAutomaticAccess(parsed.data.masterPassword);
+      return ctx.vault.status();
+    } catch (err) {
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.post('/api/password-vault/change-master-password', async (req, reply) => {
+    const parsed = changePasswordSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ message: 'Current and new master passwords are required.' });
+    }
+    try {
+      await ctx.vault.changeMasterPassword(
+        parsed.data.currentPassword,
+        parsed.data.nextPassword,
+      );
+      return ctx.vault.status();
+    } catch (err) {
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.post('/api/password-vault/credentials/:id/reveal', async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const parsed = managementSchema.safeParse(req.body);
+    if (!validCredentialId(id) || !parsed.success) {
+      return reply.code(400).send({ message: 'A valid credential and master password are required.' });
+    }
+    try {
+      const password = await ctx.vault.revealCredential(
+        id,
+        parsed.data.masterPassword,
+      );
+      if (password === undefined) {
+        return reply.code(404).send({ message: 'Saved password not found.' });
+      }
+      return reply
+        .header('cache-control', 'no-store')
+        .header('pragma', 'no-cache')
+        .send({ password });
+    } catch (err) {
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.put('/api/password-vault/credentials/:id', async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const parsed = updateCredentialSchema.safeParse(req.body);
+    if (!validCredentialId(id) || !parsed.success) {
+      return reply.code(400).send({ message: 'A valid credential, master password and password are required.' });
+    }
+    try {
+      const updated = await ctx.vault.updateCredential(
+        id,
+        parsed.data.masterPassword,
+        parsed.data.password,
+      );
+      if (!updated) {
+        return reply.code(404).send({ message: 'Saved password not found.' });
+      }
+      return ctx.vault.status();
+    } catch (err) {
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.delete('/api/password-vault/credentials/:id', (req) => {
+    const { id } = req.params as { id: string };
+    return {
+      deleted: validCredentialId(id) && ctx.vault.deleteCredential(id),
+    };
+  });
+
+  app.delete('/api/password-vault', (): PasswordVaultStatus => {
+    ctx.vault.deleteAll();
+    return ctx.vault.status();
+  });
+}
+
+function validCredentialId(id: string): boolean {
+  return id.length > 0 && id.length <= 200;
+}
+
+function sendVaultError(reply: FastifyReply, err: unknown): Promise<void> {
+  if (err instanceof InvalidMasterPasswordError) {
+    return sendError(reply, new HttpProblem(401, err.message, 'invalid-master-password'));
+  }
+  if (err instanceof InvalidMasterPasswordFormatError) {
+    return sendError(reply, new HttpProblem(400, err.message, 'invalid-master-password-format'));
+  }
+  if (err instanceof VaultAlreadyConfiguredError) {
+    return sendError(reply, new HttpProblem(409, err.message, 'vault-already-configured'));
+  }
+  if (err instanceof VaultNotConfiguredError) {
+    return sendError(reply, new HttpProblem(409, err.message, 'vault-not-configured'));
+  }
+  if (err instanceof VaultAutomaticAccessError) {
+    return sendError(reply, new HttpProblem(423, err.message, 'vault-automatic-access-unavailable'));
+  }
+  if (err instanceof InvalidSavedPasswordFormatError) {
+    return sendError(reply, new HttpProblem(400, err.message, 'invalid-saved-password-format'));
+  }
+  return sendError(reply, err);
+}

--- a/server/src/routes/password-vault.ts
+++ b/server/src/routes/password-vault.ts
@@ -178,6 +178,8 @@ export function registerPasswordVaultRoutes(
   });
 
   app.delete('/api/password-vault', async (): Promise<PasswordVaultStatus> => {
+    // Intentionally master-password-free: reset is the recovery path when the
+    // password is forgotten. This endpoint can only delete, never reveal data.
     await ctx.vault.deleteAll();
     return ctx.vault.status();
   });

--- a/server/src/security/password-vault.ts
+++ b/server/src/security/password-vault.ts
@@ -164,6 +164,9 @@ export class PasswordVault {
     if (this.initialized) return;
     await removeLegacyDeviceKey(this.database.filename);
     const config = this.database.passwordVaultConfig();
+    await this.retryPendingOsKeyCleanup(
+      config?.unlockPolicy === 'never' ? config.vaultId : undefined,
+    );
     if (config?.unlockPolicy === 'never') {
       try {
         const key = await this.keyStore.get(config.vaultId);
@@ -324,12 +327,15 @@ export class PasswordVault {
       }
 
       if (checkedConfig.unlockPolicy === 'never') {
-        await this.deleteOsKeyBestEffort(checkedConfig.vaultId);
+        this.database.queuePasswordVaultKeyCleanup(checkedConfig.vaultId);
       }
       this.database.updatePasswordVaultConfig({
         ...checkedConfig,
         unlockPolicy,
       });
+      if (checkedConfig.unlockPolicy === 'never') {
+        await this.deletePendingOsKeyBestEffort(checkedConfig.vaultId);
+      }
       if (unlockPolicy === 'startup') this.setKey(vaultKey);
       else this.lock();
     } finally {
@@ -514,10 +520,13 @@ export class PasswordVault {
   async deleteAll(): Promise<void> {
     const config = this.database.passwordVaultConfig();
     if (config?.unlockPolicy === 'never') {
-      await this.deleteOsKeyBestEffort(config.vaultId);
+      this.database.queuePasswordVaultKeyCleanup(config.vaultId);
     }
     this.lock();
     this.database.deletePasswordVaultData(PASSWORD_VAULT_PROVIDER);
+    if (config?.unlockPolicy === 'never') {
+      await this.deletePendingOsKeyBestEffort(config.vaultId);
+    }
   }
 
   private requireConfig(): PasswordVaultConfigRecord {
@@ -608,15 +617,32 @@ export class PasswordVault {
     }
   }
 
-  private async deleteOsKeyBestEffort(vaultId: string): Promise<void> {
+  private async retryPendingOsKeyCleanup(
+    activeAutomaticVaultId?: string,
+  ): Promise<void> {
+    for (const vaultId of this.database.pendingPasswordVaultKeyCleanup()) {
+      if (vaultId === activeAutomaticVaultId) {
+        // The policy change never committed, so automatic access is still the
+        // configured policy and its key must remain available.
+        this.database.finishPasswordVaultKeyCleanup(vaultId);
+        continue;
+      }
+      await this.deletePendingOsKeyBestEffort(vaultId);
+    }
+  }
+
+  private async deletePendingOsKeyBestEffort(vaultId: string): Promise<void> {
     try {
       await this.keyStore.delete(vaultId);
       this.osKeyStoreAvailable = true;
     } catch {
       // Moving away from automatic access and resetting the vault are recovery
       // paths; an unavailable credential store must not block either action.
+      // The durable queue retries deletion on the next initialization.
       this.osKeyStoreAvailable = false;
+      return;
     }
+    this.database.finishPasswordVaultKeyCleanup(vaultId);
   }
 
   private isVerifiedKey(

--- a/server/src/security/password-vault.ts
+++ b/server/src/security/password-vault.ts
@@ -1,0 +1,631 @@
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  scrypt,
+} from 'node:crypto';
+import type {
+  PasswordVaultCredential,
+  PasswordVaultStatus,
+} from '@muxus/shared';
+import type {
+  EncryptedCredentialRecord,
+  MuxusDatabase,
+  PasswordVaultConfigRecord,
+} from '../persistence/database.js';
+
+export const PASSWORD_VAULT_PROVIDER = 'muxus-master-vault';
+export const SSH_PASSWORD_SERVICE = 'muxus/ssh-password/v1';
+export const MASTER_PASSWORD_MIN_LENGTH = 8;
+export const MASTER_PASSWORD_MAX_BYTES = 1024;
+export const SSH_PASSWORD_MAX_BYTES = 8192;
+
+const FORMAT_VERSION = 2 as const;
+const CREDENTIAL_FORMAT_VERSION = 1 as const;
+const KEY_BYTES = 32;
+const SALT_BYTES = 16;
+const NONCE_BYTES = 12;
+const TAG_BYTES = 16;
+const DEVICE_KEY_FILENAME = 'muxus-vault-device.key';
+const MASTER_KEY_AAD = Buffer.from(
+  'muxus:password-vault:master-key:v2',
+  'utf8',
+);
+const DEVICE_KEY_AAD = Buffer.from(
+  'muxus:password-vault:device-key:v2',
+  'utf8',
+);
+
+export interface PasswordVaultKdf {
+  cost: number;
+  blockSize: number;
+  parallelism: number;
+}
+
+const DEFAULT_KDF: PasswordVaultKdf = {
+  cost: 32 * 1024,
+  blockSize: 8,
+  parallelism: 1,
+};
+
+interface SealedValue {
+  nonce: Buffer;
+  ciphertext: Buffer;
+  authTag: Buffer;
+}
+
+export class VaultNotConfiguredError extends Error {
+  constructor() {
+    super('Password vault is not configured.');
+  }
+}
+
+export class VaultAlreadyConfiguredError extends Error {
+  constructor() {
+    super('Password vault is already configured.');
+  }
+}
+
+export class VaultAutomaticAccessError extends Error {
+  constructor() {
+    super(
+      'Automatic password access is unavailable. Enter the master password in Settings to repair it.',
+    );
+  }
+}
+
+export class InvalidMasterPasswordError extends Error {
+  constructor() {
+    super('The master password is incorrect.');
+  }
+}
+
+export class InvalidMasterPasswordFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class InvalidSavedPasswordFormatError extends Error {
+  constructor() {
+    super('The SSH password is too long to save.');
+  }
+}
+
+export class CredentialVaultCorruptError extends Error {
+  constructor() {
+    super('A saved password could not be decrypted.');
+  }
+}
+
+/**
+ * Platform-independent encrypted credential vault.
+ *
+ * A random data key encrypts every SSH password. It is wrapped twice:
+ * - with a local device key so SSH connections can use it automatically;
+ * - with a scrypt-derived master key so revealing or editing credentials
+ *   requires the master password.
+ *
+ * The device key is a mode-0600 file next to the database. This protects a
+ * copied database by itself, but not theft of the complete application-data
+ * directory. The master password is deliberately a management gate rather
+ * than a requirement for routine SSH connections.
+ */
+export class PasswordVault {
+  private key: Buffer | undefined;
+  private readonly deviceKey: Buffer;
+
+  constructor(
+    private readonly database: MuxusDatabase,
+    private readonly options: {
+      kdf?: PasswordVaultKdf;
+      deviceKey?: Buffer;
+      deviceKeyPath?: string;
+    } = {},
+  ) {
+    this.deviceKey = options.deviceKey
+      ? checkedDeviceKey(options.deviceKey)
+      : loadOrCreateDeviceKey(
+          options.deviceKeyPath ?? defaultDeviceKeyPath(database.filename),
+        );
+    this.restoreAutomaticAccess();
+  }
+
+  status(): PasswordVaultStatus {
+    this.restoreAutomaticAccess();
+    const credentials = this.database
+      .listEncryptedCredentials(PASSWORD_VAULT_PROVIDER, SSH_PASSWORD_SERVICE)
+      .map(
+        (record): PasswordVaultCredential => ({
+          id: record.id,
+          label: record.label ?? 'Saved SSH password',
+          createdAt: record.createdAt,
+          updatedAt: record.updatedAt,
+        }),
+      );
+    return {
+      configured: this.database.passwordVaultConfig() !== undefined,
+      automaticAccess: this.key !== undefined,
+      credentialCount: credentials.length,
+      credentials,
+    };
+  }
+
+  async create(masterPassword: string): Promise<void> {
+    validateMasterPassword(masterPassword);
+    if (this.database.passwordVaultConfig()) {
+      throw new VaultAlreadyConfiguredError();
+    }
+
+    const vaultKey = randomBytes(KEY_BYTES);
+    const salt = randomBytes(SALT_BYTES);
+    let masterKey: Buffer | undefined;
+    try {
+      const kdf = this.options.kdf ?? DEFAULT_KDF;
+      masterKey = await deriveKey(masterPassword, salt, kdf);
+      const masterWrapped = seal(vaultKey, masterKey, MASTER_KEY_AAD);
+      const deviceWrapped = seal(vaultKey, this.deviceKey, DEVICE_KEY_AAD);
+      this.database.createPasswordVaultConfig({
+        formatVersion: FORMAT_VERSION,
+        kdfAlgorithm: 'scrypt',
+        kdfSalt: salt,
+        kdfCost: kdf.cost,
+        kdfBlockSize: kdf.blockSize,
+        kdfParallelism: kdf.parallelism,
+        masterKeyNonce: masterWrapped.nonce,
+        masterKeyCiphertext: masterWrapped.ciphertext,
+        masterKeyTag: masterWrapped.authTag,
+        deviceKeyNonce: deviceWrapped.nonce,
+        deviceKeyCiphertext: deviceWrapped.ciphertext,
+        deviceKeyTag: deviceWrapped.authTag,
+      });
+      this.setKey(vaultKey);
+    } catch (err) {
+      vaultKey.fill(0);
+      throw err;
+    } finally {
+      masterKey?.fill(0);
+    }
+  }
+
+  /**
+   * Recreates the automatic wrap after the database was restored without its
+   * companion device-key file.
+   */
+  async repairAutomaticAccess(masterPassword: string): Promise<void> {
+    const config = this.requireConfig();
+    const vaultKey = await unwrapMasterKey(masterPassword, config);
+    try {
+      const deviceWrapped = seal(vaultKey, this.deviceKey, DEVICE_KEY_AAD);
+      this.database.updatePasswordVaultConfig({
+        ...config,
+        deviceKeyNonce: deviceWrapped.nonce,
+        deviceKeyCiphertext: deviceWrapped.ciphertext,
+        deviceKeyTag: deviceWrapped.authTag,
+      });
+      this.setKey(vaultKey);
+    } catch (err) {
+      vaultKey.fill(0);
+      throw err;
+    }
+  }
+
+  /**
+   * Wipes the current data key. It will be restored from the local device key
+   * on the next status check or password operation.
+   */
+  lock(): void {
+    this.key?.fill(0);
+    this.key = undefined;
+  }
+
+  dispose(): void {
+    this.lock();
+    this.deviceKey.fill(0);
+  }
+
+  async changeMasterPassword(
+    currentPassword: string,
+    nextPassword: string,
+  ): Promise<void> {
+    validateMasterPassword(nextPassword);
+    const config = this.requireConfig();
+    const vaultKey = await unwrapMasterKey(currentPassword, config);
+    const nextSalt = randomBytes(SALT_BYTES);
+    let nextMasterKey: Buffer | undefined;
+    try {
+      const kdf = this.options.kdf ?? DEFAULT_KDF;
+      nextMasterKey = await deriveKey(nextPassword, nextSalt, kdf);
+      const masterWrapped = seal(vaultKey, nextMasterKey, MASTER_KEY_AAD);
+      this.database.updatePasswordVaultConfig({
+        ...config,
+        formatVersion: FORMAT_VERSION,
+        kdfAlgorithm: 'scrypt',
+        kdfSalt: nextSalt,
+        kdfCost: kdf.cost,
+        kdfBlockSize: kdf.blockSize,
+        kdfParallelism: kdf.parallelism,
+        masterKeyNonce: masterWrapped.nonce,
+        masterKeyCiphertext: masterWrapped.ciphertext,
+        masterKeyTag: masterWrapped.authTag,
+      });
+      this.setKey(vaultKey);
+    } catch (err) {
+      vaultKey.fill(0);
+      throw err;
+    } finally {
+      nextMasterKey?.fill(0);
+    }
+  }
+
+  hasSshPassword(account: string): boolean {
+    return (
+      this.database.encryptedCredential(
+        PASSWORD_VAULT_PROVIDER,
+        SSH_PASSWORD_SERVICE,
+        account,
+      ) !== undefined
+    );
+  }
+
+  sshPassword(account: string): string | undefined {
+    const record = this.database.encryptedCredential(
+      PASSWORD_VAULT_PROVIDER,
+      SSH_PASSWORD_SERVICE,
+      account,
+    );
+    if (!record) return undefined;
+    return this.decryptRecord(record, this.requireAutomaticKey());
+  }
+
+  rememberSshPassword(account: string, label: string, password: string): void {
+    validateSavedPassword(password);
+    const key = this.requireAutomaticKey();
+    const ref = this.database.upsertCredentialRef({
+      provider: PASSWORD_VAULT_PROVIDER,
+      service: SSH_PASSWORD_SERVICE,
+      account,
+      label,
+    });
+    const plaintext = Buffer.from(password, 'utf8');
+    try {
+      const encrypted = seal(plaintext, key, credentialAad(ref.id));
+      this.database.upsertEncryptedCredential({
+        provider: PASSWORD_VAULT_PROVIDER,
+        service: SSH_PASSWORD_SERVICE,
+        account,
+        label,
+        formatVersion: CREDENTIAL_FORMAT_VERSION,
+        nonce: encrypted.nonce,
+        ciphertext: encrypted.ciphertext,
+        authTag: encrypted.authTag,
+      });
+    } finally {
+      plaintext.fill(0);
+    }
+  }
+
+  async revealCredential(
+    id: string,
+    masterPassword: string,
+  ): Promise<string | undefined> {
+    const record = this.database.encryptedCredentialById(
+      id,
+      PASSWORD_VAULT_PROVIDER,
+    );
+    if (!record) return undefined;
+    const managementKey = await unwrapMasterKey(
+      masterPassword,
+      this.requireConfig(),
+    );
+    try {
+      return this.decryptRecord(record, managementKey);
+    } finally {
+      managementKey.fill(0);
+    }
+  }
+
+  async updateCredential(
+    id: string,
+    masterPassword: string,
+    password: string,
+  ): Promise<boolean> {
+    validateSavedPassword(password);
+    const record = this.database.encryptedCredentialById(
+      id,
+      PASSWORD_VAULT_PROVIDER,
+    );
+    if (!record) return false;
+    const managementKey = await unwrapMasterKey(
+      masterPassword,
+      this.requireConfig(),
+    );
+    const plaintext = Buffer.from(password, 'utf8');
+    try {
+      const encrypted = seal(
+        plaintext,
+        managementKey,
+        credentialAad(record.id),
+      );
+      this.database.upsertEncryptedCredential({
+        provider: record.provider,
+        service: record.service,
+        account: record.account,
+        label: record.label,
+        formatVersion: CREDENTIAL_FORMAT_VERSION,
+        nonce: encrypted.nonce,
+        ciphertext: encrypted.ciphertext,
+        authTag: encrypted.authTag,
+      });
+      return true;
+    } finally {
+      plaintext.fill(0);
+      managementKey.fill(0);
+    }
+  }
+
+  deleteCredential(id: string): boolean {
+    return this.database.deleteEncryptedCredential(
+      id,
+      PASSWORD_VAULT_PROVIDER,
+    );
+  }
+
+  deleteAll(): void {
+    this.lock();
+    this.database.deletePasswordVaultData(PASSWORD_VAULT_PROVIDER);
+  }
+
+  private requireConfig(): PasswordVaultConfigRecord {
+    const config = this.database.passwordVaultConfig();
+    if (!config) throw new VaultNotConfiguredError();
+    return config;
+  }
+
+  private requireAutomaticKey(): Buffer {
+    this.restoreAutomaticAccess();
+    if (!this.key) throw new VaultAutomaticAccessError();
+    return this.key;
+  }
+
+  private restoreAutomaticAccess(): void {
+    if (this.key) return;
+    const config = this.database.passwordVaultConfig();
+    if (!config) return;
+    try {
+      const key = open(
+        {
+          nonce: config.deviceKeyNonce,
+          ciphertext: config.deviceKeyCiphertext,
+          authTag: config.deviceKeyTag,
+        },
+        this.deviceKey,
+        DEVICE_KEY_AAD,
+      );
+      if (key.length !== KEY_BYTES) {
+        key.fill(0);
+        return;
+      }
+      this.setKey(key);
+    } catch {
+      // A missing/replaced device key is repairable with the master password.
+    }
+  }
+
+  private decryptRecord(
+    record: EncryptedCredentialRecord,
+    key: Buffer,
+  ): string {
+    let plaintext: Buffer;
+    try {
+      plaintext = open(
+        {
+          nonce: record.nonce,
+          ciphertext: record.ciphertext,
+          authTag: record.authTag,
+        },
+        key,
+        credentialAad(record.id),
+      );
+    } catch {
+      throw new CredentialVaultCorruptError();
+    }
+    try {
+      return plaintext.toString('utf8');
+    } finally {
+      plaintext.fill(0);
+    }
+  }
+
+  private setKey(key: Buffer): void {
+    this.key?.fill(0);
+    this.key = key;
+  }
+}
+
+export function sshPasswordAccount(input: {
+  user: string;
+  host: string;
+  port: number;
+}): string {
+  return Buffer.from(
+    JSON.stringify([input.user, input.host.toLowerCase(), input.port]),
+    'utf8',
+  ).toString('base64url');
+}
+
+export function sshPasswordLabel(input: {
+  user: string;
+  host: string;
+  port: number;
+}): string {
+  return `${input.user}@${input.host}:${input.port}`;
+}
+
+export function validateMasterPassword(password: string): void {
+  const bytes = Buffer.byteLength(password, 'utf8');
+  if (Array.from(password).length < MASTER_PASSWORD_MIN_LENGTH) {
+    throw new InvalidMasterPasswordFormatError(
+      `Master password must contain at least ${MASTER_PASSWORD_MIN_LENGTH} characters.`,
+    );
+  }
+  if (bytes > MASTER_PASSWORD_MAX_BYTES) {
+    throw new InvalidMasterPasswordFormatError('Master password is too long.');
+  }
+}
+
+function validateSavedPassword(password: string): void {
+  if (Buffer.byteLength(password, 'utf8') > SSH_PASSWORD_MAX_BYTES) {
+    throw new InvalidSavedPasswordFormatError();
+  }
+}
+
+function defaultDeviceKeyPath(filename: string): string | undefined {
+  return filename === ':memory:'
+    ? undefined
+    : path.join(path.dirname(filename), DEVICE_KEY_FILENAME);
+}
+
+function checkedDeviceKey(value: Buffer): Buffer {
+  if (value.length !== KEY_BYTES) {
+    throw new Error(`Password-vault device key must be ${KEY_BYTES} bytes.`);
+  }
+  return Buffer.from(value);
+}
+
+function loadOrCreateDeviceKey(filename: string | undefined): Buffer {
+  if (!filename) return randomBytes(KEY_BYTES);
+  try {
+    const key = checkedDeviceKey(readFileSync(filename));
+    if (process.platform !== 'win32') chmodSync(filename, 0o600);
+    return key;
+  } catch (err) {
+    if (!isMissingFileError(err)) throw err;
+  }
+
+  mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const key = randomBytes(KEY_BYTES);
+  try {
+    writeFileSync(filename, key, { flag: 'wx', mode: 0o600 });
+  } catch (err) {
+    if (!isExistingFileError(err)) {
+      key.fill(0);
+      throw err;
+    }
+    key.fill(0);
+    return checkedDeviceKey(readFileSync(filename));
+  }
+  if (process.platform !== 'win32') chmodSync(filename, 0o600);
+  return key;
+}
+
+function isMissingFileError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    (err as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+function isExistingFileError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    (err as NodeJS.ErrnoException).code === 'EEXIST'
+  );
+}
+
+function credentialAad(id: string): Buffer {
+  return Buffer.from(`muxus:ssh-password:${id}:v1`, 'utf8');
+}
+
+function seal(plaintext: Buffer, key: Buffer, aad: Buffer): SealedValue {
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce, {
+    authTagLength: TAG_BYTES,
+  });
+  cipher.setAAD(aad);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return { nonce, ciphertext, authTag: cipher.getAuthTag() };
+}
+
+function open(value: SealedValue, key: Buffer, aad: Buffer): Buffer {
+  const decipher = createDecipheriv('aes-256-gcm', key, value.nonce, {
+    authTagLength: TAG_BYTES,
+  });
+  decipher.setAAD(aad);
+  decipher.setAuthTag(value.authTag);
+  return Buffer.concat([
+    decipher.update(value.ciphertext),
+    decipher.final(),
+  ]);
+}
+
+function deriveKey(
+  password: string,
+  salt: Buffer,
+  kdf: PasswordVaultKdf,
+): Promise<Buffer> {
+  const message = Buffer.from(password, 'utf8');
+  const requiredMemory = 128 * kdf.cost * kdf.blockSize;
+  const maxmem = Math.max(32 * 1024 * 1024, requiredMemory + 8 * 1024 * 1024);
+  return new Promise((resolve, reject) => {
+    scrypt(
+      message,
+      salt,
+      KEY_BYTES,
+      {
+        N: kdf.cost,
+        r: kdf.blockSize,
+        p: kdf.parallelism,
+        maxmem,
+      },
+      (err, key) => {
+        message.fill(0);
+        if (err) reject(err);
+        else resolve(key);
+      },
+    );
+  });
+}
+
+async function unwrapMasterKey(
+  masterPassword: string,
+  config: PasswordVaultConfigRecord,
+): Promise<Buffer> {
+  validateMasterPassword(masterPassword);
+  let masterKey: Buffer | undefined;
+  try {
+    masterKey = await deriveKey(masterPassword, config.kdfSalt, {
+      cost: config.kdfCost,
+      blockSize: config.kdfBlockSize,
+      parallelism: config.kdfParallelism,
+    });
+    const key = open(
+      {
+        nonce: config.masterKeyNonce,
+        ciphertext: config.masterKeyCiphertext,
+        authTag: config.masterKeyTag,
+      },
+      masterKey,
+      MASTER_KEY_AAD,
+    );
+    if (key.length !== KEY_BYTES) {
+      key.fill(0);
+      throw new InvalidMasterPasswordError();
+    }
+    return key;
+  } catch (err) {
+    if (err instanceof InvalidMasterPasswordFormatError) throw err;
+    throw new InvalidMasterPasswordError();
+  } finally {
+    masterKey?.fill(0);
+  }
+}

--- a/server/src/security/password-vault.ts
+++ b/server/src/security/password-vault.ts
@@ -1,45 +1,49 @@
 import {
-  chmodSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from 'node:fs';
-import path from 'node:path';
-import {
   createCipheriv,
   createDecipheriv,
   randomBytes,
   scrypt,
 } from 'node:crypto';
-import type {
-  PasswordVaultCredential,
-  PasswordVaultStatus,
+import { open as openFile, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY,
+  type PasswordVaultCredential,
+  type PasswordVaultStatus,
+  type PasswordVaultUnlockPolicy,
 } from '@muxus/shared';
 import type {
   EncryptedCredentialRecord,
   MuxusDatabase,
   PasswordVaultConfigRecord,
 } from '../persistence/database.js';
+import {
+  MemoryVaultKeyStore,
+  SystemVaultKeyStore,
+  type VaultKeyStore,
+  VaultKeyStoreUnavailableError,
+} from './vault-key-store.js';
 
 export const PASSWORD_VAULT_PROVIDER = 'muxus-master-vault';
 export const SSH_PASSWORD_SERVICE = 'muxus/ssh-password/v1';
-export const MASTER_PASSWORD_MIN_LENGTH = 8;
+export const MASTER_PASSWORD_MIN_LENGTH = 12;
 export const MASTER_PASSWORD_MAX_BYTES = 1024;
 export const SSH_PASSWORD_MAX_BYTES = 8192;
 
-const FORMAT_VERSION = 2 as const;
+const FORMAT_VERSION = 3 as const;
 const CREDENTIAL_FORMAT_VERSION = 1 as const;
 const KEY_BYTES = 32;
 const SALT_BYTES = 16;
 const NONCE_BYTES = 12;
 const TAG_BYTES = 16;
-const DEVICE_KEY_FILENAME = 'muxus-vault-device.key';
-const MASTER_KEY_AAD = Buffer.from(
+const LEGACY_MASTER_PASSWORD_MIN_LENGTH = 8;
+const LEGACY_DEVICE_KEY_FILENAME = 'muxus-vault-device.key';
+const LEGACY_MASTER_KEY_AAD = Buffer.from(
   'muxus:password-vault:master-key:v2',
   'utf8',
 );
-const DEVICE_KEY_AAD = Buffer.from(
-  'muxus:password-vault:device-key:v2',
+const MASTER_KEY_AAD = Buffer.from(
+  'muxus:password-vault:master-key:v3',
   'utf8',
 );
 
@@ -50,7 +54,7 @@ export interface PasswordVaultKdf {
 }
 
 const DEFAULT_KDF: PasswordVaultKdf = {
-  cost: 32 * 1024,
+  cost: 128 * 1024,
   blockSize: 8,
   parallelism: 1,
 };
@@ -59,6 +63,11 @@ interface SealedValue {
   nonce: Buffer;
   ciphertext: Buffer;
   authTag: Buffer;
+}
+
+interface CredentialKey {
+  key: Buffer;
+  ephemeral: boolean;
 }
 
 export class VaultNotConfiguredError extends Error {
@@ -73,11 +82,24 @@ export class VaultAlreadyConfiguredError extends Error {
   }
 }
 
-export class VaultAutomaticAccessError extends Error {
+export class VaultPolicyMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class VaultUnlockRequiredError extends Error {
+  constructor(readonly policy: PasswordVaultUnlockPolicy) {
+    super('Enter the master password to unlock the saved credential.');
+  }
+}
+
+/** Kept as an alias for callers that still distinguish automatic access. */
+export class VaultAutomaticAccessError extends VaultUnlockRequiredError {
   constructor() {
-    super(
-      'Automatic password access is unavailable. Enter the master password in Settings to repair it.',
-    );
+    super('never');
+    this.message =
+      'The OS credential-store copy is unavailable. Enter the master password to restore it.';
   }
 }
 
@@ -106,40 +128,52 @@ export class CredentialVaultCorruptError extends Error {
 }
 
 /**
- * Platform-independent encrypted credential vault.
- *
- * A random data key encrypts every SSH password. It is wrapped twice:
- * - with a local device key so SSH connections can use it automatically;
- * - with a scrypt-derived master key so revealing or editing credentials
- *   requires the master password.
- *
- * The device key is a mode-0600 file next to the database. This protects a
- * copied database by itself, but not theft of the complete application-data
- * directory. The master password is deliberately a management gate rather
- * than a requirement for routine SSH connections.
+ * A random data key encrypts each saved SSH password with AES-256-GCM. The
+ * database contains only a master-password-wrapped copy. With the "never"
+ * policy, the raw data key is additionally stored in the native OS credential
+ * store. Other policies keep it only in process memory or derive it for one
+ * operation.
  */
 export class PasswordVault {
   private key: Buffer | undefined;
-  private readonly deviceKey: Buffer;
+  private osKeyStoreAvailable = true;
+  private initialized = false;
+  private readonly keyStore: VaultKeyStore;
 
   constructor(
     private readonly database: MuxusDatabase,
     private readonly options: {
       kdf?: PasswordVaultKdf;
-      deviceKey?: Buffer;
-      deviceKeyPath?: string;
+      keyStore?: VaultKeyStore;
     } = {},
   ) {
-    this.deviceKey = options.deviceKey
-      ? checkedDeviceKey(options.deviceKey)
-      : loadOrCreateDeviceKey(
-          options.deviceKeyPath ?? defaultDeviceKeyPath(database.filename),
-        );
-    this.restoreAutomaticAccess();
+    this.keyStore =
+      options.keyStore ??
+      (database.filename === ':memory:'
+        ? new MemoryVaultKeyStore()
+        : new SystemVaultKeyStore());
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    await removeLegacyDeviceKey(this.database.filename);
+    const config = this.database.passwordVaultConfig();
+    if (!config || config.unlockPolicy !== 'never') return;
+    try {
+      const key = await this.keyStore.get(config.vaultId);
+      if (key) {
+        this.setKey(key);
+        key.fill(0);
+      }
+    } catch (err) {
+      if (!(err instanceof VaultKeyStoreUnavailableError)) throw err;
+      this.osKeyStoreAvailable = false;
+    }
   }
 
   status(): PasswordVaultStatus {
-    this.restoreAutomaticAccess();
+    const config = this.database.passwordVaultConfig();
     const credentials = this.database
       .listEncryptedCredentials(PASSWORD_VAULT_PROVIDER, SSH_PASSWORD_SERVICE)
       .map(
@@ -151,29 +185,42 @@ export class PasswordVault {
         }),
       );
     return {
-      configured: this.database.passwordVaultConfig() !== undefined,
-      automaticAccess: this.key !== undefined,
+      configured: config !== undefined,
+      ...(config ? { unlockPolicy: config.unlockPolicy } : {}),
+      locked: this.key === undefined,
+      osKeyStoreAvailable: this.osKeyStoreAvailable,
       credentialCount: credentials.length,
       credentials,
     };
   }
 
-  async create(masterPassword: string): Promise<void> {
+  async create(
+    masterPassword: string,
+    unlockPolicy: PasswordVaultUnlockPolicy =
+      DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY,
+  ): Promise<void> {
     validateMasterPassword(masterPassword);
     if (this.database.passwordVaultConfig()) {
       throw new VaultAlreadyConfiguredError();
     }
 
     const vaultKey = randomBytes(KEY_BYTES);
+    const vaultId = randomBytes(16).toString('base64url');
     const salt = randomBytes(SALT_BYTES);
     let masterKey: Buffer | undefined;
+    let osKeyStored = false;
     try {
       const kdf = this.options.kdf ?? DEFAULT_KDF;
       masterKey = await deriveKey(masterPassword, salt, kdf);
       const masterWrapped = seal(vaultKey, masterKey, MASTER_KEY_AAD);
-      const deviceWrapped = seal(vaultKey, this.deviceKey, DEVICE_KEY_AAD);
+      if (unlockPolicy === 'never') {
+        await this.storeOsKey(vaultId, vaultKey);
+        osKeyStored = true;
+      }
       this.database.createPasswordVaultConfig({
         formatVersion: FORMAT_VERSION,
+        vaultId,
+        unlockPolicy,
         kdfAlgorithm: 'scrypt',
         kdfSalt: salt,
         kdfCost: kdf.cost,
@@ -182,45 +229,93 @@ export class PasswordVault {
         masterKeyNonce: masterWrapped.nonce,
         masterKeyCiphertext: masterWrapped.ciphertext,
         masterKeyTag: masterWrapped.authTag,
-        deviceKeyNonce: deviceWrapped.nonce,
-        deviceKeyCiphertext: deviceWrapped.ciphertext,
-        deviceKeyTag: deviceWrapped.authTag,
       });
-      this.setKey(vaultKey);
+      if (unlockPolicy !== 'credential') this.setKey(vaultKey);
     } catch (err) {
-      vaultKey.fill(0);
+      if (osKeyStored) {
+        await this.keyStore.delete(vaultId).catch(() => undefined);
+      }
       throw err;
     } finally {
+      vaultKey.fill(0);
       masterKey?.fill(0);
     }
   }
 
+  async unlockForSession(masterPassword: string): Promise<void> {
+    const config = this.requireConfig();
+    if (config.unlockPolicy !== 'startup') {
+      throw new VaultPolicyMismatchError(
+        'Session unlock is available only with the startup prompt policy.',
+      );
+    }
+    const vaultKey = await unwrapMasterKey(masterPassword, config);
+    try {
+      this.setKey(vaultKey);
+    } finally {
+      vaultKey.fill(0);
+    }
+  }
+
   /**
-   * Recreates the automatic wrap after the database was restored without its
-   * companion device-key file.
+   * Restores "never prompt" access after a database or OS-keyring restore.
    */
   async repairAutomaticAccess(masterPassword: string): Promise<void> {
     const config = this.requireConfig();
     const vaultKey = await unwrapMasterKey(masterPassword, config);
     try {
-      const deviceWrapped = seal(vaultKey, this.deviceKey, DEVICE_KEY_AAD);
-      this.database.updatePasswordVaultConfig({
-        ...config,
-        deviceKeyNonce: deviceWrapped.nonce,
-        deviceKeyCiphertext: deviceWrapped.ciphertext,
-        deviceKeyTag: deviceWrapped.authTag,
-      });
+      await this.storeOsKey(config.vaultId, vaultKey);
+      try {
+        this.database.updatePasswordVaultConfig({
+          ...config,
+          unlockPolicy: 'never',
+        });
+      } catch (err) {
+        await this.keyStore.delete(config.vaultId).catch(() => undefined);
+        throw err;
+      }
       this.setKey(vaultKey);
-    } catch (err) {
+    } finally {
       vaultKey.fill(0);
-      throw err;
     }
   }
 
-  /**
-   * Wipes the current data key. It will be restored from the local device key
-   * on the next status check or password operation.
-   */
+  async changeUnlockPolicy(
+    masterPassword: string,
+    unlockPolicy: PasswordVaultUnlockPolicy,
+  ): Promise<void> {
+    const config = this.requireConfig();
+    const vaultKey = await unwrapMasterKey(masterPassword, config);
+    try {
+      if (unlockPolicy === 'never') {
+        await this.storeOsKey(config.vaultId, vaultKey);
+        try {
+          this.database.updatePasswordVaultConfig({
+            ...config,
+            unlockPolicy,
+          });
+        } catch (err) {
+          await this.keyStore.delete(config.vaultId).catch(() => undefined);
+          throw err;
+        }
+        this.setKey(vaultKey);
+        return;
+      }
+
+      if (config.unlockPolicy === 'never') {
+        await this.keyStore.delete(config.vaultId);
+      }
+      this.database.updatePasswordVaultConfig({
+        ...config,
+        unlockPolicy,
+      });
+      if (unlockPolicy === 'startup') this.setKey(vaultKey);
+      else this.lock();
+    } finally {
+      vaultKey.fill(0);
+    }
+  }
+
   lock(): void {
     this.key?.fill(0);
     this.key = undefined;
@@ -228,7 +323,6 @@ export class PasswordVault {
 
   dispose(): void {
     this.lock();
-    this.deviceKey.fill(0);
   }
 
   async changeMasterPassword(
@@ -244,6 +338,9 @@ export class PasswordVault {
       const kdf = this.options.kdf ?? DEFAULT_KDF;
       nextMasterKey = await deriveKey(nextPassword, nextSalt, kdf);
       const masterWrapped = seal(vaultKey, nextMasterKey, MASTER_KEY_AAD);
+      if (config.unlockPolicy === 'never') {
+        await this.storeOsKey(config.vaultId, vaultKey);
+      }
       this.database.updatePasswordVaultConfig({
         ...config,
         formatVersion: FORMAT_VERSION,
@@ -256,11 +353,9 @@ export class PasswordVault {
         masterKeyCiphertext: masterWrapped.ciphertext,
         masterKeyTag: masterWrapped.authTag,
       });
-      this.setKey(vaultKey);
-    } catch (err) {
-      vaultKey.fill(0);
-      throw err;
+      if (config.unlockPolicy !== 'credential') this.setKey(vaultKey);
     } finally {
+      vaultKey.fill(0);
       nextMasterKey?.fill(0);
     }
   }
@@ -275,19 +370,32 @@ export class PasswordVault {
     );
   }
 
-  sshPassword(account: string): string | undefined {
+  async sshPassword(
+    account: string,
+    masterPassword?: string,
+  ): Promise<string | undefined> {
     const record = this.database.encryptedCredential(
       PASSWORD_VAULT_PROVIDER,
       SSH_PASSWORD_SERVICE,
       account,
     );
     if (!record) return undefined;
-    return this.decryptRecord(record, this.requireAutomaticKey());
+    const access = await this.credentialKey(masterPassword);
+    try {
+      return this.decryptRecord(record, access.key);
+    } finally {
+      if (access.ephemeral) access.key.fill(0);
+    }
   }
 
-  rememberSshPassword(account: string, label: string, password: string): void {
+  async rememberSshPassword(
+    account: string,
+    label: string,
+    password: string,
+    masterPassword?: string,
+  ): Promise<void> {
     validateSavedPassword(password);
-    const key = this.requireAutomaticKey();
+    const access = await this.credentialKey(masterPassword);
     const ref = this.database.upsertCredentialRef({
       provider: PASSWORD_VAULT_PROVIDER,
       service: SSH_PASSWORD_SERVICE,
@@ -296,7 +404,11 @@ export class PasswordVault {
     });
     const plaintext = Buffer.from(password, 'utf8');
     try {
-      const encrypted = seal(plaintext, key, credentialAad(ref.id));
+      const encrypted = seal(
+        plaintext,
+        access.key,
+        credentialAad(ref.id),
+      );
       this.database.upsertEncryptedCredential({
         provider: PASSWORD_VAULT_PROVIDER,
         service: SSH_PASSWORD_SERVICE,
@@ -309,6 +421,7 @@ export class PasswordVault {
       });
     } finally {
       plaintext.fill(0);
+      if (access.ephemeral) access.key.fill(0);
     }
   }
 
@@ -378,7 +491,11 @@ export class PasswordVault {
     );
   }
 
-  deleteAll(): void {
+  async deleteAll(): Promise<void> {
+    const config = this.database.passwordVaultConfig();
+    if (config?.unlockPolicy === 'never') {
+      await this.keyStore.delete(config.vaultId);
+    }
     this.lock();
     this.database.deletePasswordVaultData(PASSWORD_VAULT_PROVIDER);
   }
@@ -389,34 +506,33 @@ export class PasswordVault {
     return config;
   }
 
-  private requireAutomaticKey(): Buffer {
-    this.restoreAutomaticAccess();
-    if (!this.key) throw new VaultAutomaticAccessError();
-    return this.key;
-  }
-
-  private restoreAutomaticAccess(): void {
-    if (this.key) return;
-    const config = this.database.passwordVaultConfig();
-    if (!config) return;
-    try {
-      const key = open(
-        {
-          nonce: config.deviceKeyNonce,
-          ciphertext: config.deviceKeyCiphertext,
-          authTag: config.deviceKeyTag,
-        },
-        this.deviceKey,
-        DEVICE_KEY_AAD,
-      );
-      if (key.length !== KEY_BYTES) {
-        key.fill(0);
-        return;
+  private async credentialKey(
+    masterPassword?: string,
+  ): Promise<CredentialKey> {
+    const config = this.requireConfig();
+    if (this.key) return { key: this.key, ephemeral: false };
+    if (masterPassword === undefined) {
+      if (config.unlockPolicy === 'never') {
+        throw new VaultAutomaticAccessError();
       }
-      this.setKey(key);
-    } catch {
-      // A missing/replaced device key is repairable with the master password.
+      throw new VaultUnlockRequiredError(config.unlockPolicy);
     }
+
+    const vaultKey = await unwrapMasterKey(masterPassword, config);
+    if (config.unlockPolicy === 'credential') {
+      return { key: vaultKey, ephemeral: true };
+    }
+    if (config.unlockPolicy === 'never') {
+      try {
+        await this.storeOsKey(config.vaultId, vaultKey);
+      } catch (err) {
+        vaultKey.fill(0);
+        throw err;
+      }
+    }
+    this.setKey(vaultKey);
+    vaultKey.fill(0);
+    return { key: this.key!, ephemeral: false };
   }
 
   private decryptRecord(
@@ -446,7 +562,17 @@ export class PasswordVault {
 
   private setKey(key: Buffer): void {
     this.key?.fill(0);
-    this.key = key;
+    this.key = Buffer.from(key);
+  }
+
+  private async storeOsKey(vaultId: string, key: Buffer): Promise<void> {
+    try {
+      await this.keyStore.set(vaultId, key);
+      this.osKeyStoreAvailable = true;
+    } catch (err) {
+      this.osKeyStoreAvailable = false;
+      throw err;
+    }
   }
 }
 
@@ -470,10 +596,17 @@ export function sshPasswordLabel(input: {
 }
 
 export function validateMasterPassword(password: string): void {
+  validateMasterPasswordLength(password, MASTER_PASSWORD_MIN_LENGTH);
+}
+
+function validateMasterPasswordLength(
+  password: string,
+  minimumLength: number,
+): void {
   const bytes = Buffer.byteLength(password, 'utf8');
-  if (Array.from(password).length < MASTER_PASSWORD_MIN_LENGTH) {
+  if (Array.from(password).length < minimumLength) {
     throw new InvalidMasterPasswordFormatError(
-      `Master password must contain at least ${MASTER_PASSWORD_MIN_LENGTH} characters.`,
+      `Master password must contain at least ${minimumLength} characters.`,
     );
   }
   if (bytes > MASTER_PASSWORD_MAX_BYTES) {
@@ -485,61 +618,6 @@ function validateSavedPassword(password: string): void {
   if (Buffer.byteLength(password, 'utf8') > SSH_PASSWORD_MAX_BYTES) {
     throw new InvalidSavedPasswordFormatError();
   }
-}
-
-function defaultDeviceKeyPath(filename: string): string | undefined {
-  return filename === ':memory:'
-    ? undefined
-    : path.join(path.dirname(filename), DEVICE_KEY_FILENAME);
-}
-
-function checkedDeviceKey(value: Buffer): Buffer {
-  if (value.length !== KEY_BYTES) {
-    throw new Error(`Password-vault device key must be ${KEY_BYTES} bytes.`);
-  }
-  return Buffer.from(value);
-}
-
-function loadOrCreateDeviceKey(filename: string | undefined): Buffer {
-  if (!filename) return randomBytes(KEY_BYTES);
-  try {
-    const key = checkedDeviceKey(readFileSync(filename));
-    if (process.platform !== 'win32') chmodSync(filename, 0o600);
-    return key;
-  } catch (err) {
-    if (!isMissingFileError(err)) throw err;
-  }
-
-  mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
-  const key = randomBytes(KEY_BYTES);
-  try {
-    writeFileSync(filename, key, { flag: 'wx', mode: 0o600 });
-  } catch (err) {
-    if (!isExistingFileError(err)) {
-      key.fill(0);
-      throw err;
-    }
-    key.fill(0);
-    return checkedDeviceKey(readFileSync(filename));
-  }
-  if (process.platform !== 'win32') chmodSync(filename, 0o600);
-  return key;
-}
-
-function isMissingFileError(err: unknown): boolean {
-  return (
-    err instanceof Error &&
-    'code' in err &&
-    (err as NodeJS.ErrnoException).code === 'ENOENT'
-  );
-}
-
-function isExistingFileError(err: unknown): boolean {
-  return (
-    err instanceof Error &&
-    'code' in err &&
-    (err as NodeJS.ErrnoException).code === 'EEXIST'
-  );
 }
 
 function credentialAad(id: string): Buffer {
@@ -575,7 +653,10 @@ function deriveKey(
 ): Promise<Buffer> {
   const message = Buffer.from(password, 'utf8');
   const requiredMemory = 128 * kdf.cost * kdf.blockSize;
-  const maxmem = Math.max(32 * 1024 * 1024, requiredMemory + 8 * 1024 * 1024);
+  const maxmem = Math.max(
+    32 * 1024 * 1024,
+    requiredMemory + 8 * 1024 * 1024,
+  );
   return new Promise((resolve, reject) => {
     scrypt(
       message,
@@ -600,7 +681,12 @@ async function unwrapMasterKey(
   masterPassword: string,
   config: PasswordVaultConfigRecord,
 ): Promise<Buffer> {
-  validateMasterPassword(masterPassword);
+  validateMasterPasswordLength(
+    masterPassword,
+    config.formatVersion === 2
+      ? LEGACY_MASTER_PASSWORD_MIN_LENGTH
+      : MASTER_PASSWORD_MIN_LENGTH,
+  );
   let masterKey: Buffer | undefined;
   try {
     masterKey = await deriveKey(masterPassword, config.kdfSalt, {
@@ -615,7 +701,7 @@ async function unwrapMasterKey(
         authTag: config.masterKeyTag,
       },
       masterKey,
-      MASTER_KEY_AAD,
+      config.formatVersion === 2 ? LEGACY_MASTER_KEY_AAD : MASTER_KEY_AAD,
     );
     if (key.length !== KEY_BYTES) {
       key.fill(0);
@@ -628,4 +714,46 @@ async function unwrapMasterKey(
   } finally {
     masterKey?.fill(0);
   }
+}
+
+async function removeLegacyDeviceKey(databaseFilename: string): Promise<void> {
+  if (databaseFilename === ':memory:') return;
+  const filename = path.join(
+    path.dirname(databaseFilename),
+    LEGACY_DEVICE_KEY_FILENAME,
+  );
+  let handle;
+  try {
+    handle = await openFile(filename, 'r+');
+    const replacement = Buffer.alloc(KEY_BYTES);
+    try {
+      await handle.write(replacement, 0, replacement.length, 0);
+      await handle.truncate(0);
+      await handle.sync();
+    } finally {
+      replacement.fill(0);
+      await handle.close();
+      handle = undefined;
+    }
+    await unlink(filename);
+  } catch (err) {
+    if (isMissingFileError(err)) return;
+    try {
+      await handle?.close();
+    } catch {
+      // Preserve the original cleanup failure.
+    }
+    throw new Error(
+      'Muxus could not remove the obsolete on-disk password-vault key.',
+      { cause: err },
+    );
+  }
+}
+
+function isMissingFileError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    (err as NodeJS.ErrnoException).code === 'ENOENT'
+  );
 }

--- a/server/src/security/password-vault.ts
+++ b/server/src/security/password-vault.ts
@@ -1,8 +1,10 @@
 import {
   createCipheriv,
   createDecipheriv,
+  createHmac,
   randomBytes,
   scrypt,
+  timingSafeEqual,
 } from 'node:crypto';
 import { open as openFile, unlink } from 'node:fs/promises';
 import path from 'node:path';
@@ -44,6 +46,10 @@ const LEGACY_MASTER_KEY_AAD = Buffer.from(
 );
 const MASTER_KEY_AAD = Buffer.from(
   'muxus:password-vault:master-key:v3',
+  'utf8',
+);
+const KEY_CHECK_CONTEXT = Buffer.from(
+  'muxus:password-vault:key-check:v1',
   'utf8',
 );
 
@@ -156,20 +162,27 @@ export class PasswordVault {
 
   async initialize(): Promise<void> {
     if (this.initialized) return;
-    this.initialized = true;
     await removeLegacyDeviceKey(this.database.filename);
     const config = this.database.passwordVaultConfig();
-    if (!config || config.unlockPolicy !== 'never') return;
-    try {
-      const key = await this.keyStore.get(config.vaultId);
-      if (key) {
-        this.setKey(key);
-        key.fill(0);
+    if (config?.unlockPolicy === 'never') {
+      try {
+        const key = await this.keyStore.get(config.vaultId);
+        if (key) {
+          try {
+            if (this.isVerifiedKey(config, key)) {
+              this.ensureKeyCheck(config, key);
+              this.setKey(key);
+            }
+          } finally {
+            key.fill(0);
+          }
+        }
+      } catch (err) {
+        if (!(err instanceof VaultKeyStoreUnavailableError)) throw err;
+        this.osKeyStoreAvailable = false;
       }
-    } catch (err) {
-      if (!(err instanceof VaultKeyStoreUnavailableError)) throw err;
-      this.osKeyStoreAvailable = false;
     }
+    this.initialized = true;
   }
 
   status(): PasswordVaultStatus {
@@ -229,6 +242,7 @@ export class PasswordVault {
         masterKeyNonce: masterWrapped.nonce,
         masterKeyCiphertext: masterWrapped.ciphertext,
         masterKeyTag: masterWrapped.authTag,
+        keyCheck: vaultKeyCheck(vaultKey),
       });
       if (unlockPolicy !== 'credential') this.setKey(vaultKey);
     } catch (err) {
@@ -251,6 +265,7 @@ export class PasswordVault {
     }
     const vaultKey = await unwrapMasterKey(masterPassword, config);
     try {
+      this.ensureKeyCheck(config, vaultKey);
       this.setKey(vaultKey);
     } finally {
       vaultKey.fill(0);
@@ -264,14 +279,17 @@ export class PasswordVault {
     const config = this.requireConfig();
     const vaultKey = await unwrapMasterKey(masterPassword, config);
     try {
-      await this.storeOsKey(config.vaultId, vaultKey);
+      const checkedConfig = this.ensureKeyCheck(config, vaultKey);
+      await this.storeOsKey(checkedConfig.vaultId, vaultKey);
       try {
         this.database.updatePasswordVaultConfig({
-          ...config,
+          ...checkedConfig,
           unlockPolicy: 'never',
         });
       } catch (err) {
-        await this.keyStore.delete(config.vaultId).catch(() => undefined);
+        await this.keyStore
+          .delete(checkedConfig.vaultId)
+          .catch(() => undefined);
         throw err;
       }
       this.setKey(vaultKey);
@@ -287,26 +305,29 @@ export class PasswordVault {
     const config = this.requireConfig();
     const vaultKey = await unwrapMasterKey(masterPassword, config);
     try {
+      const checkedConfig = this.ensureKeyCheck(config, vaultKey);
       if (unlockPolicy === 'never') {
-        await this.storeOsKey(config.vaultId, vaultKey);
+        await this.storeOsKey(checkedConfig.vaultId, vaultKey);
         try {
           this.database.updatePasswordVaultConfig({
-            ...config,
+            ...checkedConfig,
             unlockPolicy,
           });
         } catch (err) {
-          await this.keyStore.delete(config.vaultId).catch(() => undefined);
+          await this.keyStore
+            .delete(checkedConfig.vaultId)
+            .catch(() => undefined);
           throw err;
         }
         this.setKey(vaultKey);
         return;
       }
 
-      if (config.unlockPolicy === 'never') {
-        await this.keyStore.delete(config.vaultId);
+      if (checkedConfig.unlockPolicy === 'never') {
+        await this.deleteOsKeyBestEffort(checkedConfig.vaultId);
       }
       this.database.updatePasswordVaultConfig({
-        ...config,
+        ...checkedConfig,
         unlockPolicy,
       });
       if (unlockPolicy === 'startup') this.setKey(vaultKey);
@@ -335,14 +356,12 @@ export class PasswordVault {
     const nextSalt = randomBytes(SALT_BYTES);
     let nextMasterKey: Buffer | undefined;
     try {
+      const checkedConfig = this.ensureKeyCheck(config, vaultKey);
       const kdf = this.options.kdf ?? DEFAULT_KDF;
       nextMasterKey = await deriveKey(nextPassword, nextSalt, kdf);
       const masterWrapped = seal(vaultKey, nextMasterKey, MASTER_KEY_AAD);
-      if (config.unlockPolicy === 'never') {
-        await this.storeOsKey(config.vaultId, vaultKey);
-      }
       this.database.updatePasswordVaultConfig({
-        ...config,
+        ...checkedConfig,
         formatVersion: FORMAT_VERSION,
         kdfAlgorithm: 'scrypt',
         kdfSalt: nextSalt,
@@ -353,7 +372,10 @@ export class PasswordVault {
         masterKeyCiphertext: masterWrapped.ciphertext,
         masterKeyTag: masterWrapped.authTag,
       });
-      if (config.unlockPolicy !== 'credential') this.setKey(vaultKey);
+      if (checkedConfig.unlockPolicy === 'never') {
+        await this.storeOsKeyBestEffort(checkedConfig.vaultId, vaultKey);
+      }
+      if (checkedConfig.unlockPolicy !== 'credential') this.setKey(vaultKey);
     } finally {
       vaultKey.fill(0);
       nextMasterKey?.fill(0);
@@ -396,29 +418,29 @@ export class PasswordVault {
   ): Promise<void> {
     validateSavedPassword(password);
     const access = await this.credentialKey(masterPassword);
-    const ref = this.database.upsertCredentialRef({
-      provider: PASSWORD_VAULT_PROVIDER,
-      service: SSH_PASSWORD_SERVICE,
-      account,
-      label,
-    });
     const plaintext = Buffer.from(password, 'utf8');
     try {
-      const encrypted = seal(
-        plaintext,
-        access.key,
-        credentialAad(ref.id),
+      this.database.upsertEncryptedCredentialAtomically(
+        {
+          provider: PASSWORD_VAULT_PROVIDER,
+          service: SSH_PASSWORD_SERVICE,
+          account,
+          label,
+        },
+        (ref) => {
+          const encrypted = seal(
+            plaintext,
+            access.key,
+            credentialAad(ref.id),
+          );
+          return {
+            formatVersion: CREDENTIAL_FORMAT_VERSION,
+            nonce: encrypted.nonce,
+            ciphertext: encrypted.ciphertext,
+            authTag: encrypted.authTag,
+          };
+        },
       );
-      this.database.upsertEncryptedCredential({
-        provider: PASSWORD_VAULT_PROVIDER,
-        service: SSH_PASSWORD_SERVICE,
-        account,
-        label,
-        formatVersion: CREDENTIAL_FORMAT_VERSION,
-        nonce: encrypted.nonce,
-        ciphertext: encrypted.ciphertext,
-        authTag: encrypted.authTag,
-      });
     } finally {
       plaintext.fill(0);
       if (access.ephemeral) access.key.fill(0);
@@ -434,11 +456,10 @@ export class PasswordVault {
       PASSWORD_VAULT_PROVIDER,
     );
     if (!record) return undefined;
-    const managementKey = await unwrapMasterKey(
-      masterPassword,
-      this.requireConfig(),
-    );
+    const config = this.requireConfig();
+    const managementKey = await unwrapMasterKey(masterPassword, config);
     try {
+      this.ensureKeyCheck(config, managementKey);
       return this.decryptRecord(record, managementKey);
     } finally {
       managementKey.fill(0);
@@ -456,12 +477,11 @@ export class PasswordVault {
       PASSWORD_VAULT_PROVIDER,
     );
     if (!record) return false;
-    const managementKey = await unwrapMasterKey(
-      masterPassword,
-      this.requireConfig(),
-    );
+    const config = this.requireConfig();
+    const managementKey = await unwrapMasterKey(masterPassword, config);
     const plaintext = Buffer.from(password, 'utf8');
     try {
+      this.ensureKeyCheck(config, managementKey);
       const encrypted = seal(
         plaintext,
         managementKey,
@@ -494,7 +514,7 @@ export class PasswordVault {
   async deleteAll(): Promise<void> {
     const config = this.database.passwordVaultConfig();
     if (config?.unlockPolicy === 'never') {
-      await this.keyStore.delete(config.vaultId);
+      await this.deleteOsKeyBestEffort(config.vaultId);
     }
     this.lock();
     this.database.deletePasswordVaultData(PASSWORD_VAULT_PROVIDER);
@@ -519,20 +539,21 @@ export class PasswordVault {
     }
 
     const vaultKey = await unwrapMasterKey(masterPassword, config);
-    if (config.unlockPolicy === 'credential') {
-      return { key: vaultKey, ephemeral: true };
-    }
-    if (config.unlockPolicy === 'never') {
-      try {
-        await this.storeOsKey(config.vaultId, vaultKey);
-      } catch (err) {
-        vaultKey.fill(0);
-        throw err;
+    try {
+      const checkedConfig = this.ensureKeyCheck(config, vaultKey);
+      if (checkedConfig.unlockPolicy === 'credential') {
+        return { key: vaultKey, ephemeral: true };
       }
+      if (checkedConfig.unlockPolicy === 'never') {
+        await this.storeOsKeyBestEffort(checkedConfig.vaultId, vaultKey);
+      }
+      this.setKey(vaultKey);
+      vaultKey.fill(0);
+      return { key: this.key!, ephemeral: false };
+    } catch (err) {
+      vaultKey.fill(0);
+      throw err;
     }
-    this.setKey(vaultKey);
-    vaultKey.fill(0);
-    return { key: this.key!, ephemeral: false };
   }
 
   private decryptRecord(
@@ -571,6 +592,86 @@ export class PasswordVault {
       this.osKeyStoreAvailable = true;
     } catch (err) {
       this.osKeyStoreAvailable = false;
+      throw err;
+    }
+  }
+
+  private async storeOsKeyBestEffort(
+    vaultId: string,
+    key: Buffer,
+  ): Promise<void> {
+    try {
+      await this.storeOsKey(vaultId, key);
+    } catch {
+      // The master-password copy remains authoritative. A cache write must not
+      // discard a key that was successfully unwrapped.
+    }
+  }
+
+  private async deleteOsKeyBestEffort(vaultId: string): Promise<void> {
+    try {
+      await this.keyStore.delete(vaultId);
+      this.osKeyStoreAvailable = true;
+    } catch {
+      // Moving away from automatic access and resetting the vault are recovery
+      // paths; an unavailable credential store must not block either action.
+      this.osKeyStoreAvailable = false;
+    }
+  }
+
+  private isVerifiedKey(
+    config: PasswordVaultConfigRecord,
+    key: Buffer,
+  ): boolean {
+    if (config.keyCheck) {
+      const actual = vaultKeyCheck(key);
+      try {
+        return timingSafeEqual(actual, config.keyCheck);
+      } finally {
+        actual.fill(0);
+      }
+    }
+
+    // Draft vaults predate the durable key check. An existing credential can
+    // authenticate their stored key once; empty vaults require the master
+    // password before automatic access is enabled.
+    const [record] = this.database.listEncryptedCredentials(
+      PASSWORD_VAULT_PROVIDER,
+      SSH_PASSWORD_SERVICE,
+    );
+    if (!record) return false;
+    try {
+      const plaintext = open(
+        {
+          nonce: record.nonce,
+          ciphertext: record.ciphertext,
+          authTag: record.authTag,
+        },
+        key,
+        credentialAad(record.id),
+      );
+      plaintext.fill(0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private ensureKeyCheck(
+    config: PasswordVaultConfigRecord,
+    key: Buffer,
+  ): PasswordVaultConfigRecord {
+    const check = vaultKeyCheck(key);
+    if (config.keyCheck && timingSafeEqual(check, config.keyCheck)) {
+      check.fill(0);
+      return config;
+    }
+    const next = { ...config, keyCheck: check };
+    try {
+      this.database.updatePasswordVaultConfig(next);
+      return next;
+    } catch (err) {
+      check.fill(0);
       throw err;
     }
   }
@@ -694,6 +795,11 @@ async function unwrapMasterKey(
       blockSize: config.kdfBlockSize,
       parallelism: config.kdfParallelism,
     });
+  } catch (err) {
+    masterKey?.fill(0);
+    throw err;
+  }
+  try {
     const key = open(
       {
         nonce: config.masterKeyNonce,
@@ -708,12 +814,15 @@ async function unwrapMasterKey(
       throw new InvalidMasterPasswordError();
     }
     return key;
-  } catch (err) {
-    if (err instanceof InvalidMasterPasswordFormatError) throw err;
+  } catch {
     throw new InvalidMasterPasswordError();
   } finally {
     masterKey?.fill(0);
   }
+}
+
+function vaultKeyCheck(key: Buffer): Buffer {
+  return createHmac('sha256', key).update(KEY_CHECK_CONTEXT).digest();
 }
 
 async function removeLegacyDeviceKey(databaseFilename: string): Promise<void> {
@@ -741,12 +850,10 @@ async function removeLegacyDeviceKey(databaseFilename: string): Promise<void> {
     try {
       await handle?.close();
     } catch {
-      // Preserve the original cleanup failure.
+      // The original cleanup failure is already intentionally ignored.
     }
-    throw new Error(
-      'Muxus could not remove the obsolete on-disk password-vault key.',
-      { cause: err },
-    );
+    // This file belongs to an obsolete draft implementation. Cleanup is
+    // retried on the next process start, but must never prevent boot.
   }
 }
 

--- a/server/src/security/vault-key-store.ts
+++ b/server/src/security/vault-key-store.ts
@@ -1,0 +1,107 @@
+const SERVICE = 'io.github.flosch62.muxus.password-vault';
+const KEY_BYTES = 32;
+
+export interface VaultKeyStore {
+  readonly backend: 'os' | 'memory';
+  get(vaultId: string): Promise<Buffer | undefined>;
+  set(vaultId: string, key: Buffer): Promise<void>;
+  delete(vaultId: string): Promise<void>;
+}
+
+export class VaultKeyStoreUnavailableError extends Error {
+  constructor(options?: ErrorOptions) {
+    super(
+      'The operating-system credential store is unavailable. Choose a master-password prompt policy or start an unlocked Secret Service-compatible keyring.',
+      options,
+    );
+  }
+}
+
+/**
+ * Windows Credential Manager / macOS Keychain / Linux Secret Service adapter.
+ *
+ * The native package also supports the Linux kernel keyring when Secret
+ * Service is unavailable. It never falls back to an application-owned file.
+ */
+export class SystemVaultKeyStore implements VaultKeyStore {
+  readonly backend = 'os' as const;
+
+  async get(vaultId: string): Promise<Buffer | undefined> {
+    try {
+      const entry = await this.entry(vaultId);
+      const secret = await entry.getSecret();
+      if (!secret) return undefined;
+      const key = Buffer.from(secret);
+      if (key.length !== KEY_BYTES) {
+        key.fill(0);
+        throw new Error('The OS credential-store entry has an invalid length.');
+      }
+      return key;
+    } catch (err) {
+      if (err instanceof VaultKeyStoreUnavailableError) throw err;
+      throw new VaultKeyStoreUnavailableError({ cause: err });
+    }
+  }
+
+  async set(vaultId: string, key: Buffer): Promise<void> {
+    if (key.length !== KEY_BYTES) {
+      throw new Error(`Password-vault key must be ${KEY_BYTES} bytes.`);
+    }
+    try {
+      const entry = await this.entry(vaultId);
+      await entry.setSecret(key);
+    } catch (err) {
+      throw new VaultKeyStoreUnavailableError({ cause: err });
+    }
+  }
+
+  async delete(vaultId: string): Promise<void> {
+    const replacement = Buffer.alloc(KEY_BYTES);
+    try {
+      const entry = await this.entry(vaultId);
+      // The binding reports deletion failures as `false` rather than
+      // rejecting. Overwrite first so even a failed delete cannot leave the
+      // usable vault key behind.
+      await entry.setSecret(replacement);
+      const deleted = await entry.deleteCredential();
+      if (!deleted) {
+        throw new Error('The OS credential-store entry could not be deleted.');
+      }
+    } catch (err) {
+      throw new VaultKeyStoreUnavailableError({ cause: err });
+    } finally {
+      replacement.fill(0);
+    }
+  }
+
+  private async entry(vaultId: string) {
+    try {
+      const { AsyncEntry } = await import('@napi-rs/keyring');
+      return new AsyncEntry(SERVICE, vaultId);
+    } catch (err) {
+      throw new VaultKeyStoreUnavailableError({ cause: err });
+    }
+  }
+}
+
+/** In-memory credential store for tests and ephemeral :memory: databases. */
+export class MemoryVaultKeyStore implements VaultKeyStore {
+  readonly backend = 'memory' as const;
+
+  constructor(private readonly values = new Map<string, Buffer>()) {}
+
+  async get(vaultId: string): Promise<Buffer | undefined> {
+    const value = this.values.get(vaultId);
+    return value ? Buffer.from(value) : undefined;
+  }
+
+  async set(vaultId: string, key: Buffer): Promise<void> {
+    this.values.get(vaultId)?.fill(0);
+    this.values.set(vaultId, Buffer.from(key));
+  }
+
+  async delete(vaultId: string): Promise<void> {
+    this.values.get(vaultId)?.fill(0);
+    this.values.delete(vaultId);
+  }
+}

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -15,7 +15,13 @@ import {
 } from 'ssh2';
 import { nanoid } from 'nanoid';
 import type { FastifyBaseLogger } from 'fastify';
-import type { ConfigForward, ConnectionInfo, SshProfile } from '@muxus/shared';
+import type {
+  AuthPromptInfo,
+  AuthPromptResponse,
+  ConfigForward,
+  ConnectionInfo,
+  SshProfile,
+} from '@muxus/shared';
 import {
   certificateAlgorithms,
   certificateMatchesKey,
@@ -33,6 +39,16 @@ import {
 } from './connection-leases.js';
 import { connectionAlgorithms } from './algorithms.js';
 import { openIntegratedRemoteShell } from './remote-shell-integration.js';
+import {
+  CredentialVaultCorruptError,
+  InvalidMasterPasswordError,
+  InvalidMasterPasswordFormatError,
+  PasswordVault,
+  VaultAlreadyConfiguredError,
+  VaultAutomaticAccessError,
+  sshPasswordAccount,
+  sshPasswordLabel,
+} from '../security/password-vault.js';
 import {
   expandIdentityPath,
   listHosts,
@@ -59,7 +75,7 @@ export interface HostKeyChallenge {
 export interface ConnectIo {
   status(message: string, options?: { transient?: boolean }): void;
   /** Ask the user to answer auth prompts (password, 2FA, key passphrase). */
-  prompt(info: { name?: string; instructions?: string; host?: string; prompts: Array<{ prompt: string; echo: boolean }> }): Promise<string[]>;
+  prompt(info: AuthPromptInfo): Promise<AuthPromptResponse>;
   /** Ask the user to accept a new or changed host key. */
   hostKey(challenge: HostKeyChallenge): Promise<boolean>;
 }
@@ -216,14 +232,20 @@ export class SshConnectionManager {
   /** In-flight dials by mux key, so simultaneous sessions share one TCP connection and one auth round-trip. */
   private readonly pendingDials = new Map<string, Promise<ManagedConnection>>();
   private readonly loadConfig: () => ConfigDocument;
+  private readonly vault: PasswordVault | undefined;
   readonly knownHosts: KnownHostsStore;
 
   constructor(
     private readonly log: FastifyBaseLogger,
-    options: { knownHosts?: KnownHostsStore; loadConfig?: () => ConfigDocument } = {},
+    options: {
+      knownHosts?: KnownHostsStore;
+      loadConfig?: () => ConfigDocument;
+      vault?: PasswordVault;
+    } = {},
   ) {
     this.knownHosts = options.knownHosts ?? new KnownHostsStore();
     this.loadConfig = options.loadConfig ?? (() => loadConfigDocument());
+    this.vault = options.vault;
   }
 
   /** Acquire an independent consumer lease on an existing SSH transport. */
@@ -532,7 +554,7 @@ export class SshConnectionManager {
 
   private dial(hop: ChainHop, sock: Duplex | undefined, io: ConnectIo): Promise<Client> {
     const agent = resolveAgentSocket(hop.resolved.identityAgent);
-    const auth = new AuthLadder(hop, io);
+    const auth = new AuthLadder(hop, io, this.vault);
     const { algorithms, notes } = connectionAlgorithms(hop.resolved);
     for (const note of notes) io.status(note);
     const proxySocket =
@@ -547,8 +569,12 @@ export class SshConnectionManager {
       hostVerifier: (key: Buffer, verify: (valid: boolean) => void) => {
         void this.verifyHostKey(hop, key, io).then(verify);
       },
-      authHandler: (authsLeft, _partialSuccess, next) => {
-        auth.next(authsLeft, next as (method: AnyAuthMethod | false) => void);
+      authHandler: (authsLeft, partialSuccess, next) => {
+        auth.next(
+          authsLeft,
+          partialSuccess,
+          next as (method: AnyAuthMethod | false) => void,
+        );
       },
       ...(transport ? { sock: transport } : { host: hop.resolved.hostname, port: hop.port }),
       ...(agent ? { agent, agentForward: hop.resolved.forwardAgent } : {}),
@@ -560,11 +586,24 @@ export class SshConnectionManager {
       client.on('banner', (message: string) => io.status(message.trimEnd()));
       client.on('ready', () => {
         settled = true;
-        resolve(client);
+        void auth
+          .commitRememberedPassword()
+          .catch((err) => {
+            io.status(
+              err instanceof Error
+                ? `Connected, but the password was not remembered: ${err.message}`
+                : 'Connected, but the password was not remembered.',
+            );
+          })
+          .finally(() => {
+            auth.dispose();
+            resolve(client);
+          });
       });
       client.on('error', (err) => {
         if (!settled) {
           settled = true;
+          auth.dispose();
           proxySocket?.destroy();
           reject(friendlyConnectError(auth.cancelled ? new Error('authentication cancelled') : err, hop));
         } else {
@@ -832,6 +871,12 @@ interface AuthAttempt {
   get(): Promise<AnyAuthMethod | undefined>;
 }
 
+interface RememberedPasswordCandidate {
+  account: string;
+  label: string;
+  password: string;
+}
+
 /**
  * OpenSSH's client auth order as an ssh2 authHandler: none → agent (unless
  * IdentitiesOnly) → configured certificates with their matching private keys
@@ -847,16 +892,37 @@ class AuthLadder {
     Promise<ParsedKey | undefined>
   >();
   private index = 0;
+  private lastPasswordCandidate: RememberedPasswordCandidate | undefined;
+  private partialPasswordCandidate: RememberedPasswordCandidate | undefined;
+  private savedPasswordAttempted = false;
   cancelled = false;
 
   constructor(
     private readonly hop: ChainHop,
     private readonly io: ConnectIo,
+    private readonly vault?: PasswordVault,
   ) {
     this.attempts = this.build();
   }
 
-  next(authsLeft: AuthenticationType[] | null, cb: (method: AnyAuthMethod | false) => void): void {
+  next(
+    authsLeft: AuthenticationType[] | null,
+    partialSuccess: boolean,
+    cb: (method: AnyAuthMethod | false) => void,
+  ): void {
+    if (this.lastPasswordCandidate) {
+      if (partialSuccess) {
+        this.partialPasswordCandidate = this.lastPasswordCandidate;
+      }
+      this.lastPasswordCandidate = undefined;
+    }
+    this.advance(authsLeft, cb);
+  }
+
+  private advance(
+    authsLeft: AuthenticationType[] | null,
+    cb: (method: AnyAuthMethod | false) => void,
+  ): void {
     const attempt = this.attempts[this.index++];
     if (!attempt || this.cancelled) {
       cb(false);
@@ -864,19 +930,44 @@ class AuthLadder {
     }
     // The server told us which methods can still succeed; skip the rest.
     if (authsLeft && attempt.type !== 'none' && !authsLeft.includes(attempt.type)) {
-      this.next(authsLeft, cb);
+      this.advance(authsLeft, cb);
       return;
     }
     attempt
       .get()
       .then((method) => {
         if (method) cb(method);
-        else this.next(authsLeft, cb);
+        else this.advance(authsLeft, cb);
       })
       .catch(() => {
         this.cancelled = true;
         cb(false);
       });
+  }
+
+  async commitRememberedPassword(): Promise<void> {
+    const candidate =
+      this.lastPasswordCandidate ?? this.partialPasswordCandidate;
+    if (!candidate || !this.vault) return;
+    try {
+      if (!(await this.ensureVaultAvailableForSave(candidate.label))) return;
+      this.vault.rememberSshPassword(
+        candidate.account,
+        candidate.label,
+        candidate.password,
+      );
+      this.io.status(`Remembered the password for ${candidate.label}.`);
+    } finally {
+      this.lastPasswordCandidate = undefined;
+      this.partialPasswordCandidate = undefined;
+    }
+  }
+
+  dispose(): void {
+    this.lastPasswordCandidate = undefined;
+    this.partialPasswordCandidate = undefined;
+    this.privateKeys.clear();
+    this.certificateKeys.clear();
   }
 
   private build(): AuthAttempt[] {
@@ -942,9 +1033,10 @@ class AuthLadder {
                   name: name || undefined,
                   instructions: instructions || undefined,
                   host: label,
+                  purpose: 'authentication',
                   prompts: prompts.map((p) => ({ prompt: p.prompt, echo: p.echo !== false })),
                 })
-                .then(finish)
+                .then((response) => finish(response.answers))
                 .catch(() => {
                   this.cancelled = true;
                   finish(prompts.map(() => ''));
@@ -958,17 +1050,170 @@ class AuthLadder {
       for (let attempt = 1; attempt <= MAX_PASSWORD_ATTEMPTS; attempt++) {
         attempts.push({
           type: 'password',
-          get: async () => {
-            const [password] = await this.io.prompt({
-              host: label,
-              prompts: [{ prompt: attempt === 1 ? `${user}@${label}'s password` : 'Permission denied, please try again. Password', echo: false }],
-            });
-            return { type: 'password', username: user, password: password ?? '' };
-          },
+          get: () => this.passwordMethod(attempt, label),
         });
       }
     }
     return attempts;
+  }
+
+  private async passwordMethod(
+    attempt: number,
+    promptLabel: string,
+  ): Promise<AnyAuthMethod> {
+    const { user, resolved, port } = this.hop;
+    const account = sshPasswordAccount({
+      user,
+      host: resolved.hostname,
+      port,
+    });
+    const credentialLabel = sshPasswordLabel({
+      user,
+      host: resolved.hostname,
+      port,
+    });
+    const existing = this.vault?.hasSshPassword(account) ?? false;
+
+    if (existing && !this.savedPasswordAttempted && this.vault) {
+      this.savedPasswordAttempted = true;
+      const saved = await this.savedPassword(account, credentialLabel);
+      if (saved !== undefined) {
+        this.io.status(`Using the saved password for ${credentialLabel}.`, {
+          transient: true,
+        });
+        return { type: 'password', username: user, password: saved };
+      }
+    }
+
+    const response = await this.io.prompt({
+      host: promptLabel,
+      purpose: 'ssh-password',
+      instructions:
+        existing && this.savedPasswordAttempted
+          ? 'The saved password was unavailable or was not accepted. Enter the current password.'
+          : undefined,
+      prompts: [
+        {
+          prompt:
+            attempt === 1
+              ? `${user}@${promptLabel}'s password`
+              : 'Permission denied, please try again. Password',
+          echo: false,
+        },
+      ],
+      ...(this.vault
+        ? {
+            rememberPassword: {
+              label: credentialLabel,
+              existing,
+            },
+          }
+        : {}),
+    });
+    if (response.skipped) throw new Error('authentication cancelled');
+    const password = response.answers[0] ?? '';
+    this.lastPasswordCandidate = response.rememberPassword
+      ? { account, label: credentialLabel, password }
+      : undefined;
+    return { type: 'password', username: user, password };
+  }
+
+  private async savedPassword(
+    account: string,
+    label: string,
+  ): Promise<string | undefined> {
+    if (!this.vault) return undefined;
+    if (!this.vault.status().automaticAccess) {
+      this.io.status(
+        `The saved password for ${label} is unavailable because automatic vault access needs repair.`,
+      );
+      return undefined;
+    }
+    try {
+      return this.vault.sshPassword(account);
+    } catch (err) {
+      if (err instanceof CredentialVaultCorruptError) {
+        this.io.status(
+          `The saved password for ${label} is damaged. Enter it again to replace the saved copy.`,
+        );
+        return undefined;
+      }
+      if (err instanceof VaultAutomaticAccessError) return undefined;
+      throw err;
+    }
+  }
+
+  private async ensureVaultAvailableForSave(label: string): Promise<boolean> {
+    if (!this.vault) return false;
+    const status = this.vault.status();
+    if (status.automaticAccess) return true;
+    if (status.configured) {
+      return this.promptToRepairAutomaticAccess(
+        `Repair automatic vault access to remember the password for ${label}.`,
+        'Not now',
+      );
+    }
+
+    const response = await this.io.prompt({
+      name: 'Create password vault',
+      purpose: 'vault-create',
+      instructions:
+        `Create a master password to protect viewing and editing saved SSH passwords. ` +
+        `Routine SSH connections will use them automatically.`,
+      prompts: [
+        { prompt: 'Master password', echo: false },
+        { prompt: 'Confirm master password', echo: false },
+      ],
+      skipLabel: 'Not now',
+    });
+    if (response.skipped) return false;
+    const [masterPassword = '', confirmation = ''] = response.answers;
+    if (masterPassword !== confirmation) {
+      throw new InvalidMasterPasswordFormatError(
+        'The master-password confirmation did not match.',
+      );
+    }
+    try {
+      await this.vault.create(masterPassword);
+    } catch (err) {
+      if (!(err instanceof VaultAlreadyConfiguredError)) throw err;
+      await this.vault.repairAutomaticAccess(masterPassword);
+    }
+    return true;
+  }
+
+  private async promptToRepairAutomaticAccess(
+    instructions: string,
+    skipLabel: string,
+  ): Promise<boolean> {
+    if (!this.vault) return false;
+    let error: string | undefined;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if (this.vault.status().automaticAccess) return true;
+      const response = await this.io.prompt({
+        name: 'Repair automatic password access',
+        purpose: 'vault-repair',
+        instructions: error ? `${error}\n\n${instructions}` : instructions,
+        prompts: [{ prompt: 'Master password', echo: false }],
+        skipLabel,
+      });
+      if (response.skipped) return false;
+      try {
+        await this.vault.repairAutomaticAccess(response.answers[0] ?? '');
+        return true;
+      } catch (err) {
+        if (
+          err instanceof InvalidMasterPasswordError ||
+          err instanceof InvalidMasterPasswordFormatError
+        ) {
+          error = err.message;
+          continue;
+        }
+        throw err;
+      }
+    }
+    this.io.status('Automatic password access remains unavailable.');
+    return false;
   }
 
   private loadCertificate(
@@ -1055,10 +1300,12 @@ class AuthLadder {
       // skipped silently — the agent attempt already covered the loaded ones.
       if (!explicit && agentAvailable) return undefined;
       for (let i = 0; i < MAX_PASSPHRASE_ATTEMPTS && parsed instanceof Error; i++) {
-        const [passphrase] = await this.io.prompt({
+        const response = await this.io.prompt({
           host: label,
+          purpose: 'authentication',
           prompts: [{ prompt: `${i > 0 ? 'Bad passphrase, try again. ' : ''}Passphrase for ${path.basename(file)}`, echo: false }],
         });
+        const [passphrase] = response.answers;
         if (!passphrase) return undefined; // empty answer = skip this key
         parsed = parseSshKey(content, passphrase);
       }

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -129,6 +129,8 @@ export interface ManagedConnection {
   onHealth(listener: (state: SshTransportHealth) => void): () => void;
   /** Subscribe to transport loss; returns an unsubscribe function. */
   onClose(listener: (reason?: string) => void): () => void;
+  /** Wait for post-authentication password-vault prompts and saving. */
+  waitForPostAuth(): Promise<void>;
   /** Force-close the transport, regardless of active leases. */
   close(): void;
 }
@@ -230,6 +232,7 @@ export interface ChainHop {
 export class SshConnectionManager {
   private readonly connections = new ConnectionLeaseRegistry<ManagedConnection>();
   private readonly closeReasons = new WeakMap<Client, string>();
+  private readonly postAuth = new WeakMap<Client, Promise<void>>();
   /** In-flight dials by mux key, so simultaneous sessions share one TCP connection and one auth round-trip. */
   private readonly pendingDials = new Map<string, Promise<ManagedConnection>>();
   private readonly loadConfig: () => ConfigDocument;
@@ -393,6 +396,7 @@ export class SshConnectionManager {
     key: string,
   ): Promise<ConnectionLease> {
     const clients: Client[] = [];
+    const postAuth: Promise<void>[] = [];
     const healthListeners = new Set<(state: SshTransportHealth) => void>();
     const hopHealth = new Map<number, SshTransportHealth>();
     const stopHealthObservers: Array<() => void> = [];
@@ -418,6 +422,8 @@ export class SshConnectionManager {
         );
         const client = await this.dial(hop, sock, io);
         clients.push(client);
+        const pendingPostAuth = this.postAuth.get(client);
+        if (pendingPostAuth) postAuth.push(pendingPostAuth);
         hopHealth.set(i, 'healthy');
         const transport = (client as Client & { _sock?: Duplex })._sock;
         if (transport) {
@@ -445,6 +451,7 @@ export class SshConnectionManager {
       profile.useConfig === false ? undefined : findMetadataAlias(doc, target.spec.host);
     const id = nanoid(10);
     const closeListeners = new Set<(reason?: string) => void>();
+    const postAuthSettled = Promise.all(postAuth).then(() => undefined);
     let sftpPromise: Promise<SFTPWrapper> | undefined;
     let closed = false;
     let ending = false;
@@ -517,6 +524,7 @@ export class SshConnectionManager {
         closeListeners.add(listener);
         return () => closeListeners.delete(listener);
       },
+      waitForPostAuth: () => postAuthSettled,
       close: () => {
         if (ending) return;
         ending = true;
@@ -615,8 +623,7 @@ export class SshConnectionManager {
         ready = true;
         settled = true;
         readyDeadline?.clear();
-        resolve(client);
-        void auth
+        const postAuth = auth
           .commitRememberedPassword()
           .catch((err) => {
             io.status(
@@ -628,6 +635,8 @@ export class SshConnectionManager {
           .finally(() => {
             auth.dispose();
           });
+        this.postAuth.set(client, postAuth);
+        resolve(client);
       });
       client.on('error', (err) => {
         if (!settled) {

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -15,12 +15,13 @@ import {
 } from 'ssh2';
 import { nanoid } from 'nanoid';
 import type { FastifyBaseLogger } from 'fastify';
-import type {
-  AuthPromptInfo,
-  AuthPromptResponse,
-  ConfigForward,
-  ConnectionInfo,
-  SshProfile,
+import {
+  DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY,
+  type AuthPromptInfo,
+  type AuthPromptResponse,
+  type ConfigForward,
+  type ConnectionInfo,
+  type SshProfile,
 } from '@muxus/shared';
 import {
   certificateAlgorithms,
@@ -45,7 +46,6 @@ import {
   InvalidMasterPasswordFormatError,
   PasswordVault,
   VaultAlreadyConfiguredError,
-  VaultAutomaticAccessError,
   sshPasswordAccount,
   sshPasswordLabel,
 } from '../security/password-vault.js';
@@ -950,12 +950,31 @@ class AuthLadder {
       this.lastPasswordCandidate ?? this.partialPasswordCandidate;
     if (!candidate || !this.vault) return;
     try {
-      if (!(await this.ensureVaultAvailableForSave(candidate.label))) return;
-      this.vault.rememberSshPassword(
-        candidate.account,
-        candidate.label,
-        candidate.password,
-      );
+      const status = this.vault.status();
+      if (!status.configured) {
+        if (!(await this.createVaultForSave(candidate.label))) return;
+      }
+      if (this.vault.status().locked) {
+        const result = await this.promptForVaultOperation(
+          'Unlock password vault',
+          `Enter the master password to remember the password for ${candidate.label}.`,
+          'Not now',
+          (masterPassword) =>
+            this.vault!.rememberSshPassword(
+              candidate.account,
+              candidate.label,
+              candidate.password,
+              masterPassword,
+            ),
+        );
+        if (!result.ok) return;
+      } else {
+        await this.vault.rememberSshPassword(
+          candidate.account,
+          candidate.label,
+          candidate.password,
+        );
+      }
       this.io.status(`Remembered the password for ${candidate.label}.`);
     } finally {
       this.lastPasswordCandidate = undefined;
@@ -1123,14 +1142,18 @@ class AuthLadder {
     label: string,
   ): Promise<string | undefined> {
     if (!this.vault) return undefined;
-    if (!this.vault.status().automaticAccess) {
-      this.io.status(
-        `The saved password for ${label} is unavailable because automatic vault access needs repair.`,
-      );
-      return undefined;
-    }
     try {
-      return this.vault.sshPassword(account);
+      if (!this.vault.status().locked) {
+        return await this.vault.sshPassword(account);
+      }
+      const result = await this.promptForVaultOperation(
+        'Unlock password vault',
+        `Enter the master password to use the saved password for ${label}.`,
+        'Use another password',
+        (masterPassword) =>
+          this.vault!.sshPassword(account, masterPassword),
+      );
+      return result.ok ? result.value : undefined;
     } catch (err) {
       if (err instanceof CredentialVaultCorruptError) {
         this.io.status(
@@ -1138,28 +1161,20 @@ class AuthLadder {
         );
         return undefined;
       }
-      if (err instanceof VaultAutomaticAccessError) return undefined;
       throw err;
     }
   }
 
-  private async ensureVaultAvailableForSave(label: string): Promise<boolean> {
+  private async createVaultForSave(label: string): Promise<boolean> {
     if (!this.vault) return false;
-    const status = this.vault.status();
-    if (status.automaticAccess) return true;
-    if (status.configured) {
-      return this.promptToRepairAutomaticAccess(
-        `Repair automatic vault access to remember the password for ${label}.`,
-        'Not now',
-      );
-    }
 
     const response = await this.io.prompt({
       name: 'Create password vault',
       purpose: 'vault-create',
       instructions:
         `Create a master password to protect viewing and editing saved SSH passwords. ` +
-        `Routine SSH connections will use them automatically.`,
+        `By default, Muxus stores the vault key in the operating-system credential store ` +
+        `so saved passwords can be used without another master-password prompt.`,
       prompts: [
         { prompt: 'Master password', echo: false },
         { prompt: 'Confirm master password', echo: false },
@@ -1174,33 +1189,39 @@ class AuthLadder {
       );
     }
     try {
-      await this.vault.create(masterPassword);
+      await this.vault.create(
+        masterPassword,
+        DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY,
+      );
     } catch (err) {
       if (!(err instanceof VaultAlreadyConfiguredError)) throw err;
-      await this.vault.repairAutomaticAccess(masterPassword);
+      this.io.status(
+        `The vault was created in another session; unlock it to remember the password for ${label}.`,
+      );
     }
     return true;
   }
 
-  private async promptToRepairAutomaticAccess(
+  private async promptForVaultOperation<T>(
+    name: string,
     instructions: string,
     skipLabel: string,
-  ): Promise<boolean> {
-    if (!this.vault) return false;
+    operation: (masterPassword: string) => Promise<T>,
+  ): Promise<{ ok: true; value: T } | { ok: false }> {
+    if (!this.vault) return { ok: false };
     let error: string | undefined;
     for (let attempt = 0; attempt < 3; attempt++) {
-      if (this.vault.status().automaticAccess) return true;
       const response = await this.io.prompt({
-        name: 'Repair automatic password access',
-        purpose: 'vault-repair',
+        name,
+        purpose: 'vault-unlock',
         instructions: error ? `${error}\n\n${instructions}` : instructions,
         prompts: [{ prompt: 'Master password', echo: false }],
         skipLabel,
       });
-      if (response.skipped) return false;
+      if (response.skipped) return { ok: false };
       try {
-        await this.vault.repairAutomaticAccess(response.answers[0] ?? '');
-        return true;
+        const value = await operation(response.answers[0] ?? '');
+        return { ok: true, value };
       } catch (err) {
         if (
           err instanceof InvalidMasterPasswordError ||
@@ -1212,8 +1233,8 @@ class AuthLadder {
         throw err;
       }
     }
-    this.io.status('Automatic password access remains unavailable.');
-    return false;
+    this.io.status('The password vault remains locked.');
+    return { ok: false };
   }
 
   private loadCertificate(

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -49,6 +49,7 @@ import {
   sshPasswordAccount,
   sshPasswordLabel,
 } from '../security/password-vault.js';
+import { VaultKeyStoreUnavailableError } from '../security/vault-key-store.js';
 import {
   expandIdentityPath,
   listHosts,
@@ -554,20 +555,32 @@ export class SshConnectionManager {
 
   private dial(hop: ChainHop, sock: Duplex | undefined, io: ConnectIo): Promise<Client> {
     const agent = resolveAgentSocket(hop.resolved.identityAgent);
-    const auth = new AuthLadder(hop, io, this.vault);
+    let readyDeadline: PausableDeadline | undefined;
+    const runInteraction: InteractionRunner = async (interaction) => {
+      readyDeadline?.pause();
+      try {
+        return await interaction();
+      } finally {
+        readyDeadline?.resume();
+      }
+    };
+    const auth = new AuthLadder(hop, io, this.vault, runInteraction);
     const { algorithms, notes } = connectionAlgorithms(hop.resolved);
     for (const note of notes) io.status(note);
     const proxySocket =
       !sock && hop.resolved.proxyCommand ? openProxyCommand(expandedProxyCommand(hop)!) : undefined;
     const transport = sock ?? proxySocket;
+    const readyTimeoutMs = (hop.resolved.connectTimeout ?? 20) * 1000;
     const config: ConnectConfig = {
       username: hop.user,
-      readyTimeout: (hop.resolved.connectTimeout ?? 20) * 1000,
+      // ssh2's deadline includes time spent in UI prompts and cannot be
+      // paused. An equivalent pausable deadline is installed below.
+      readyTimeout: 0,
       keepaliveInterval: (hop.resolved.serverAliveInterval ?? 15) * 1000,
       keepaliveCountMax: hop.resolved.serverAliveCountMax ?? 3,
       ...(algorithms ? { algorithms } : {}),
       hostVerifier: (key: Buffer, verify: (valid: boolean) => void) => {
-        void this.verifyHostKey(hop, key, io).then(verify);
+        void this.verifyHostKey(hop, key, io, runInteraction).then(verify);
       },
       authHandler: (authsLeft, partialSuccess, next) => {
         auth.next(
@@ -583,9 +596,26 @@ export class SshConnectionManager {
     return new Promise((resolve, reject) => {
       const client = new Client();
       let settled = false;
+      let ready = false;
+      const rejectBeforeReady = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        readyDeadline?.clear();
+        auth.dispose();
+        proxySocket?.destroy();
+        reject(friendlyConnectError(err, hop));
+      };
+      readyDeadline = new PausableDeadline(readyTimeoutMs, () => {
+        rejectBeforeReady(new Error('Timed out while waiting for SSH readiness.'));
+        client.destroy();
+      });
       client.on('banner', (message: string) => io.status(message.trimEnd()));
       client.on('ready', () => {
+        if (settled) return;
+        ready = true;
         settled = true;
+        readyDeadline?.clear();
+        resolve(client);
         void auth
           .commitRememberedPassword()
           .catch((err) => {
@@ -597,21 +627,24 @@ export class SshConnectionManager {
           })
           .finally(() => {
             auth.dispose();
-            resolve(client);
           });
       });
       client.on('error', (err) => {
         if (!settled) {
-          settled = true;
-          auth.dispose();
-          proxySocket?.destroy();
-          reject(friendlyConnectError(auth.cancelled ? new Error('authentication cancelled') : err, hop));
-        } else {
+          rejectBeforeReady(
+            auth.cancelled ? new Error('authentication cancelled') : err,
+          );
+        } else if (ready) {
           this.closeReasons.set(client, friendlyConnectError(err, hop).message);
           this.log.warn({ err, host: hop.resolved.hostname }, 'ssh connection error');
         }
       });
-      client.on('close', () => proxySocket?.destroy());
+      client.on('close', () => {
+        proxySocket?.destroy();
+        rejectBeforeReady(
+          new Error('SSH connection closed before it became ready.'),
+        );
+      });
       client.connect(config);
       // Interactive input consists of tiny packets. Disable Nagle explicitly
       // so a keystroke never waits for a previous packet's acknowledgement.
@@ -626,7 +659,12 @@ export class SshConnectionManager {
     return new KnownHostsStore(userKnownHostsFiles, globalKnownHostsFiles);
   }
 
-  private async verifyHostKey(hop: ChainHop, key: Buffer, io: ConnectIo): Promise<boolean> {
+  private async verifyHostKey(
+    hop: ChainHop,
+    key: Buffer,
+    io: ConnectIo,
+    runInteraction: InteractionRunner,
+  ): Promise<boolean> {
     const host = hop.resolved.hostname;
     const port = hop.port;
     const store = this.knownHostsFor(hop);
@@ -652,8 +690,8 @@ export class SshConnectionManager {
       io.status(`Automatically accepted the new host key for ${host} (${fingerprintSha256(key)}).`);
       return true;
     }
-    const accepted = await io
-      .hostKey({
+    const accepted = await runInteraction(() =>
+      io.hostKey({
         host,
         port,
         keyType: hostKeyType(key),
@@ -661,8 +699,8 @@ export class SshConnectionManager {
         state: verdict.state === 'changed' ? 'mismatch' : 'new',
         previous: verdict.state === 'changed' ? verdict.previous : undefined,
         hop: hop.hopLabel,
-      })
-      .catch(() => false);
+      }),
+    ).catch(() => false);
     if (accepted) store.record(host, port, key);
     return accepted;
   }
@@ -877,6 +915,64 @@ interface RememberedPasswordCandidate {
   password: string;
 }
 
+type InteractionRunner = <T>(interaction: () => Promise<T>) => Promise<T>;
+
+class PausableDeadline {
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private remainingMs: number;
+  private startedAt = 0;
+  private pauseDepth = 0;
+  private active: boolean;
+
+  constructor(
+    durationMs: number,
+    private readonly expire: () => void,
+  ) {
+    this.remainingMs = durationMs;
+    this.active = durationMs > 0;
+    this.arm();
+  }
+
+  pause(): void {
+    if (!this.active) return;
+    this.pauseDepth += 1;
+    if (this.pauseDepth !== 1) return;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+      this.remainingMs = Math.max(
+        0,
+        this.remainingMs - (Date.now() - this.startedAt),
+      );
+    }
+  }
+
+  resume(): void {
+    if (!this.active || this.pauseDepth === 0) return;
+    this.pauseDepth -= 1;
+    if (this.pauseDepth === 0) this.arm();
+  }
+
+  clear(): void {
+    this.active = false;
+    this.pauseDepth = 0;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+  }
+
+  private arm(): void {
+    if (!this.active || this.pauseDepth > 0) return;
+    this.startedAt = Date.now();
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      if (!this.active) return;
+      this.active = false;
+      this.expire();
+    }, this.remainingMs);
+    this.timer.unref?.();
+  }
+}
+
 /**
  * OpenSSH's client auth order as an ssh2 authHandler: none → agent (unless
  * IdentitiesOnly) → configured certificates with their matching private keys
@@ -901,6 +997,8 @@ class AuthLadder {
     private readonly hop: ChainHop,
     private readonly io: ConnectIo,
     private readonly vault?: PasswordVault,
+    private readonly runInteraction: InteractionRunner = (interaction) =>
+      interaction(),
   ) {
     this.attempts = this.build();
   }
@@ -1047,14 +1145,15 @@ class AuthLadder {
             type: 'keyboard-interactive',
             username: user,
             prompt: (name, instructions, _lang, prompts, finish) => {
-              this.io
-                .prompt({
+              this.runInteraction(() =>
+                this.io.prompt({
                   name: name || undefined,
                   instructions: instructions || undefined,
                   host: label,
                   purpose: 'authentication',
                   prompts: prompts.map((p) => ({ prompt: p.prompt, echo: p.echo !== false })),
-                })
+                }),
+              )
                 .then((response) => finish(response.answers))
                 .catch(() => {
                   this.cancelled = true;
@@ -1104,31 +1203,33 @@ class AuthLadder {
       }
     }
 
-    const response = await this.io.prompt({
-      host: promptLabel,
-      purpose: 'ssh-password',
-      instructions:
-        existing && this.savedPasswordAttempted
-          ? 'The saved password was unavailable or was not accepted. Enter the current password.'
-          : undefined,
-      prompts: [
-        {
-          prompt:
-            attempt === 1
-              ? `${user}@${promptLabel}'s password`
-              : 'Permission denied, please try again. Password',
-          echo: false,
-        },
-      ],
-      ...(this.vault
-        ? {
-            rememberPassword: {
-              label: credentialLabel,
-              existing,
-            },
-          }
-        : {}),
-    });
+    const response = await this.runInteraction(() =>
+      this.io.prompt({
+        host: promptLabel,
+        purpose: 'ssh-password',
+        instructions:
+          existing && this.savedPasswordAttempted
+            ? 'The saved password was unavailable or was not accepted. Enter the current password.'
+            : undefined,
+        prompts: [
+          {
+            prompt:
+              attempt === 1
+                ? `${user}@${promptLabel}'s password`
+                : 'Permission denied, please try again. Password',
+            echo: false,
+          },
+        ],
+        ...(this.vault
+          ? {
+              rememberPassword: {
+                label: credentialLabel,
+                existing,
+              },
+            }
+          : {}),
+      }),
+    );
     if (response.skipped) throw new Error('authentication cancelled');
     const password = response.answers[0] ?? '';
     this.lastPasswordCandidate = response.rememberPassword
@@ -1161,6 +1262,12 @@ class AuthLadder {
         );
         return undefined;
       }
+      if (err instanceof VaultKeyStoreUnavailableError) {
+        this.io.status(
+          `The OS credential store is unavailable. Enter the current password for ${label}.`,
+        );
+        return undefined;
+      }
       throw err;
     }
   }
@@ -1168,19 +1275,21 @@ class AuthLadder {
   private async createVaultForSave(label: string): Promise<boolean> {
     if (!this.vault) return false;
 
-    const response = await this.io.prompt({
-      name: 'Create password vault',
-      purpose: 'vault-create',
-      instructions:
-        `Create a master password to protect viewing and editing saved SSH passwords. ` +
-        `By default, Muxus stores the vault key in the operating-system credential store ` +
-        `so saved passwords can be used without another master-password prompt.`,
-      prompts: [
-        { prompt: 'Master password', echo: false },
-        { prompt: 'Confirm master password', echo: false },
-      ],
-      skipLabel: 'Not now',
-    });
+    const response = await this.runInteraction(() =>
+      this.io.prompt({
+        name: 'Create password vault',
+        purpose: 'vault-create',
+        instructions:
+          `Create a master password to protect viewing and editing saved SSH passwords. ` +
+          `By default, Muxus stores the vault key in the operating-system credential store ` +
+          `so saved passwords can be used without another master-password prompt.`,
+        prompts: [
+          { prompt: 'Master password', echo: false },
+          { prompt: 'Confirm master password', echo: false },
+        ],
+        skipLabel: 'Not now',
+      }),
+    );
     if (response.skipped) return false;
     const [masterPassword = '', confirmation = ''] = response.answers;
     if (masterPassword !== confirmation) {
@@ -1209,32 +1318,34 @@ class AuthLadder {
     operation: (masterPassword: string) => Promise<T>,
   ): Promise<{ ok: true; value: T } | { ok: false }> {
     if (!this.vault) return { ok: false };
-    let error: string | undefined;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const response = await this.io.prompt({
-        name,
-        purpose: 'vault-unlock',
-        instructions: error ? `${error}\n\n${instructions}` : instructions,
-        prompts: [{ prompt: 'Master password', echo: false }],
-        skipLabel,
-      });
-      if (response.skipped) return { ok: false };
-      try {
-        const value = await operation(response.answers[0] ?? '');
-        return { ok: true, value };
-      } catch (err) {
-        if (
-          err instanceof InvalidMasterPasswordError ||
-          err instanceof InvalidMasterPasswordFormatError
-        ) {
-          error = err.message;
-          continue;
+    return this.runInteraction(async () => {
+      let error: string | undefined;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const response = await this.io.prompt({
+          name,
+          purpose: 'vault-unlock',
+          instructions: error ? `${error}\n\n${instructions}` : instructions,
+          prompts: [{ prompt: 'Master password', echo: false }],
+          skipLabel,
+        });
+        if (response.skipped) return { ok: false };
+        try {
+          const value = await operation(response.answers[0] ?? '');
+          return { ok: true, value };
+        } catch (err) {
+          if (
+            err instanceof InvalidMasterPasswordError ||
+            err instanceof InvalidMasterPasswordFormatError
+          ) {
+            error = err.message;
+            continue;
+          }
+          throw err;
         }
-        throw err;
       }
-    }
-    this.io.status('The password vault remains locked.');
-    return { ok: false };
+      this.io.status('The password vault remains locked.');
+      return { ok: false };
+    });
   }
 
   private loadCertificate(
@@ -1321,11 +1432,13 @@ class AuthLadder {
       // skipped silently — the agent attempt already covered the loaded ones.
       if (!explicit && agentAvailable) return undefined;
       for (let i = 0; i < MAX_PASSPHRASE_ATTEMPTS && parsed instanceof Error; i++) {
-        const response = await this.io.prompt({
-          host: label,
-          purpose: 'authentication',
-          prompts: [{ prompt: `${i > 0 ? 'Bad passphrase, try again. ' : ''}Passphrase for ${path.basename(file)}`, echo: false }],
-        });
+        const response = await this.runInteraction(() =>
+          this.io.prompt({
+            host: label,
+            purpose: 'authentication',
+            prompts: [{ prompt: `${i > 0 ? 'Bad passphrase, try again. ' : ''}Passphrase for ${path.basename(file)}`, echo: false }],
+          }),
+        );
         const [passphrase] = response.answers;
         if (!passphrase) return undefined; // empty answer = skip this key
         parsed = parseSshKey(content, passphrase);

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -167,6 +167,14 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
         app.log.warn({ err, target: conn.metadataAlias }, 'could not record recent connection');
       }
     }
+    // A dial client closes this socket as soon as it has handed the connection
+    // to a forward. Finish any post-auth vault prompt first so closing the dial
+    // lease cannot reject the prompt before the password is saved.
+    await conn.waitForPostAuth();
+    if (!socketOpen) {
+      dialLease.release();
+      return;
+    }
     sendControl(socket, { op: 'ready', connId: conn.id, host: conn.host, user: conn.user });
     return;
   }

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -126,7 +126,11 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
       sendControl(socket, { op: 'auth-prompt', ...info });
       const reply = await control.next();
       if (reply.op !== 'auth-response') throw new Error('authentication cancelled');
-      return reply.answers;
+      return {
+        answers: reply.answers,
+        rememberPassword: reply.rememberPassword,
+        skipped: reply.skipped,
+      };
     },
     hostKey: async (challenge) => {
       sendControl(socket, { op: 'host-key', ...challenge });

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -29,11 +29,30 @@ export interface PasswordVaultCredential {
   updatedAt: string;
 }
 
-/** Runtime state of the local, platform-independent password vault. */
+/**
+ * Controls when a master password is required to use a saved credential.
+ *
+ * - never: keep the vault key in the operating-system credential store;
+ * - startup: unlock once for the lifetime of the server process;
+ * - credential: unlock separately for every saved-credential operation.
+ */
+export type PasswordVaultUnlockPolicy =
+  | 'never'
+  | 'startup'
+  | 'credential';
+
+/** New vaults use the operating-system credential store unless explicitly overridden. */
+export const DEFAULT_PASSWORD_VAULT_UNLOCK_POLICY =
+  'never' as const satisfies PasswordVaultUnlockPolicy;
+
+/** Runtime state of the local password vault. */
 export interface PasswordVaultStatus {
   configured: boolean;
-  /** Saved passwords are available to SSH without a master-password prompt. */
-  automaticAccess: boolean;
+  unlockPolicy?: PasswordVaultUnlockPolicy;
+  /** True when using a saved credential currently requires the master password. */
+  locked: boolean;
+  /** Whether the native OS credential-store integration loaded successfully. */
+  osKeyStoreAvailable: boolean;
   credentialCount: number;
   credentials: PasswordVaultCredential[];
 }

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -21,6 +21,23 @@ export interface AppInfo {
   sshAlgorithms: Record<string, string[]>;
 }
 
+/** Public metadata for one SSH password encrypted in the local password vault. */
+export interface PasswordVaultCredential {
+  id: string;
+  label: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Runtime state of the local, platform-independent password vault. */
+export interface PasswordVaultStatus {
+  configured: boolean;
+  /** Saved passwords are available to SSH without a master-password prompt. */
+  automaticAccess: boolean;
+  credentialCount: number;
+  credentials: PasswordVaultCredential[];
+}
+
 /** Raw bookmark data discovered from a local Windows MobaXterm installation. */
 export interface MobaXtermSessionSource {
   /** Human-readable origin shown before the user confirms the import. */

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -81,6 +81,35 @@ export type LocalProfile = Extract<SessionProfile, { kind: 'local' }>;
 export type TelnetProfile = Extract<SessionProfile, { kind: 'telnet' }>;
 export type SerialProfile = Extract<SessionProfile, { kind: 'serial' }>;
 
+export type AuthPromptPurpose =
+  | 'authentication'
+  | 'ssh-password'
+  | 'vault-repair'
+  | 'vault-create';
+
+export interface AuthPromptInfo {
+  name?: string;
+  instructions?: string;
+  /** Which host in the connection chain is asking ("bastion", "user@web1"). */
+  host?: string;
+  prompts: Array<{ prompt: string; echo: boolean }>;
+  purpose?: AuthPromptPurpose;
+  /** Offer to encrypt a successful SSH password in the local vault. */
+  rememberPassword?: {
+    label: string;
+    /** True when remembering will replace an older saved password. */
+    existing: boolean;
+  };
+  /** Secondary action that continues without answering this prompt. */
+  skipLabel?: string;
+}
+
+export interface AuthPromptResponse {
+  answers: string[];
+  rememberPassword?: boolean;
+  skipped?: boolean;
+}
+
 /** Text frames the client sends on /ws/terminal. */
 export const terminalClientMessageSchema = z.discriminatedUnion('op', [
   z.object({
@@ -101,7 +130,12 @@ export const terminalClientMessageSchema = z.discriminatedUnion('op', [
   z.object({ op: z.literal('dial'), profile: sshProfileSchema }),
   z.object({ op: z.literal('resize'), cols: z.number().int().positive(), rows: z.number().int().positive() }),
   /** Answers to the last `auth-prompt`, in prompt order. */
-  z.object({ op: z.literal('auth-response'), answers: z.array(z.string()) }),
+  z.object({
+    op: z.literal('auth-response'),
+    answers: z.array(z.string().max(8192)).max(16),
+    rememberPassword: z.boolean().optional(),
+    skipped: z.boolean().optional(),
+  }),
   /** Verdict on the last `host-key` challenge. */
   z.object({ op: z.literal('host-key-response'), accept: z.boolean() }),
   /** Change only the current session; persisted policy is managed over REST. */
@@ -126,14 +160,7 @@ export type TerminalServerMessage =
   /** Passive SSH transport health derived from the existing keepalive lifecycle. */
   | { op: 'connection-health'; state: 'healthy' | 'suspect' }
   /** Interactive auth (password, 2FA, key passphrase). echo=false → mask input. */
-  | {
-      op: 'auth-prompt';
-      name?: string;
-      instructions?: string;
-      /** Which host in the connection chain is asking ("bastion", "user@web1"). */
-      host?: string;
-      prompts: Array<{ prompt: string; echo: boolean }>;
-    }
+  | ({ op: 'auth-prompt' } & AuthPromptInfo)
   /** Host key verification: `new` = first contact (TOFU), `mismatch` = KEY CHANGED. */
   | {
       op: 'host-key';

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -84,6 +84,7 @@ export type SerialProfile = Extract<SessionProfile, { kind: 'serial' }>;
 export type AuthPromptPurpose =
   | 'authentication'
   | 'ssh-password'
+  | 'vault-unlock'
   | 'vault-repair'
   | 'vault-create';
 

--- a/tests/unit/client/password-vault-startup.test.ts
+++ b/tests/unit/client/password-vault-startup.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { PasswordVaultStatus } from '@muxus/shared';
+import { shouldDelayWorkspaceRestoreForVault } from '../../../client/src/password-vault-startup.js';
+
+const status = (
+  overrides: Partial<PasswordVaultStatus> = {},
+): PasswordVaultStatus => ({
+  configured: true,
+  unlockPolicy: 'startup',
+  locked: true,
+  osKeyStoreAvailable: true,
+  credentialCount: 1,
+  credentials: [],
+  ...overrides,
+});
+
+describe('password-vault startup coordination', () => {
+  it('delays restored sessions while the startup-policy vault is locked', () => {
+    expect(
+      shouldDelayWorkspaceRestoreForVault({
+        status: status(),
+        pending: false,
+        failed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('waits for the status request before restoring sessions', () => {
+    expect(
+      shouldDelayWorkspaceRestoreForVault({
+        status: undefined,
+        pending: true,
+        failed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('continues after unlock or when no startup prompt applies', () => {
+    for (const current of [
+      status({ locked: false }),
+      status({ unlockPolicy: 'credential' }),
+      status({ unlockPolicy: 'never' }),
+      status({ configured: false, unlockPolicy: undefined, locked: false }),
+    ]) {
+      expect(
+        shouldDelayWorkspaceRestoreForVault({
+          status: current,
+          pending: false,
+          failed: false,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it('does not let a failed status request block workspace startup', () => {
+    expect(
+      shouldDelayWorkspaceRestoreForVault({
+        status: undefined,
+        pending: false,
+        failed: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/server/connection-algorithms.test.ts
+++ b/tests/unit/server/connection-algorithms.test.ts
@@ -81,7 +81,8 @@ function makeManager(configFile: string): SshConnectionManager {
 function makeIo(): ConnectIo {
   return {
     status: () => undefined,
-    prompt: (info) => Promise.resolve(info.prompts.map(() => PASSWORD)),
+    prompt: (info) =>
+      Promise.resolve({ answers: info.prompts.map(() => PASSWORD) }),
     hostKey: () => Promise.resolve(true),
   };
 }

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -105,7 +105,9 @@ function makeIo(): { io: ConnectIo; prompts: string[]; hostKeyAsks: number[] } {
     status: () => undefined,
     prompt: (info) => {
       prompts.push(...info.prompts.map((p) => p.prompt));
-      return Promise.resolve(info.prompts.map(() => PASSWORD));
+      return Promise.resolve({
+        answers: info.prompts.map(() => PASSWORD),
+      });
     },
     hostKey: (challenge) => {
       hostKeyAsks.push(challenge.port);

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -14,6 +14,7 @@ import {
   PasswordVault,
   sshPasswordAccount,
 } from '../../../server/src/security/password-vault.js';
+import { MemoryVaultKeyStore } from '../../../server/src/security/vault-key-store.js';
 
 const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-session-'));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
@@ -198,13 +199,15 @@ describe('session settings from ssh config', () => {
     expect(started.capture.authMethods).not.toContain('password');
   }, 15_000);
 
-  it('remembers a successful password and unlocks the vault on the next connection', async () => {
+  it('remembers a successful password in the OS keyring and reuses it after restart', async () => {
     const started = await startCapturingServer();
     server = started.server;
     const config = writeConfig(started.port, []);
     database = new MuxusDatabase(':memory:');
+    const keyStore = new MemoryVaultKeyStore();
     vault = new PasswordVault(database, {
       kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+      keyStore,
     });
     manager = makeManager(config, vault);
     const master = 'correct horse battery staple';
@@ -226,21 +229,29 @@ describe('session settings from ssh config', () => {
     const first = await manager.connect(profile, firstIo);
     expect(vault.status()).toMatchObject({
       configured: true,
-      automaticAccess: true,
+      unlockPolicy: 'never',
+      locked: false,
       credentialCount: 1,
     });
     first.release();
     manager.closeAll();
 
-    vault.lock();
+    vault.dispose();
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+      keyStore,
+    });
+    await vault.initialize();
     manager = makeManager(config, vault);
     const secondIo = makeIo({
       prompt: (info) => {
-        throw new Error(`remote password prompt was not expected: ${info.purpose}`);
+        throw new Error(
+          `authentication prompt was not expected: ${info.purpose}`,
+        );
       },
     });
     const second = await manager.connect(profile, secondIo);
-    expect(vault.status().automaticAccess).toBe(true);
+    expect(vault.status().locked).toBe(false);
     expect(secondIo.passwordPrompts).toBe(0);
     second.release();
   }, 15_000);
@@ -259,7 +270,7 @@ describe('session settings from ssh config', () => {
       host: '127.0.0.1',
       port: started.port,
     });
-    vault.rememberSshPassword(
+    await vault.rememberSshPassword(
       account,
       `tester@127.0.0.1:${started.port}`,
       'stale-password',
@@ -278,7 +289,7 @@ describe('session settings from ssh config', () => {
       },
     });
     const lease = await manager.connect(profile, io);
-    expect(vault.sshPassword(account)).toBe(PASSWORD);
+    await expect(vault.sshPassword(account)).resolves.toBe(PASSWORD);
     lease.release();
   }, 15_000);
 });

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -407,8 +407,16 @@ describe('session settings from ssh config', () => {
     const lease = await manager.connect(profile, io);
     await vi.waitFor(() => expect(createPromptSeen).toBe(true));
     expect(vault.status().configured).toBe(false);
+    let postAuthSettled = false;
+    void lease.connection.waitForPostAuth().then(() => {
+      postAuthSettled = true;
+    });
+    await Promise.resolve();
+    expect(postAuthSettled).toBe(false);
 
     finishCreate!({ answers: [master, master] });
+    await lease.connection.waitForPostAuth();
+    expect(postAuthSettled).toBe(true);
     await vi.waitFor(() => {
       expect(vault!.status()).toMatchObject({
         configured: true,

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -14,7 +14,10 @@ import {
   PasswordVault,
   sshPasswordAccount,
 } from '../../../server/src/security/password-vault.js';
-import { MemoryVaultKeyStore } from '../../../server/src/security/vault-key-store.js';
+import {
+  MemoryVaultKeyStore,
+  VaultKeyStoreUnavailableError,
+} from '../../../server/src/security/vault-key-store.js';
 
 const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-session-'));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
@@ -227,11 +230,13 @@ describe('session settings from ssh config', () => {
       },
     });
     const first = await manager.connect(profile, firstIo);
-    expect(vault.status()).toMatchObject({
-      configured: true,
-      unlockPolicy: 'never',
-      locked: false,
-      credentialCount: 1,
+    await vi.waitFor(() => {
+      expect(vault!.status()).toMatchObject({
+        configured: true,
+        unlockPolicy: 'never',
+        locked: false,
+        credentialCount: 1,
+      });
     });
     first.release();
     manager.closeAll();
@@ -289,7 +294,127 @@ describe('session settings from ssh config', () => {
       },
     });
     const lease = await manager.connect(profile, io);
-    await expect(vault.sshPassword(account)).resolves.toBe(PASSWORD);
+    await vi.waitFor(async () => {
+      await expect(vault!.sshPassword(account)).resolves.toBe(PASSWORD);
+    });
+    lease.release();
+  }, 15_000);
+
+  it('falls back to a manual password when vault access reports an unavailable keyring', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    const config = writeConfig(started.port, []);
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    await vault.create('correct horse battery staple');
+    const account = sshPasswordAccount({
+      user: 'tester',
+      host: '127.0.0.1',
+      port: started.port,
+    });
+    await vault.rememberSshPassword(
+      account,
+      `tester@127.0.0.1:${started.port}`,
+      PASSWORD,
+    );
+    vi.spyOn(vault, 'sshPassword').mockRejectedValueOnce(
+      new VaultKeyStoreUnavailableError(),
+    );
+    manager = makeManager(config, vault);
+    const statuses: string[] = [];
+    const io = makeIo({
+      status: (message) => statuses.push(message),
+    });
+
+    const lease = await manager.connect(profile, io);
+    expect(io.passwordPrompts).toBe(1);
+    expect(statuses).toContain(
+      `The OS credential store is unavailable. Enter the current password for tester@127.0.0.1:${started.port}.`,
+    );
+    lease.release();
+  }, 15_000);
+
+  it('pauses ConnectTimeout while the user unlocks a saved password', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    const config = writeConfig(started.port, ['  ConnectTimeout 1']);
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    await vault.create('correct horse battery staple', 'startup');
+    await vault.rememberSshPassword(
+      sshPasswordAccount({
+        user: 'tester',
+        host: '127.0.0.1',
+        port: started.port,
+      }),
+      `tester@127.0.0.1:${started.port}`,
+      PASSWORD,
+    );
+    vault.lock();
+    manager = makeManager(config, vault);
+    const io = makeIo({
+      prompt: async (info) => {
+        if (info.purpose !== 'vault-unlock') {
+          throw new Error(`unexpected prompt: ${info.purpose}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1_250));
+        return { answers: ['correct horse battery staple'] };
+      },
+    });
+
+    const lease = await manager.connect(profile, io);
+    expect(vault.status().locked).toBe(false);
+    lease.release();
+  }, 15_000);
+
+  it('does not hold connection readiness on the remember-password dialog', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    const config = writeConfig(started.port, []);
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    manager = makeManager(config, vault);
+    const master = 'correct horse battery staple';
+    let createPromptSeen = false;
+    let finishCreate:
+      | ((response: { answers: string[] }) => void)
+      | undefined;
+    const createResponse = new Promise<{ answers: string[] }>((resolve) => {
+      finishCreate = resolve;
+    });
+    const io = makeIo({
+      prompt: (info) => {
+        if (info.purpose === 'ssh-password') {
+          return Promise.resolve({
+            answers: [PASSWORD],
+            rememberPassword: true,
+          });
+        }
+        if (info.purpose === 'vault-create') {
+          createPromptSeen = true;
+          return createResponse;
+        }
+        throw new Error(`unexpected prompt: ${info.purpose}`);
+      },
+    });
+
+    const lease = await manager.connect(profile, io);
+    await vi.waitFor(() => expect(createPromptSeen).toBe(true));
+    expect(vault.status().configured).toBe(false);
+
+    finishCreate!({ answers: [master, master] });
+    await vi.waitFor(() => {
+      expect(vault!.status()).toMatchObject({
+        configured: true,
+        credentialCount: 1,
+      });
+    });
     lease.release();
   }, 15_000);
 });

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -9,6 +9,11 @@ import type { SshProfile } from '@muxus/shared/ws-protocol';
 import { SshConnectionManager, type ConnectIo } from '../../../server/src/ssh/connection-manager.js';
 import { KnownHostsStore } from '../../../server/src/ssh/known-hosts.js';
 import { loadConfigDocument } from '../../../server/src/ssh/ssh-config.js';
+import { MuxusDatabase } from '../../../server/src/persistence/database.js';
+import {
+  PasswordVault,
+  sshPasswordAccount,
+} from '../../../server/src/security/password-vault.js';
 
 const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-session-'));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
@@ -71,7 +76,10 @@ function startCapturingServer(): Promise<{ server: Server; port: number; capture
 }
 
 let counter = 0;
-function makeManager(configFile: string): SshConnectionManager {
+function makeManager(
+  configFile: string,
+  vault?: PasswordVault,
+): SshConnectionManager {
   const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
   return new SshConnectionManager(log as never, {
     knownHosts: new KnownHostsStore(
@@ -79,6 +87,7 @@ function makeManager(configFile: string): SshConnectionManager {
       path.join(tmp, 'no-global-known-hosts'),
     ),
     loadConfig: () => loadConfigDocument(configFile),
+    vault,
   });
 }
 
@@ -88,7 +97,9 @@ function makeIo(overrides: Partial<ConnectIo> = {}): ConnectIo & { passwordPromp
     status: () => undefined,
     prompt: (info: { prompts: Array<{ prompt: string }> }) => {
       io.passwordPrompts += info.prompts.length;
-      return Promise.resolve(info.prompts.map(() => PASSWORD));
+      return Promise.resolve({
+        answers: info.prompts.map(() => PASSWORD),
+      });
     },
     hostKey: () => Promise.resolve(true),
     ...overrides,
@@ -114,10 +125,16 @@ async function firstData(stream: NodeJS.ReadableStream): Promise<string> {
 describe('session settings from ssh config', () => {
   let manager: SshConnectionManager | undefined;
   let server: Server | undefined;
+  let database: MuxusDatabase | undefined;
+  let vault: PasswordVault | undefined;
 
   afterEach(async () => {
     manager?.closeAll();
     manager = undefined;
+    vault?.lock();
+    database?.close();
+    vault = undefined;
+    database = undefined;
     if (server) {
       await new Promise<void>((resolve) => server!.close(() => resolve()));
       server = undefined;
@@ -179,5 +196,89 @@ describe('session settings from ssh config', () => {
     await expect(manager.connect(profile, io)).rejects.toThrow(/authentication/);
     expect(io.passwordPrompts).toBe(0);
     expect(started.capture.authMethods).not.toContain('password');
+  }, 15_000);
+
+  it('remembers a successful password and unlocks the vault on the next connection', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    const config = writeConfig(started.port, []);
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    manager = makeManager(config, vault);
+    const master = 'correct horse battery staple';
+
+    const firstIo = makeIo({
+      prompt: (info) => {
+        if (info.purpose === 'ssh-password') {
+          return Promise.resolve({
+            answers: [PASSWORD],
+            rememberPassword: true,
+          });
+        }
+        if (info.purpose === 'vault-create') {
+          return Promise.resolve({ answers: [master, master] });
+        }
+        throw new Error(`unexpected prompt: ${info.purpose}`);
+      },
+    });
+    const first = await manager.connect(profile, firstIo);
+    expect(vault.status()).toMatchObject({
+      configured: true,
+      automaticAccess: true,
+      credentialCount: 1,
+    });
+    first.release();
+    manager.closeAll();
+
+    vault.lock();
+    manager = makeManager(config, vault);
+    const secondIo = makeIo({
+      prompt: (info) => {
+        throw new Error(`remote password prompt was not expected: ${info.purpose}`);
+      },
+    });
+    const second = await manager.connect(profile, secondIo);
+    expect(vault.status().automaticAccess).toBe(true);
+    expect(secondIo.passwordPrompts).toBe(0);
+    second.release();
+  }, 15_000);
+
+  it('replaces a rejected saved password only after the new password succeeds', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    const config = writeConfig(started.port, []);
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    await vault.create('correct horse battery staple');
+    const account = sshPasswordAccount({
+      user: 'tester',
+      host: '127.0.0.1',
+      port: started.port,
+    });
+    vault.rememberSshPassword(
+      account,
+      `tester@127.0.0.1:${started.port}`,
+      'stale-password',
+    );
+    manager = makeManager(config, vault);
+
+    const io = makeIo({
+      prompt: (info) => {
+        if (info.purpose !== 'ssh-password') {
+          throw new Error(`unexpected prompt: ${info.purpose}`);
+        }
+        return Promise.resolve({
+          answers: [PASSWORD],
+          rememberPassword: true,
+        });
+      },
+    });
+    const lease = await manager.connect(profile, io);
+    expect(vault.sshPassword(account)).toBe(PASSWORD);
+    lease.release();
   }, 15_000);
 });

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -36,6 +36,7 @@ describe('MuxusDatabase migrations', () => {
       { version: 13, name: 'automatic-password-vault' },
       { version: 14, name: 'password-vault-os-keystore' },
       { version: 15, name: 'password-vault-key-check' },
+      { version: 16, name: 'password-vault-key-cleanup' },
     ]);
   });
 
@@ -61,10 +62,11 @@ describe('MuxusDatabase migrations', () => {
     const draft = new DatabaseSync(filename);
     try {
       draft.exec(`
-        DELETE FROM schema_migrations WHERE version IN (13, 14, 15);
+        DELETE FROM schema_migrations WHERE version IN (13, 14, 15, 16);
         UPDATE schema_migrations
         SET name = 'master-password-vault'
         WHERE version = 12;
+        DROP TABLE password_vault_key_cleanup;
         DROP TABLE password_vault;
         CREATE TABLE password_vault (
           singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
@@ -111,8 +113,8 @@ describe('MuxusDatabase migrations', () => {
 
     database = new MuxusDatabase(filename);
     expect(database.appliedMigrations().at(-1)).toEqual({
-      version: 15,
-      name: 'password-vault-key-check',
+      version: 16,
+      name: 'password-vault-key-cleanup',
     });
     expect(database.passwordVaultConfig()).toMatchObject({
       formatVersion: 2,

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -1,11 +1,20 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { afterEach, describe, expect, it } from 'vitest';
 import { MuxusDatabase, assertSecretFree } from '../../../server/src/persistence/database.js';
 
 let database: MuxusDatabase | undefined;
+let temporaryDirectory: string | undefined;
 
 afterEach(() => {
   database?.close();
   database = undefined;
+  if (temporaryDirectory) {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = undefined;
+  }
 });
 
 describe('MuxusDatabase migrations', () => {
@@ -23,9 +32,98 @@ describe('MuxusDatabase migrations', () => {
       { version: 9, name: 'drop-favorites' },
       { version: 10, name: 'terminal-scrollback-snapshots' },
       { version: 11, name: 'version-terminal-scrollback-snapshots' },
-      { version: 12, name: 'master-password-vault' },
+      { version: 12, name: 'password-vault' },
       { version: 13, name: 'automatic-password-vault' },
+      { version: 14, name: 'password-vault-os-keystore' },
     ]);
+  });
+
+  it('upgrades the draft version 13 vault without deleting credentials', () => {
+    temporaryDirectory = mkdtempSync(
+      path.join(os.tmpdir(), 'muxus-v13-migration-'),
+    );
+    const filename = path.join(temporaryDirectory, 'muxus.sqlite3');
+    database = new MuxusDatabase(filename);
+    database.upsertEncryptedCredential({
+      provider: 'muxus-master-vault',
+      service: 'muxus/ssh-password/v1',
+      account: 'legacy-account',
+      label: 'legacy credential',
+      formatVersion: 1,
+      nonce: Buffer.alloc(12, 1),
+      ciphertext: Buffer.from('legacy-ciphertext'),
+      authTag: Buffer.alloc(16, 2),
+    });
+    database.close();
+    database = undefined;
+
+    const draft = new DatabaseSync(filename);
+    try {
+      draft.exec(`
+        DELETE FROM schema_migrations WHERE version IN (13, 14);
+        UPDATE schema_migrations
+        SET name = 'master-password-vault'
+        WHERE version = 12;
+        DROP TABLE password_vault;
+        CREATE TABLE password_vault (
+          singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+          format_version INTEGER NOT NULL CHECK(format_version = 2),
+          kdf_algorithm TEXT NOT NULL CHECK(kdf_algorithm = 'scrypt'),
+          kdf_salt BLOB NOT NULL CHECK(length(kdf_salt) = 16),
+          kdf_cost INTEGER NOT NULL CHECK(kdf_cost BETWEEN 1024 AND 1048576),
+          kdf_block_size INTEGER NOT NULL CHECK(kdf_block_size BETWEEN 1 AND 32),
+          kdf_parallelism INTEGER NOT NULL CHECK(kdf_parallelism BETWEEN 1 AND 16),
+          master_key_nonce BLOB NOT NULL CHECK(length(master_key_nonce) = 12),
+          master_key_ciphertext BLOB NOT NULL CHECK(length(master_key_ciphertext) = 32),
+          master_key_tag BLOB NOT NULL CHECK(length(master_key_tag) = 16),
+          device_key_nonce BLOB NOT NULL CHECK(length(device_key_nonce) = 12),
+          device_key_ciphertext BLOB NOT NULL CHECK(length(device_key_ciphertext) = 32),
+          device_key_tag BLOB NOT NULL CHECK(length(device_key_tag) = 16),
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ) STRICT;
+        INSERT INTO schema_migrations(version, name)
+        VALUES (13, 'automatic-password-vault');
+        PRAGMA user_version = 13;
+      `);
+      draft
+        .prepare(`
+          INSERT INTO password_vault(
+            singleton, format_version, kdf_algorithm, kdf_salt,
+            kdf_cost, kdf_block_size, kdf_parallelism,
+            master_key_nonce, master_key_ciphertext, master_key_tag,
+            device_key_nonce, device_key_ciphertext, device_key_tag
+          ) VALUES (1, 2, 'scrypt', ?, 1024, 8, 1, ?, ?, ?, ?, ?, ?)
+        `)
+        .run(
+          Buffer.alloc(16, 3),
+          Buffer.alloc(12, 4),
+          Buffer.alloc(32, 5),
+          Buffer.alloc(16, 6),
+          Buffer.alloc(12, 7),
+          Buffer.alloc(32, 8),
+          Buffer.alloc(16, 9),
+        );
+    } finally {
+      draft.close();
+    }
+
+    database = new MuxusDatabase(filename);
+    expect(database.appliedMigrations().at(-1)).toEqual({
+      version: 14,
+      name: 'password-vault-os-keystore',
+    });
+    expect(database.passwordVaultConfig()).toMatchObject({
+      formatVersion: 2,
+      unlockPolicy: 'startup',
+    });
+    expect(database.passwordVaultConfig()!.vaultId).toHaveLength(21);
+    expect(
+      database.listEncryptedCredentials(
+        'muxus-master-vault',
+        'muxus/ssh-password/v1',
+      ),
+    ).toHaveLength(1);
   });
 });
 

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -23,6 +23,8 @@ describe('MuxusDatabase migrations', () => {
       { version: 9, name: 'drop-favorites' },
       { version: 10, name: 'terminal-scrollback-snapshots' },
       { version: 11, name: 'version-terminal-scrollback-snapshots' },
+      { version: 12, name: 'master-password-vault' },
+      { version: 13, name: 'automatic-password-vault' },
     ]);
   });
 });
@@ -395,12 +397,12 @@ describe('saved Telnet and serial hosts', () => {
           password: 'do-not-save',
         } as never,
       }),
-    ).toThrow(/OS credential store/);
+    ).toThrow(/password vault/);
   });
 });
 
 describe('credential and workspace safety', () => {
-  it('stores only an OS credential reference alongside native profile data', () => {
+  it('stores only a credential reference alongside native profile data', () => {
     database = new MuxusDatabase(':memory:');
     const credential = database.upsertCredentialRef({
       provider: 'os-keychain',
@@ -421,11 +423,11 @@ describe('credential and workspace safety', () => {
 
   it('rejects secrets anywhere in persisted profile or workspace JSON', () => {
     database = new MuxusDatabase(':memory:');
-    expect(() => assertSecretFree({ nested: { password: 'hunter2' } })).toThrow(/OS credential store/);
+    expect(() => assertSecretFree({ nested: { password: 'hunter2' } })).toThrow(/password vault/);
     expect(() => assertSecretFree({ auth: { privateKeyPem: '-----BEGIN PRIVATE KEY-----' } })).toThrow(
-      /OS credential store/,
+      /password vault/,
     );
-    expect(() => assertSecretFree({ auth: { api_token_value: 'secret' } })).toThrow(/OS credential store/);
+    expect(() => assertSecretFree({ auth: { api_token_value: 'secret' } })).toThrow(/password vault/);
     expect(() =>
       assertSecretFree({
         auth: {
@@ -440,13 +442,13 @@ describe('credential and workspace safety', () => {
         name: 'Unsafe',
         config: { auth: { passphrase: 'secret' } },
       }),
-    ).toThrow(/OS credential store/);
+    ).toThrow(/password vault/);
     expect(() =>
       database!.saveWorkspace({
         name: 'Unsafe',
         layout: { pane: { token: 'secret' } },
       }),
-    ).toThrow(/OS credential store/);
+    ).toThrow(/password vault/);
   });
 
   it('round-trips a secret-free recoverable workspace layout', () => {

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -35,6 +35,7 @@ describe('MuxusDatabase migrations', () => {
       { version: 12, name: 'password-vault' },
       { version: 13, name: 'automatic-password-vault' },
       { version: 14, name: 'password-vault-os-keystore' },
+      { version: 15, name: 'password-vault-key-check' },
     ]);
   });
 
@@ -60,7 +61,7 @@ describe('MuxusDatabase migrations', () => {
     const draft = new DatabaseSync(filename);
     try {
       draft.exec(`
-        DELETE FROM schema_migrations WHERE version IN (13, 14);
+        DELETE FROM schema_migrations WHERE version IN (13, 14, 15);
         UPDATE schema_migrations
         SET name = 'master-password-vault'
         WHERE version = 12;
@@ -110,14 +111,15 @@ describe('MuxusDatabase migrations', () => {
 
     database = new MuxusDatabase(filename);
     expect(database.appliedMigrations().at(-1)).toEqual({
-      version: 14,
-      name: 'password-vault-os-keystore',
+      version: 15,
+      name: 'password-vault-key-check',
     });
     expect(database.passwordVaultConfig()).toMatchObject({
       formatVersion: 2,
       unlockPolicy: 'startup',
     });
     expect(database.passwordVaultConfig()!.vaultId).toHaveLength(21);
+    expect(database.passwordVaultConfig()!.keyCheck).toBeUndefined();
     expect(
       database.listEncryptedCredentials(
         'muxus-master-vault',
@@ -500,6 +502,27 @@ describe('saved Telnet and serial hosts', () => {
 });
 
 describe('credential and workspace safety', () => {
+  it('rolls back a new credential reference when encryption fails', () => {
+    database = new MuxusDatabase(':memory:');
+    const input = {
+      provider: 'muxus-master-vault',
+      service: 'muxus/ssh-password/v1',
+      account: 'failed-encryption',
+      label: 'Failed encryption',
+    };
+    let rolledBackId = '';
+
+    expect(() =>
+      database!.upsertEncryptedCredentialAtomically(input, (ref) => {
+        rolledBackId = ref.id;
+        throw new Error('sealing failed');
+      }),
+    ).toThrow('sealing failed');
+
+    const next = database.upsertCredentialRef(input);
+    expect(next.id).not.toBe(rolledBackId);
+  });
+
   it('stores only a credential reference alongside native profile data', () => {
     database = new MuxusDatabase(':memory:');
     const credential = database.upsertCredentialRef({

--- a/tests/unit/server/password-vault-routes.test.ts
+++ b/tests/unit/server/password-vault-routes.test.ts
@@ -5,7 +5,7 @@ import { resolveConfig } from '../../../server/src/config.js';
 import { sshPasswordAccount } from '../../../server/src/security/password-vault.js';
 
 const TOKEN = 'password-vault-route-token';
-const MASTER = 'master-8';
+const MASTER = 'master-pass-12';
 const REMOTE_PASSWORD = 'remote-password';
 let app: Awaited<ReturnType<typeof buildApp>>['app'];
 let ctx: AppContext;
@@ -39,7 +39,7 @@ describe('password vault routes', () => {
     });
     expect(initial.json()).toMatchObject({
       configured: false,
-      automaticAccess: false,
+      locked: true,
       credentialCount: 0,
     });
 
@@ -47,7 +47,7 @@ describe('password vault routes', () => {
       method: 'POST',
       url: '/api/password-vault/create',
       headers: auth(),
-      payload: { password: '1234567' },
+      payload: { password: '12345678901' },
     });
     expect(short.statusCode).toBe(400);
 
@@ -60,7 +60,8 @@ describe('password vault routes', () => {
     expect(created.statusCode).toBe(200);
     expect(created.json()).toMatchObject({
       configured: true,
-      automaticAccess: true,
+      unlockPolicy: 'never',
+      locked: false,
     });
 
     const account = sshPasswordAccount({
@@ -68,7 +69,7 @@ describe('password vault routes', () => {
       host: 'router.example',
       port: 22,
     });
-    ctx.vault.rememberSshPassword(
+    await ctx.vault.rememberSshPassword(
       account,
       'alice@router.example:22',
       REMOTE_PASSWORD,
@@ -80,7 +81,7 @@ describe('password vault routes', () => {
       method: 'POST',
       url: `/api/password-vault/credentials/${credential!.id}/reveal`,
       headers: auth(),
-      payload: { masterPassword: 'incorrect' },
+      payload: { masterPassword: 'incorrect-pass' },
     });
     expect(wrongReveal.statusCode).toBe(401);
     expect(wrongReveal.json().code).toBe('invalid-master-password');
@@ -105,7 +106,44 @@ describe('password vault routes', () => {
       },
     });
     expect(updated.statusCode).toBe(200);
-    expect(ctx.vault.sshPassword(account)).toBe('changed-password');
+    await expect(ctx.vault.sshPassword(account)).resolves.toBe(
+      'changed-password',
+    );
+
+    const perCredential = await app.inject({
+      method: 'PUT',
+      url: '/api/password-vault/unlock-policy',
+      headers: auth(),
+      payload: {
+        masterPassword: MASTER,
+        unlockPolicy: 'credential',
+      },
+    });
+    expect(perCredential.statusCode).toBe(200);
+    expect(perCredential.json()).toMatchObject({
+      unlockPolicy: 'credential',
+      locked: true,
+    });
+
+    const startup = await app.inject({
+      method: 'PUT',
+      url: '/api/password-vault/unlock-policy',
+      headers: auth(),
+      payload: {
+        masterPassword: MASTER,
+        unlockPolicy: 'startup',
+      },
+    });
+    expect(startup.statusCode).toBe(200);
+    ctx.vault.lock();
+    const unlocked = await app.inject({
+      method: 'POST',
+      url: '/api/password-vault/unlock',
+      headers: auth(),
+      payload: { masterPassword: MASTER },
+    });
+    expect(unlocked.statusCode).toBe(200);
+    expect(unlocked.json().locked).toBe(false);
 
     const deleted = await app.inject({
       method: 'DELETE',
@@ -114,7 +152,7 @@ describe('password vault routes', () => {
     });
     expect(deleted.json()).toMatchObject({
       configured: false,
-      automaticAccess: false,
+      locked: true,
       credentialCount: 0,
     });
   }, 15_000);

--- a/tests/unit/server/password-vault-routes.test.ts
+++ b/tests/unit/server/password-vault-routes.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { AppContext } from '../../../server/src/app.js';
+import { buildApp } from '../../../server/src/app.js';
+import { resolveConfig } from '../../../server/src/config.js';
+import { sshPasswordAccount } from '../../../server/src/security/password-vault.js';
+
+const TOKEN = 'password-vault-route-token';
+const MASTER = 'master-8';
+const REMOTE_PASSWORD = 'remote-password';
+let app: Awaited<ReturnType<typeof buildApp>>['app'];
+let ctx: AppContext;
+
+beforeEach(async () => {
+  ({ app, ctx } = await buildApp(
+    resolveConfig({
+      token: TOKEN,
+      databasePath: ':memory:',
+      openBrowser: false,
+      prettyLogs: false,
+      staticRoot: '/path/that/does/not/exist',
+    }),
+  ));
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+function auth() {
+  return { authorization: `Bearer ${TOKEN}` };
+}
+
+describe('password vault routes', () => {
+  it('creates an automatic vault and gates reveal and edit with the master password', async () => {
+    const initial = await app.inject({
+      method: 'GET',
+      url: '/api/password-vault',
+      headers: auth(),
+    });
+    expect(initial.json()).toMatchObject({
+      configured: false,
+      automaticAccess: false,
+      credentialCount: 0,
+    });
+
+    const short = await app.inject({
+      method: 'POST',
+      url: '/api/password-vault/create',
+      headers: auth(),
+      payload: { password: '1234567' },
+    });
+    expect(short.statusCode).toBe(400);
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/password-vault/create',
+      headers: auth(),
+      payload: { password: MASTER },
+    });
+    expect(created.statusCode).toBe(200);
+    expect(created.json()).toMatchObject({
+      configured: true,
+      automaticAccess: true,
+    });
+
+    const account = sshPasswordAccount({
+      user: 'alice',
+      host: 'router.example',
+      port: 22,
+    });
+    ctx.vault.rememberSshPassword(
+      account,
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+    const [credential] = ctx.vault.status().credentials;
+    expect(credential).toBeDefined();
+
+    const wrongReveal = await app.inject({
+      method: 'POST',
+      url: `/api/password-vault/credentials/${credential!.id}/reveal`,
+      headers: auth(),
+      payload: { masterPassword: 'incorrect' },
+    });
+    expect(wrongReveal.statusCode).toBe(401);
+    expect(wrongReveal.json().code).toBe('invalid-master-password');
+
+    const revealed = await app.inject({
+      method: 'POST',
+      url: `/api/password-vault/credentials/${credential!.id}/reveal`,
+      headers: auth(),
+      payload: { masterPassword: MASTER },
+    });
+    expect(revealed.statusCode).toBe(200);
+    expect(revealed.headers['cache-control']).toBe('no-store');
+    expect(revealed.json()).toEqual({ password: REMOTE_PASSWORD });
+
+    const updated = await app.inject({
+      method: 'PUT',
+      url: `/api/password-vault/credentials/${credential!.id}`,
+      headers: auth(),
+      payload: {
+        masterPassword: MASTER,
+        password: 'changed-password',
+      },
+    });
+    expect(updated.statusCode).toBe(200);
+    expect(ctx.vault.sshPassword(account)).toBe('changed-password');
+
+    const deleted = await app.inject({
+      method: 'DELETE',
+      url: '/api/password-vault',
+      headers: auth(),
+    });
+    expect(deleted.json()).toMatchObject({
+      configured: false,
+      automaticAccess: false,
+      credentialCount: 0,
+    });
+  }, 15_000);
+});

--- a/tests/unit/server/password-vault.test.ts
+++ b/tests/unit/server/password-vault.test.ts
@@ -1,6 +1,7 @@
 import {
   existsSync,
   mkdtempSync,
+  mkdirSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -19,7 +20,11 @@ import {
   VaultUnlockRequiredError,
   sshPasswordAccount,
 } from '../../../server/src/security/password-vault.js';
-import { MemoryVaultKeyStore } from '../../../server/src/security/vault-key-store.js';
+import {
+  MemoryVaultKeyStore,
+  type VaultKeyStore,
+  VaultKeyStoreUnavailableError,
+} from '../../../server/src/security/vault-key-store.js';
 
 const MASTER = 'master-pass-12';
 const NEXT_MASTER = 'next-master-12';
@@ -54,6 +59,32 @@ function account(): string {
   });
 }
 
+class ToggleVaultKeyStore
+  extends MemoryVaultKeyStore
+  implements VaultKeyStore
+{
+  unavailable = false;
+
+  override async get(vaultId: string): Promise<Buffer | undefined> {
+    this.assertAvailable();
+    return super.get(vaultId);
+  }
+
+  override async set(vaultId: string, key: Buffer): Promise<void> {
+    this.assertAvailable();
+    await super.set(vaultId, key);
+  }
+
+  override async delete(vaultId: string): Promise<void> {
+    this.assertAvailable();
+    await super.delete(vaultId);
+  }
+
+  private assertAvailable(): void {
+    if (this.unavailable) throw new VaultKeyStoreUnavailableError();
+  }
+}
+
 describe('password vault', () => {
   it('uses the OS-keyring policy while the master password gates management', async () => {
     const store = await setup();
@@ -70,6 +101,7 @@ describe('password vault', () => {
       locked: false,
       credentialCount: 1,
     });
+    expect(database!.passwordVaultConfig()!.keyCheck).toHaveLength(32);
     await expect(store.sshPassword(account())).resolves.toBe(REMOTE_PASSWORD);
 
     const [credential] = store.status().credentials;
@@ -254,6 +286,138 @@ describe('password vault', () => {
     );
     await store.repairAutomaticAccess(MASTER);
     await expect(store.sshPassword(account())).resolves.toBe(REMOTE_PASSWORD);
+  });
+
+  it('uses a successfully unwrapped key when OS caching is unavailable', async () => {
+    const keyStore = new ToggleVaultKeyStore();
+    const store = await setup(':memory:', keyStore);
+    await store.create(MASTER, 'never');
+    await store.rememberSshPassword(
+      account(),
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+
+    store.lock();
+    keyStore.unavailable = true;
+    await expect(store.sshPassword(account(), MASTER)).resolves.toBe(
+      REMOTE_PASSWORD,
+    );
+    expect(store.status()).toMatchObject({
+      unlockPolicy: 'never',
+      locked: false,
+      osKeyStoreAvailable: false,
+    });
+
+    await expect(
+      store.changeMasterPassword(MASTER, NEXT_MASTER),
+    ).resolves.toBeUndefined();
+    store.lock();
+    await expect(
+      store.changeUnlockPolicy(NEXT_MASTER, 'startup'),
+    ).resolves.toBeUndefined();
+    expect(store.status()).toMatchObject({
+      unlockPolicy: 'startup',
+      locked: false,
+      osKeyStoreAvailable: false,
+    });
+  });
+
+  it('resets a never-policy vault even when OS-key deletion fails', async () => {
+    const keyStore = new ToggleVaultKeyStore();
+    const store = await setup(':memory:', keyStore);
+    await store.create(MASTER, 'never');
+    await store.rememberSshPassword(
+      account(),
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+
+    keyStore.unavailable = true;
+    await expect(store.deleteAll()).resolves.toBeUndefined();
+    expect(store.status()).toMatchObject({
+      configured: false,
+      locked: true,
+      credentialCount: 0,
+      osKeyStoreAvailable: false,
+    });
+  });
+
+  it('rejects a stale 32-byte OS key and repairs it with the master password', async () => {
+    const keyStore = new MemoryVaultKeyStore();
+    const first = await setup(':memory:', keyStore);
+    await first.create(MASTER, 'never');
+    await first.rememberSshPassword(
+      account(),
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+    const vaultId = database!.passwordVaultConfig()!.vaultId;
+    const correctKey = (await keyStore.get(vaultId))!;
+    first.dispose();
+    await keyStore.set(vaultId, Buffer.alloc(32, 0x5a));
+
+    vault = new PasswordVault(database!, {
+      kdf: TEST_KDF,
+      keyStore,
+    });
+    await vault.initialize();
+    expect(vault.status()).toMatchObject({
+      unlockPolicy: 'never',
+      locked: true,
+    });
+    await expect(vault.sshPassword(account())).rejects.toThrow(
+      VaultAutomaticAccessError,
+    );
+    await expect(vault.sshPassword(account(), MASTER)).resolves.toBe(
+      REMOTE_PASSWORD,
+    );
+    expect(await keyStore.get(vaultId)).toEqual(correctKey);
+    correctKey.fill(0);
+  });
+
+  it('does not let obsolete-key cleanup failures block initialization', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-cleanup-'));
+    const file = path.join(dir, 'muxus.sqlite3');
+    try {
+      database = new MuxusDatabase(file);
+      mkdirSync(path.join(dir, 'muxus-vault-device.key'));
+      vault = new PasswordVault(database, {
+        kdf: TEST_KDF,
+        keyStore: new MemoryVaultKeyStore(),
+      });
+
+      await expect(vault.initialize()).resolves.toBeUndefined();
+      expect(vault.status().configured).toBe(false);
+    } finally {
+      vault?.dispose();
+      database?.close();
+      vault = undefined;
+      database = undefined;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves KDF failures instead of reporting an incorrect password', async () => {
+    const store = await setup();
+    database!.createPasswordVaultConfig({
+      formatVersion: 3,
+      vaultId: 'invalid-kdf-vault',
+      unlockPolicy: 'startup',
+      kdfAlgorithm: 'scrypt',
+      kdfSalt: Buffer.alloc(16),
+      kdfCost: 1025,
+      kdfBlockSize: 8,
+      kdfParallelism: 1,
+      masterKeyNonce: Buffer.alloc(12),
+      masterKeyCiphertext: Buffer.alloc(32),
+      masterKeyTag: Buffer.alloc(16),
+    });
+
+    const error = await store.unlockForSession(MASTER).catch((err) => err);
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(InvalidMasterPasswordError);
+    expect((error as Error).message).toMatch(/scrypt/i);
   });
 
   it('does not create a key file or leave deleted secrets in SQLite/WAL', async () => {

--- a/tests/unit/server/password-vault.test.ts
+++ b/tests/unit/server/password-vault.test.ts
@@ -1,0 +1,217 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MuxusDatabase } from '../../../server/src/persistence/database.js';
+import {
+  InvalidMasterPasswordError,
+  InvalidMasterPasswordFormatError,
+  PasswordVault,
+  VaultAutomaticAccessError,
+  sshPasswordAccount,
+} from '../../../server/src/security/password-vault.js';
+
+const MASTER = 'master-8';
+const NEXT_MASTER = 'new-pass';
+const REMOTE_PASSWORD = 'remote-password-that-must-not-leak';
+const TEST_KDF = { cost: 1024, blockSize: 8, parallelism: 1 };
+
+let database: MuxusDatabase | undefined;
+let vault: PasswordVault | undefined;
+
+afterEach(() => {
+  vault?.dispose();
+  database?.close();
+  vault = undefined;
+  database = undefined;
+});
+
+function setup(filename = ':memory:'): PasswordVault {
+  database = new MuxusDatabase(filename);
+  vault = new PasswordVault(database, { kdf: TEST_KDF });
+  return vault;
+}
+
+function account(): string {
+  return sshPasswordAccount({
+    user: 'alice',
+    host: 'router.example',
+    port: 22,
+  });
+}
+
+describe('automatic password vault', () => {
+  it('uses passwords automatically while the master password gates reveal and edit', async () => {
+    const store = setup();
+
+    await store.create(MASTER);
+    store.rememberSshPassword(
+      account(),
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+    expect(store.status()).toMatchObject({
+      configured: true,
+      automaticAccess: true,
+      credentialCount: 1,
+    });
+
+    store.lock();
+    expect(store.sshPassword(account())).toBe(REMOTE_PASSWORD);
+
+    const [credential] = store.status().credentials;
+    expect(credential).toBeDefined();
+    await expect(
+      store.revealCredential(credential!.id, 'incorrect'),
+    ).rejects.toThrow(InvalidMasterPasswordError);
+    await expect(store.revealCredential(credential!.id, MASTER)).resolves.toBe(
+      REMOTE_PASSWORD,
+    );
+
+    await expect(
+      store.updateCredential(credential!.id, 'incorrect', 'changed-password'),
+    ).rejects.toThrow(InvalidMasterPasswordError);
+    await expect(
+      store.updateCredential(credential!.id, MASTER, 'changed-password'),
+    ).resolves.toBe(true);
+    expect(store.sshPassword(account())).toBe('changed-password');
+
+    await store.changeMasterPassword(MASTER, NEXT_MASTER);
+    await expect(
+      store.revealCredential(credential!.id, MASTER),
+    ).rejects.toThrow(InvalidMasterPasswordError);
+    await expect(
+      store.revealCredential(credential!.id, NEXT_MASTER),
+    ).resolves.toBe('changed-password');
+    expect(store.sshPassword(account())).toBe('changed-password');
+  });
+
+  it('restores automatic access after a complete application restart', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-restart-'));
+    const file = path.join(dir, 'muxus.sqlite3');
+    try {
+      const first = setup(file);
+      await first.create(MASTER);
+      first.rememberSshPassword(
+        account(),
+        'alice@router.example:22',
+        REMOTE_PASSWORD,
+      );
+      first.dispose();
+      database!.close();
+      vault = undefined;
+      database = undefined;
+
+      database = new MuxusDatabase(file);
+      vault = new PasswordVault(database, { kdf: TEST_KDF });
+      expect(vault.status().automaticAccess).toBe(true);
+      expect(vault.sshPassword(account())).toBe(REMOTE_PASSWORD);
+      if (process.platform !== 'win32') {
+        expect(
+          statSync(path.join(dir, 'muxus-vault-device.key')).mode & 0o777,
+        ).toBe(0o600);
+      }
+    } finally {
+      vault?.dispose();
+      database?.close();
+      vault = undefined;
+      database = undefined;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs automatic access with the master password if the device key is lost', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-repair-'));
+    const file = path.join(dir, 'muxus.sqlite3');
+    try {
+      const first = setup(file);
+      await first.create(MASTER);
+      first.rememberSshPassword(
+        account(),
+        'alice@router.example:22',
+        REMOTE_PASSWORD,
+      );
+      first.dispose();
+      database!.close();
+      vault = undefined;
+      database = undefined;
+      rmSync(path.join(dir, 'muxus-vault-device.key'));
+
+      database = new MuxusDatabase(file);
+      vault = new PasswordVault(database, { kdf: TEST_KDF });
+      expect(vault.status().automaticAccess).toBe(false);
+      expect(() => vault!.sshPassword(account())).toThrow(
+        VaultAutomaticAccessError,
+      );
+      await expect(
+        vault.repairAutomaticAccess('incorrect'),
+      ).rejects.toThrow(InvalidMasterPasswordError);
+      await vault.repairAutomaticAccess(MASTER);
+      expect(vault.sshPassword(account())).toBe(REMOTE_PASSWORD);
+    } finally {
+      vault?.dispose();
+      database?.close();
+      vault = undefined;
+      database = undefined;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('never writes the master or remote password in the database', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-plaintext-'));
+    const file = path.join(dir, 'muxus.sqlite3');
+    try {
+      const store = setup(file);
+      await store.create(MASTER);
+      store.rememberSshPassword(
+        account(),
+        'alice@router.example:22',
+        REMOTE_PASSWORD,
+      );
+      store.dispose();
+      database!.close();
+      database = undefined;
+      vault = undefined;
+
+      const bytes = readFileSync(file);
+      expect(bytes.includes(Buffer.from(MASTER))).toBe(false);
+      expect(bytes.includes(Buffer.from(REMOTE_PASSWORD))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('forgets individual credentials or resets the whole vault', async () => {
+    const store = setup();
+    await store.create(MASTER);
+    store.rememberSshPassword(
+      account(),
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+    const [credential] = store.status().credentials;
+    expect(credential).toBeDefined();
+    expect(store.deleteCredential(credential!.id)).toBe(true);
+    expect(store.hasSshPassword(account())).toBe(false);
+
+    store.deleteAll();
+    expect(store.status()).toMatchObject({
+      configured: false,
+      automaticAccess: false,
+      credentialCount: 0,
+    });
+  });
+
+  it('accepts eight-character master passwords and rejects seven', async () => {
+    const store = setup();
+    await expect(store.create('1234567')).rejects.toThrow(
+      InvalidMasterPasswordFormatError,
+    );
+    await expect(store.create('12345678')).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/server/password-vault.test.ts
+++ b/tests/unit/server/password-vault.test.ts
@@ -1,9 +1,12 @@
 import {
+  existsSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
-  statSync,
+  writeFileSync,
 } from 'node:fs';
+import { createCipheriv, scryptSync } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -13,11 +16,13 @@ import {
   InvalidMasterPasswordFormatError,
   PasswordVault,
   VaultAutomaticAccessError,
+  VaultUnlockRequiredError,
   sshPasswordAccount,
 } from '../../../server/src/security/password-vault.js';
+import { MemoryVaultKeyStore } from '../../../server/src/security/vault-key-store.js';
 
-const MASTER = 'master-8';
-const NEXT_MASTER = 'new-pass';
+const MASTER = 'master-pass-12';
+const NEXT_MASTER = 'next-master-12';
 const REMOTE_PASSWORD = 'remote-password-that-must-not-leak';
 const TEST_KDF = { cost: 1024, blockSize: 8, parallelism: 1 };
 
@@ -31,9 +36,13 @@ afterEach(() => {
   database = undefined;
 });
 
-function setup(filename = ':memory:'): PasswordVault {
+async function setup(
+  filename = ':memory:',
+  keyStore = new MemoryVaultKeyStore(),
+): Promise<PasswordVault> {
   database = new MuxusDatabase(filename);
-  vault = new PasswordVault(database, { kdf: TEST_KDF });
+  vault = new PasswordVault(database, { kdf: TEST_KDF, keyStore });
+  await vault.initialize();
   return vault;
 }
 
@@ -45,42 +54,38 @@ function account(): string {
   });
 }
 
-describe('automatic password vault', () => {
-  it('uses passwords automatically while the master password gates reveal and edit', async () => {
-    const store = setup();
+describe('password vault', () => {
+  it('uses the OS-keyring policy while the master password gates management', async () => {
+    const store = await setup();
 
-    await store.create(MASTER);
-    store.rememberSshPassword(
+    await store.create(MASTER, 'never');
+    await store.rememberSshPassword(
       account(),
       'alice@router.example:22',
       REMOTE_PASSWORD,
     );
     expect(store.status()).toMatchObject({
       configured: true,
-      automaticAccess: true,
+      unlockPolicy: 'never',
+      locked: false,
       credentialCount: 1,
     });
-
-    store.lock();
-    expect(store.sshPassword(account())).toBe(REMOTE_PASSWORD);
+    await expect(store.sshPassword(account())).resolves.toBe(REMOTE_PASSWORD);
 
     const [credential] = store.status().credentials;
     expect(credential).toBeDefined();
     await expect(
-      store.revealCredential(credential!.id, 'incorrect'),
+      store.revealCredential(credential!.id, 'incorrect-pass'),
     ).rejects.toThrow(InvalidMasterPasswordError);
     await expect(store.revealCredential(credential!.id, MASTER)).resolves.toBe(
       REMOTE_PASSWORD,
     );
 
-    await expect(
-      store.updateCredential(credential!.id, 'incorrect', 'changed-password'),
-    ).rejects.toThrow(InvalidMasterPasswordError);
-    await expect(
-      store.updateCredential(credential!.id, MASTER, 'changed-password'),
-    ).resolves.toBe(true);
-    expect(store.sshPassword(account())).toBe('changed-password');
-
+    await store.updateCredential(
+      credential!.id,
+      MASTER,
+      'changed-password',
+    );
     await store.changeMasterPassword(MASTER, NEXT_MASTER);
     await expect(
       store.revealCredential(credential!.id, MASTER),
@@ -88,16 +93,119 @@ describe('automatic password vault', () => {
     await expect(
       store.revealCredential(credential!.id, NEXT_MASTER),
     ).resolves.toBe('changed-password');
-    expect(store.sshPassword(account())).toBe('changed-password');
   });
 
-  it('restores automatic access after a complete application restart', async () => {
+  it('implements startup and per-credential prompt policies', async () => {
+    const keyStore = new MemoryVaultKeyStore();
+    const store = await setup(':memory:', keyStore);
+    await store.create(MASTER, 'startup');
+    await store.rememberSshPassword(
+      account(),
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+
+    store.lock();
+    expect(store.status()).toMatchObject({
+      unlockPolicy: 'startup',
+      locked: true,
+    });
+    await expect(store.sshPassword(account())).rejects.toThrow(
+      VaultUnlockRequiredError,
+    );
+    await store.unlockForSession(MASTER);
+    await expect(store.sshPassword(account())).resolves.toBe(REMOTE_PASSWORD);
+
+    await store.changeUnlockPolicy(MASTER, 'credential');
+    expect(store.status()).toMatchObject({
+      unlockPolicy: 'credential',
+      locked: true,
+    });
+    await expect(store.sshPassword(account())).rejects.toThrow(
+      VaultUnlockRequiredError,
+    );
+    await expect(store.sshPassword(account(), MASTER)).resolves.toBe(
+      REMOTE_PASSWORD,
+    );
+    expect(store.status().locked).toBe(true);
+
+    await store.changeUnlockPolicy(MASTER, 'never');
+    expect(store.status()).toMatchObject({
+      unlockPolicy: 'never',
+      locked: false,
+    });
+  });
+
+  it('unlocks a draft-v13 vault and upgrades it on master-password change', async () => {
+    const store = await setup();
+    const legacyMaster = 'old-pass';
+    const vaultKey = Buffer.alloc(32, 11);
+    const salt = Buffer.alloc(16, 12);
+    const masterKey = scryptSync(legacyMaster, salt, 32, {
+      N: TEST_KDF.cost,
+      r: TEST_KDF.blockSize,
+      p: TEST_KDF.parallelism,
+    });
+    const masterWrap = sealForTest(
+      vaultKey,
+      masterKey,
+      Buffer.from('muxus:password-vault:master-key:v2'),
+    );
+    database!.createPasswordVaultConfig({
+      formatVersion: 2,
+      vaultId: 'legacy-vault-id-12345',
+      unlockPolicy: 'startup',
+      kdfAlgorithm: 'scrypt',
+      kdfSalt: salt,
+      kdfCost: TEST_KDF.cost,
+      kdfBlockSize: TEST_KDF.blockSize,
+      kdfParallelism: TEST_KDF.parallelism,
+      masterKeyNonce: masterWrap.nonce,
+      masterKeyCiphertext: masterWrap.ciphertext,
+      masterKeyTag: masterWrap.authTag,
+    });
+    const ref = database!.upsertCredentialRef({
+      provider: 'muxus-master-vault',
+      service: 'muxus/ssh-password/v1',
+      account: account(),
+      label: 'legacy credential',
+    });
+    const encrypted = sealForTest(
+      Buffer.from(REMOTE_PASSWORD),
+      vaultKey,
+      Buffer.from(`muxus:ssh-password:${ref.id}:v1`),
+    );
+    database!.upsertEncryptedCredential({
+      provider: ref.provider,
+      service: ref.service,
+      account: ref.account,
+      label: ref.label,
+      formatVersion: 1,
+      nonce: encrypted.nonce,
+      ciphertext: encrypted.ciphertext,
+      authTag: encrypted.authTag,
+    });
+
+    await store.unlockForSession(legacyMaster);
+    await expect(store.sshPassword(account())).resolves.toBe(REMOTE_PASSWORD);
+    await store.changeMasterPassword(legacyMaster, NEXT_MASTER);
+    expect(database!.passwordVaultConfig()!.formatVersion).toBe(3);
+    store.lock();
+    await store.unlockForSession(NEXT_MASTER);
+    await expect(store.sshPassword(account())).resolves.toBe(REMOTE_PASSWORD);
+
+    vaultKey.fill(0);
+    masterKey.fill(0);
+  });
+
+  it('restores never-prompt access after a complete application restart', async () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-restart-'));
     const file = path.join(dir, 'muxus.sqlite3');
+    const keyStore = new MemoryVaultKeyStore();
     try {
-      const first = setup(file);
-      await first.create(MASTER);
-      first.rememberSshPassword(
+      const first = await setup(file, keyStore);
+      await first.create(MASTER, 'never');
+      await first.rememberSshPassword(
         account(),
         'alice@router.example:22',
         REMOTE_PASSWORD,
@@ -107,15 +215,15 @@ describe('automatic password vault', () => {
       vault = undefined;
       database = undefined;
 
-      database = new MuxusDatabase(file);
-      vault = new PasswordVault(database, { kdf: TEST_KDF });
-      expect(vault.status().automaticAccess).toBe(true);
-      expect(vault.sshPassword(account())).toBe(REMOTE_PASSWORD);
-      if (process.platform !== 'win32') {
-        expect(
-          statSync(path.join(dir, 'muxus-vault-device.key')).mode & 0o777,
-        ).toBe(0o600);
-      }
+      const second = await setup(file, keyStore);
+      expect(second.status()).toMatchObject({
+        unlockPolicy: 'never',
+        locked: false,
+      });
+      await expect(second.sshPassword(account())).resolves.toBe(
+        REMOTE_PASSWORD,
+      );
+      expect(existsSync(path.join(dir, 'muxus-vault-device.key'))).toBe(false);
     } finally {
       vault?.dispose();
       database?.close();
@@ -125,71 +233,82 @@ describe('automatic password vault', () => {
     }
   });
 
-  it('repairs automatic access with the master password if the device key is lost', async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-repair-'));
-    const file = path.join(dir, 'muxus.sqlite3');
-    try {
-      const first = setup(file);
-      await first.create(MASTER);
-      first.rememberSshPassword(
-        account(),
-        'alice@router.example:22',
-        REMOTE_PASSWORD,
-      );
-      first.dispose();
-      database!.close();
-      vault = undefined;
-      database = undefined;
-      rmSync(path.join(dir, 'muxus-vault-device.key'));
+  it('repairs a missing OS-keyring entry with the master password', async () => {
+    const keyStore = new MemoryVaultKeyStore();
+    const store = await setup(':memory:', keyStore);
+    await store.create(MASTER, 'never');
+    await store.rememberSshPassword(
+      account(),
+      'alice@router.example:22',
+      REMOTE_PASSWORD,
+    );
+    const vaultId = database!.passwordVaultConfig()!.vaultId;
+    store.lock();
+    await keyStore.delete(vaultId);
 
-      database = new MuxusDatabase(file);
-      vault = new PasswordVault(database, { kdf: TEST_KDF });
-      expect(vault.status().automaticAccess).toBe(false);
-      expect(() => vault!.sshPassword(account())).toThrow(
-        VaultAutomaticAccessError,
-      );
-      await expect(
-        vault.repairAutomaticAccess('incorrect'),
-      ).rejects.toThrow(InvalidMasterPasswordError);
-      await vault.repairAutomaticAccess(MASTER);
-      expect(vault.sshPassword(account())).toBe(REMOTE_PASSWORD);
-    } finally {
-      vault?.dispose();
-      database?.close();
-      vault = undefined;
-      database = undefined;
-      rmSync(dir, { recursive: true, force: true });
-    }
+    await expect(store.sshPassword(account())).rejects.toThrow(
+      VaultAutomaticAccessError,
+    );
+    await expect(store.repairAutomaticAccess('incorrect-pass')).rejects.toThrow(
+      InvalidMasterPasswordError,
+    );
+    await store.repairAutomaticAccess(MASTER);
+    await expect(store.sshPassword(account())).resolves.toBe(REMOTE_PASSWORD);
   });
 
-  it('never writes the master or remote password in the database', async () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-plaintext-'));
+  it('does not create a key file or leave deleted secrets in SQLite/WAL', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'muxus-vault-delete-'));
     const file = path.join(dir, 'muxus.sqlite3');
+    const keyStore = new MemoryVaultKeyStore();
     try {
-      const store = setup(file);
-      await store.create(MASTER);
-      store.rememberSshPassword(
+      writeFileSync(
+        path.join(dir, 'muxus-vault-device.key'),
+        Buffer.alloc(32, 42),
+      );
+      const store = await setup(file, keyStore);
+      expect(readdirSync(dir)).not.toContain('muxus-vault-device.key');
+      await store.create(MASTER, 'never');
+      await store.rememberSshPassword(
         account(),
-        'alice@router.example:22',
+        'unique-label-that-must-be-scrubbed',
         REMOTE_PASSWORD,
       );
+      const record = database!.listEncryptedCredentials(
+        'muxus-master-vault',
+        'muxus/ssh-password/v1',
+      )[0]!;
+      const ciphertext = Buffer.from(record.ciphertext);
+      const vaultId = database!.passwordVaultConfig()!.vaultId;
+
+      await store.deleteAll();
+      expect(await keyStore.get(vaultId)).toBeUndefined();
       store.dispose();
       database!.close();
       database = undefined;
       vault = undefined;
 
-      const bytes = readFileSync(file);
-      expect(bytes.includes(Buffer.from(MASTER))).toBe(false);
-      expect(bytes.includes(Buffer.from(REMOTE_PASSWORD))).toBe(false);
+      const persisted = Buffer.concat(
+        readdirSync(dir)
+          .filter((name) => name.startsWith('muxus.sqlite3'))
+          .map((name) => readFileSync(path.join(dir, name))),
+      );
+      expect(
+        persisted.includes(
+          Buffer.from('unique-label-that-must-be-scrubbed'),
+        ),
+      ).toBe(false);
+      expect(persisted.includes(ciphertext)).toBe(false);
+      expect(persisted.includes(Buffer.from(MASTER))).toBe(false);
+      expect(persisted.includes(Buffer.from(REMOTE_PASSWORD))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it('forgets individual credentials or resets the whole vault', async () => {
-    const store = setup();
-    await store.create(MASTER);
-    store.rememberSshPassword(
+    const store = await setup();
+    await store.create(MASTER, 'startup');
+    await store.rememberSshPassword(
       account(),
       'alice@router.example:22',
       REMOTE_PASSWORD,
@@ -199,19 +318,28 @@ describe('automatic password vault', () => {
     expect(store.deleteCredential(credential!.id)).toBe(true);
     expect(store.hasSshPassword(account())).toBe(false);
 
-    store.deleteAll();
+    await store.deleteAll();
     expect(store.status()).toMatchObject({
       configured: false,
-      automaticAccess: false,
+      locked: true,
       credentialCount: 0,
     });
   });
 
-  it('accepts eight-character master passwords and rejects seven', async () => {
-    const store = setup();
-    await expect(store.create('1234567')).rejects.toThrow(
+  it('accepts twelve-character master passwords and rejects eleven', async () => {
+    const store = await setup();
+    await expect(store.create('12345678901')).rejects.toThrow(
       InvalidMasterPasswordFormatError,
     );
-    await expect(store.create('12345678')).resolves.toBeUndefined();
+    await expect(store.create('123456789012')).resolves.toBeUndefined();
+    expect(store.status().unlockPolicy).toBe('never');
   });
 });
+
+function sealForTest(plaintext: Buffer, key: Buffer, aad: Buffer) {
+  const nonce = Buffer.alloc(12, 13);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  cipher.setAAD(aad);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return { nonce, ciphertext, authTag: cipher.getAuthTag() };
+}

--- a/tests/unit/server/password-vault.test.ts
+++ b/tests/unit/server/password-vault.test.ts
@@ -292,6 +292,7 @@ describe('password vault', () => {
     const keyStore = new ToggleVaultKeyStore();
     const store = await setup(':memory:', keyStore);
     await store.create(MASTER, 'never');
+    const vaultId = database!.passwordVaultConfig()!.vaultId;
     await store.rememberSshPassword(
       account(),
       'alice@router.example:22',
@@ -320,6 +321,19 @@ describe('password vault', () => {
       unlockPolicy: 'startup',
       locked: false,
       osKeyStoreAvailable: false,
+    });
+    expect(database!.pendingPasswordVaultKeyCleanup()).toEqual([vaultId]);
+
+    store.dispose();
+    keyStore.unavailable = false;
+    vault = new PasswordVault(database!, { kdf: TEST_KDF, keyStore });
+    await vault.initialize();
+    expect(database!.pendingPasswordVaultKeyCleanup()).toEqual([]);
+    await expect(keyStore.get(vaultId)).resolves.toBeUndefined();
+    expect(vault.status()).toMatchObject({
+      unlockPolicy: 'startup',
+      locked: true,
+      osKeyStoreAvailable: true,
     });
   });
 

--- a/tests/unit/server/terminal-socket-dial.test.ts
+++ b/tests/unit/server/terminal-socket-dial.test.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { registerTerminalSocket } from '../../../server/src/ws/terminal-socket.js';
+
+class TestSocket extends EventEmitter {
+  readonly OPEN = 1;
+  readyState = this.OPEN;
+  readonly send = vi.fn();
+  readonly ping = vi.fn();
+
+  close(): void {
+    if (this.readyState !== this.OPEN) return;
+    this.readyState = 3;
+    this.emit('close');
+  }
+}
+
+describe('terminal socket dial mode', () => {
+  it('does not announce readiness until post-auth password saving finishes', async () => {
+    let route!: (socket: TestSocket) => void;
+    let finishPostAuth!: () => void;
+    const postAuth = new Promise<void>((resolve) => {
+      finishPostAuth = resolve;
+    });
+    const release = vi.fn();
+    const connect = vi.fn().mockResolvedValue({
+      connection: {
+        id: 'connection-1',
+        host: 'router.example',
+        user: 'alice',
+        onClose: () => () => undefined,
+        waitForPostAuth: () => postAuth,
+      },
+      release,
+      reused: false,
+    });
+    const app = {
+      get: (
+        _path: string,
+        _options: unknown,
+        handler: (socket: TestSocket) => void,
+      ) => {
+        route = handler;
+      },
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    };
+    const ctx = {
+      connections: { connect },
+      database: { recordOpenSshConnection: vi.fn() },
+    };
+    registerTerminalSocket(app as never, ctx as never);
+
+    const socket = new TestSocket();
+    route(socket);
+    socket.emit(
+      'message',
+      Buffer.from(
+        JSON.stringify({
+          op: 'dial',
+          profile: { kind: 'ssh', target: 'router.example' },
+        }),
+      ),
+      false,
+    );
+
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledOnce());
+    expect(socket.send).not.toHaveBeenCalledWith(
+      JSON.stringify({
+        op: 'ready',
+        connId: 'connection-1',
+        host: 'router.example',
+        user: 'alice',
+      }),
+    );
+
+    finishPostAuth();
+    await vi.waitFor(() =>
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          op: 'ready',
+          connId: 'connection-1',
+          host: 'router.example',
+          user: 'alice',
+        }),
+      ),
+    );
+    socket.close();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/server/vault-key-store.os.test.ts
+++ b/tests/unit/server/vault-key-store.os.test.ts
@@ -1,0 +1,39 @@
+import { randomBytes } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SystemVaultKeyStore } from '../../../server/src/security/vault-key-store.js';
+
+// Round-trips a key through the real OS credential store (Windows Credential
+// Manager, macOS Keychain, or a Secret Service keyring). Opt-in because it
+// needs an unlocked keyring, which headless environments often lack.
+const enabled = process.env.MUXUS_OS_KEYRING_SMOKE === '1';
+
+describe.runIf(enabled)('SystemVaultKeyStore (OS credential store)', () => {
+  const store = new SystemVaultKeyStore();
+  const vaultId = `os-smoke-${randomBytes(8).toString('hex')}`;
+
+  afterEach(async () => {
+    await store.delete(vaultId).catch(() => undefined);
+  });
+
+  it('reports a missing key as undefined', async () => {
+    expect(await store.get(vaultId)).toBeUndefined();
+  });
+
+  it('round-trips a 32-byte key and deletes it', async () => {
+    const key = randomBytes(32);
+    await store.set(vaultId, key);
+    const loaded = await store.get(vaultId);
+    expect(loaded?.toString('hex')).toBe(key.toString('hex'));
+
+    await store.delete(vaultId);
+    expect(await store.get(vaultId)).toBeUndefined();
+  });
+
+  it('overwrites an existing key in place', async () => {
+    await store.set(vaultId, randomBytes(32));
+    const replacement = randomBytes(32);
+    await store.set(vaultId, replacement);
+    const loaded = await store.get(vaultId);
+    expect(loaded?.toString('hex')).toBe(replacement.toString('hex'));
+  });
+});

--- a/tests/unit/shared/ws-protocol.test.ts
+++ b/tests/unit/shared/ws-protocol.test.ts
@@ -134,8 +134,30 @@ describe('terminalClientMessageSchema', () => {
 
   it('accepts resize / auth-response / host-key-response', () => {
     expect(terminalClientMessageSchema.safeParse({ op: 'resize', cols: 120, rows: 40 }).success).toBe(true);
-    expect(terminalClientMessageSchema.safeParse({ op: 'auth-response', answers: ['hunter2'] }).success).toBe(true);
+    expect(
+      terminalClientMessageSchema.safeParse({
+        op: 'auth-response',
+        answers: ['hunter2'],
+        rememberPassword: true,
+      }).success,
+    ).toBe(true);
+    expect(
+      terminalClientMessageSchema.safeParse({
+        op: 'auth-response',
+        answers: [],
+        skipped: true,
+      }).success,
+    ).toBe(true);
     expect(terminalClientMessageSchema.safeParse({ op: 'host-key-response', accept: true }).success).toBe(true);
+  });
+
+  it('bounds authentication answers', () => {
+    expect(
+      terminalClientMessageSchema.safeParse({
+        op: 'auth-response',
+        answers: ['x'.repeat(8193)],
+      }).success,
+    ).toBe(false);
   });
 
   it('requires an actual lifecycle, pause, or privacy change for logging controls', () => {


### PR DESCRIPTION
## Summary

- add an optional, cross-platform encrypted vault for remembered SSH passwords
- offer **Remember this password** during SSH password authentication and save only the password that successfully authenticated
- support three master-password prompt policies:
  - **Never for saved credentials** stores the random vault key in the operating-system credential store
  - **When Muxus starts** keeps the unlocked key only in process memory
  - **Whenever a saved credential is needed** unwraps the key for one operation
- add **Settings → Passwords** controls to create, unlock, repair, reset, or change the vault policy and master password, plus reveal, edit, and forget individual credentials
- add database migrations for encrypted credential storage, OS-keyring access, and durable key verification
- package the native keyring bindings for Linux, Windows, and macOS universal builds
- document the storage model, prompt policies, recovery paths, deletion behavior, and threat model

## Why

Remembered SSH passwords should work consistently across Linux, Windows, and macOS while keeping the application database insufficient to decrypt credentials by itself. Routine SSH use also needs a different usability/security tradeoff from viewing or editing saved values.

This implementation uses an independent random vault key for credential encryption and a master-password-derived key only to wrap that vault key. Users can then choose whether routine connections use the OS credential store, one startup unlock, or a prompt for every saved credential.

## Security model

- each SSH password is encrypted with AES-256-GCM, a fresh nonce, and credential-specific authenticated data
- scrypt derives the master wrapping key using `N=131072`, `r=8`, `p=1`, and a random salt
- the master password is never stored and is always required to reveal or edit credentials, change policies, or change the master password
- the never-prompt policy stores the random vault key in Windows Credential Manager, macOS Keychain, or a Linux keyring backend; Muxus does not fall back to an application-owned key file
- a persisted HMAC verifier rejects stale, corrupted, or unrelated 32-byte OS-keyring entries before they can encrypt replacement credentials
- private-key passphrases, keyboard-interactive answers, and two-factor codes are never persisted
- reveal responses are marked `no-store`
- resetting the vault intentionally requires no master password, so a forgotten password cannot make encrypted data impossible to remove

## Reliability and recovery

- successful master-password decryption is not discarded if opportunistic OS-key caching fails
- an unavailable keyring degrades SSH authentication to a manual password prompt instead of cancelling the connection
- policy changes away from automatic access and full vault reset remain available when the OS credential store is unavailable
- obsolete device-key cleanup is best-effort and cannot block application startup
- credential references and ciphertext are written in one transaction
- KDF runtime failures remain distinguishable from an incorrect master password
- SSH connection deadlines pause while host-key, vault, password, or passphrase dialogs are open
- post-auth password saving runs after connection readiness, so unanswered vault dialogs do not stall multiplexed sessions
- macOS universal ASAR merging permits the architecture-specific Darwin keyring packages

## Validation

- `pnpm test -- --run` — 577 tests passed across 76 files
- `pnpm typecheck`
- `pnpm lint` with warnings denied
- `pnpm build`
- `pnpm build-docs`
- `pnpm check:bundle`
- Electron directory packaging
- universal-ASAR allowlist matching for both Darwin keyring package trees
- `git diff --check`