### PR TITLE
Fix ssh-agent authentication being skipped during connect

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -38,10 +38,13 @@ export function useSshConfig(enabled = true) {
   });
 }
 
-export function useSshKeys(enabled = true) {
+export function useSshKeys(enabled = true, identityAgent?: string) {
+  const query = identityAgent === undefined
+    ? ''
+    : `?identityAgent=${encodeURIComponent(identityAgent)}`;
   return useQuery({
-    queryKey: ['ssh-keys'],
-    queryFn: () => apiFetch<SshKeysResponse>('/api/ssh/keys'),
+    queryKey: ['ssh-keys', identityAgent ?? null],
+    queryFn: () => apiFetch<SshKeysResponse>(`/api/ssh/keys${query}`),
     enabled,
     staleTime: 30_000,
   });

--- a/client/src/components/HostEditorDialog.tsx
+++ b/client/src/components/HostEditorDialog.tsx
@@ -25,7 +25,14 @@ import {
 import { useUiStore, type HostEditorState } from '../state/ui.js';
 import { AdvancedSection } from './host-editor/AdvancedSection.js';
 import { AuthSection } from './host-editor/AuthSection.js';
-import { blankDraft, draftFromEntry, draftProblem, draftToRequest, type HostDraft } from './host-editor/draft.js';
+import {
+  blankDraft,
+  draftFromEntry,
+  draftProblem,
+  draftToRequest,
+  identityAgentForDetection,
+  type HostDraft,
+} from './host-editor/draft.js';
 import { EditorShell, type EditorSectionDef } from './host-editor/EditorShell.js';
 import { ForwardsSection } from './host-editor/ForwardsSection.js';
 import { GeneralSection } from './host-editor/GeneralSection.js';
@@ -161,7 +168,12 @@ function SshHostEditorContent({
 }) {
   const setState = useUiStore((s) => s.setHostEditor);
   const { data: config } = useSshConfig();
-  const { data: keys } = useSshKeys(true);
+  const inheritedIdentityAgent =
+    state.mode === 'edit' && state.entry.options.identityAgent === undefined
+      ? state.entry.resolved.identityAgent
+      : undefined;
+  const detectedIdentityAgent = identityAgentForDetection(draft, inheritedIdentityAgent);
+  const { data: keys } = useSshKeys(true, detectedIdentityAgent);
   const loggingPolicyKey =
     state.mode === 'edit' ? `ssh:${state.entry.alias}` : '*';
   const { data: loggingPolicy } = useSessionLoggingPolicy(loggingPolicyKey);

--- a/client/src/components/host-editor/AuthSection.tsx
+++ b/client/src/components/host-editor/AuthSection.tsx
@@ -259,11 +259,7 @@ export function AuthSection({
         />
 
         <Typography variant="caption" color="text.secondary">
-          {keys
-            ? keys.agentAvailable
-              ? `Agent detected — ${keys.agentKeys.length} key${keys.agentKeys.length === 1 ? '' : 's'} loaded.`
-              : 'No agent detected in SSH_AUTH_SOCK. A custom agent may still be available.'
-            : ''}
+          {agentDetectionStatus(draft, keys)}
         </Typography>
       </Stack>
 
@@ -325,6 +321,18 @@ function agentSourceHelp(mode: IdentityAgentMode): string {
     default:
       return 'Inherits the normal SSH configuration and environment.';
   }
+}
+
+function agentDetectionStatus(draft: HostDraft, keys: SshKeysResponse | undefined): string {
+  if (draft.identityAgentMode === 'custom' && !draft.identityAgent.trim()) return '';
+  if (draft.identityAgentMode === 'none') return 'Agent disabled for this host.';
+  if (!keys) return '';
+  if (keys.agentAvailable) {
+    return `Agent detected — ${keys.agentKeys.length} key${keys.agentKeys.length === 1 ? '' : 's'} loaded.`;
+  }
+  if (draft.identityAgentMode === 'environment') return 'No agent detected in SSH_AUTH_SOCK.';
+  if (draft.identityAgentMode === 'custom') return 'No agent detected at the selected socket.';
+  return 'No agent detected for this host.';
 }
 
 function Labeled({ title, sub }: { title: string; sub: string }) {

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -225,6 +225,24 @@ export function draftToRequest(draft: HostDraft, previousAlias?: string): HostUp
   };
 }
 
+/** Agent source represented by the current editor state, for live key detection. */
+export function identityAgentForDetection(
+  draft: Pick<HostDraft, 'identityAgentMode' | 'identityAgent'>,
+  inheritedIdentityAgent?: string,
+): string | undefined {
+  switch (draft.identityAgentMode) {
+    case 'environment':
+      return 'SSH_AUTH_SOCK';
+    case 'custom':
+      // Do not accidentally scan the default agent while the custom field is empty.
+      return draft.identityAgent.trim() || 'none';
+    case 'none':
+      return 'none';
+    default:
+      return inheritedIdentityAgent;
+  }
+}
+
 function identityAgentDraft(value: string | undefined): {
   mode: IdentityAgentMode;
   value: string;

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -45,7 +45,8 @@ read-only `/etc/ssh/ssh_known_hosts`, hashed entries included.
 Within one connection Muxus follows the OpenSSH order and stops at the first method that
 succeeds:
 
-1. **Agent**: every identity in `SSH_AUTH_SOCK`.
+1. **Agent**: every identity in the host's `IdentityAgent`, falling back to
+   `SSH_AUTH_SOCK` when no override is configured.
 2. **Certificates**: a `CertificateFile` together with its matching `IdentityFile`.
 3. **Keys**: the `IdentityFile`s in the block, or the default `~/.ssh/id_*` set.
    Passphrase-protected keys issue a prompt. `IdentitiesOnly yes` is honoured.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -38,7 +38,7 @@ Muxus uses the existing SSH credentials and configuration on the machine:
 | `~/.ssh/config` (and every `Include`) | Hosts, users, ports, keys, jump chains, forwards |
 | `~/.ssh/known_hosts`, `/etc/ssh/ssh_known_hosts` | Host-key verification |
 | `~/.ssh/*` key files | The key picker in the host editor |
-| `SSH_AUTH_SOCK` | Agent authentication and `ForwardAgent` |
+| `SSH_AUTH_SOCK` | Default agent authentication and `ForwardAgent` |
 
 !!! tip "No import step"
 
@@ -65,7 +65,9 @@ are stored in a local SQLite database alongside the other application data.
 === ":material-apple: macOS"
 
     Serial ports appear as `/dev/tty.*`, for example `/dev/tty.usbserial-A50285BI`. No
-    extra permissions are required for SSH, Telnet or serial.
+    extra permissions are required for SSH, Telnet or serial. The desktop app reads
+    `SSH_AUTH_SOCK` from the login shell, so agents selected there (including 1Password
+    and Secretive) work when Muxus is opened from Finder.
 
 === ":material-microsoft-windows: Windows"
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -46,7 +46,7 @@
     "electron": "43.1.1",
     "electron-builder": "^26.15.3",
     "esbuild": "^0.28.1",
-    "fix-path": "^5.0.0",
+    "shell-env": "^4.0.3",
     "sharp": "^0.35.3",
     "typescript": "^7.0.2"
   }

--- a/electron/src/login-shell-environment.ts
+++ b/electron/src/login-shell-environment.ts
@@ -1,0 +1,30 @@
+import process from 'node:process';
+import { shellEnvSync } from 'shell-env';
+
+type Environment = Record<string, string | undefined>;
+type ReadLoginEnvironment = () => Readonly<Record<string, string>>;
+
+/**
+ * GUI launches do not inherit shell startup files. Keep PATH aligned on Unix
+ * and, on macOS, import the selected SSH agent socket for 1Password,
+ * Secretive, and other agents configured by the user's login shell.
+ */
+export function importLoginShellEnvironment(
+  platform = process.platform,
+  environment: Environment = process.env,
+  readLoginEnvironment: ReadLoginEnvironment = shellEnvSync,
+): void {
+  if (platform === 'win32') return;
+
+  let loginEnvironment: Readonly<Record<string, string>>;
+  try {
+    loginEnvironment = readLoginEnvironment();
+  } catch {
+    return;
+  }
+
+  if (loginEnvironment.PATH) environment.PATH = loginEnvironment.PATH;
+  if (platform === 'darwin' && loginEnvironment.SSH_AUTH_SOCK) {
+    environment.SSH_AUTH_SOCK = loginEnvironment.SSH_AUTH_SOCK;
+  }
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -13,7 +13,6 @@ import {
   shell,
   type MenuItemConstructorOptions,
 } from 'electron';
-import fixPath from 'fix-path';
 import { startServer, type RunningServer } from '@muxus/server';
 import { isNewerVersion } from '@muxus/shared';
 import type {
@@ -21,11 +20,10 @@ import type {
   MobaXtermSessionSource,
   UpdateCheckResult,
 } from '@muxus/shared';
+import { importLoginShellEnvironment } from './login-shell-environment.js';
 import { readLocalMobaXtermSessions } from './mobaxterm.js';
 
-// GUI apps on macOS/Linux don't inherit the shell PATH; ssh-agent sockets
-// and the user's login shell tooling need it.
-fixPath();
+importLoginShellEnvironment();
 
 app.setName('Muxus');
 // Keep the native Wayland app_id (and the X11 fallback's WM_CLASS) aligned

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,12 +140,12 @@ importers:
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
-      fix-path:
-        specifier: ^5.0.0
-        version: 5.0.0
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@24.13.3)
+      shell-env:
+        specifier: ^4.0.3
+        version: 4.0.3
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2160,10 +2160,6 @@ packages:
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
-  fix-path@5.0.0:
-    resolution: {integrity: sha512-erEWGGCN7RIu1bXTCfNVpVBdm0f5mwcbeja+4QXiEZzIQukP401sbpu8gd3Ny1vS34YNeswyMO0TdT2tP5OlHA==}
-    engines: {node: '>=20'}
-
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -3053,10 +3049,6 @@ packages:
 
   shell-env@4.0.3:
     resolution: {integrity: sha512-Ioe5h+hCDZ7pKL5+JGzbtPvZ5ESMHePZ8nLxohlDL+twmlcmutttMhRkrQOed8DeLT8mkYBgbwZfohe8pqaA3g==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  shell-path@3.1.0:
-    resolution: {integrity: sha512-s/9q9PEtcRmDTz69+cJ3yYBAe9yGrL7e46gm2bU4pQ9N48ecPK9QrGFnLwYgb4smOHskx4PL7wCNMktW2AoD+g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   siginfo@2.0.0:
@@ -5184,11 +5176,6 @@ snapshots:
 
   find-root@1.1.0: {}
 
-  fix-path@5.0.0:
-    dependencies:
-      shell-path: 3.1.0
-      strip-ansi: 7.2.0
-
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -6108,10 +6095,6 @@ snapshots:
       default-shell: 2.2.0
       execa: 5.1.1
       strip-ansi: 7.2.0
-
-  shell-path@3.1.0:
-    dependencies:
-      shell-env: 4.0.3
 
   siginfo@2.0.0: {}
 

--- a/server/src/routes/ssh.ts
+++ b/server/src/routes/ssh.ts
@@ -21,6 +21,10 @@ const forwardSchema = z.object({
   targetPort: z.number().int().min(1).max(65535).optional(),
 });
 
+const sshKeysQuerySchema = z.object({
+  identityAgent: z.string().max(4096).optional(),
+});
+
 const upsertSchema = z.object({
   aliases: z.array(z.string().min(1)).min(1),
   description: z.string().max(2000).optional(),
@@ -33,6 +37,7 @@ const upsertSchema = z.object({
     identityFiles: z.array(z.string()).optional(),
     certificateFiles: z.array(z.string()).optional(),
     identitiesOnly: z.boolean().optional(),
+    identityAgent: z.string().optional(),
     forwardAgent: z.boolean().optional(),
     proxyJump: z.array(z.string()).optional(),
     proxyCommand: z.string().optional(),
@@ -109,5 +114,11 @@ export function registerSshRoutes(app: FastifyInstance, ctx: AppContext): void {
     }
   });
 
-  app.get('/api/ssh/keys', async (): Promise<SshKeysResponse> => listSshKeys());
+  app.get('/api/ssh/keys', async (req, reply): Promise<SshKeysResponse | void> => {
+    const parsed = sshKeysQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return await reply.code(400).send({ message: parsed.error.issues[0]?.message ?? 'invalid SSH key query' });
+    }
+    return listSshKeys({ identityAgent: parsed.data.identityAgent });
+  });
 }

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -32,7 +32,7 @@ import {
   type OpenSshCertificate,
 } from './certificates.js';
 import { KnownHostsStore, fingerprintSha256, hostKeyType } from './known-hosts.js';
-import { resolveAgentSocket } from './key-scan.js';
+import { listAgentKeys, resolveAgentSocket } from './key-scan.js';
 import {
   ConnectionLeaseRegistry,
   type ConnectionLeaseOwner,
@@ -639,6 +639,12 @@ export class SshConnectionManager {
         resolve(client);
       });
       client.on('error', (err) => {
+        if (!settled && err.level === 'agent') {
+          // ssh2 reports an unreachable agent mid-auth and then moves on to
+          // the next method itself; surface it without aborting the dial.
+          io.status(`ssh-agent unavailable (${err.message}) — trying other authentication methods`);
+          return;
+        }
         if (!settled) {
           rejectBeforeReady(
             auth.cancelled ? new Error('authentication cancelled') : err,
@@ -997,6 +1003,7 @@ class AuthLadder {
     Promise<ParsedKey | undefined>
   >();
   private index = 0;
+  private agentIdentityPrints: Promise<Set<string>> | undefined;
   private lastPasswordCandidate: RememberedPasswordCandidate | undefined;
   private partialPasswordCandidate: RememberedPasswordCandidate | undefined;
   private savedPasswordAttempted = false;
@@ -1036,7 +1043,9 @@ class AuthLadder {
       return;
     }
     // The server told us which methods can still succeed; skip the rest.
-    if (authsLeft && attempt.type !== 'none' && !authsLeft.includes(attempt.type)) {
+    // Agent auth is publickey on the wire — servers never advertise "agent".
+    const wireType = attempt.type === 'agent' ? 'publickey' : attempt.type;
+    if (authsLeft && attempt.type !== 'none' && !authsLeft.includes(wireType)) {
       this.advance(authsLeft, cb);
       return;
     }
@@ -1094,6 +1103,7 @@ class AuthLadder {
     this.partialPasswordCandidate = undefined;
     this.privateKeys.clear();
     this.certificateKeys.clear();
+    this.agentIdentityPrints = undefined;
   }
 
   private build(): AuthAttempt[] {
@@ -1121,7 +1131,7 @@ class AuthLadder {
                 certificate,
                 files,
                 explicit || resolved.certificateFiles.length > 0,
-                !!agent,
+                agent,
                 label,
               );
               if (!privateKey) return undefined;
@@ -1139,7 +1149,7 @@ class AuthLadder {
         attempts.push({
           type: 'publickey',
           get: async () => {
-            const key = await this.loadPrivateKey(file, explicit, !!agent, label);
+            const key = await this.loadPrivateKey(file, explicit, agent, label);
             return key ? { type: 'publickey', username: user, key } : undefined;
           },
         });
@@ -1382,7 +1392,7 @@ class AuthLadder {
     certificate: OpenSshCertificate,
     identityFiles: string[],
     explicit: boolean,
-    agentAvailable: boolean,
+    agent: string | undefined,
     label: string,
   ): Promise<ParsedKey | undefined> {
     const cached = this.certificateKeys.get(certificate);
@@ -1392,7 +1402,7 @@ class AuthLadder {
         const key = await this.loadPrivateKey(
           file,
           explicit,
-          agentAvailable,
+          agent,
           label,
         );
         if (key && certificateMatchesKey(certificate, key)) {
@@ -1412,12 +1422,12 @@ class AuthLadder {
   private loadPrivateKey(
     file: string,
     explicit: boolean,
-    agentAvailable: boolean,
+    agent: string | undefined,
     label: string,
   ): Promise<ParsedKey | undefined> {
     const cached = this.privateKeys.get(file);
     if (cached) return cached;
-    const pending = this.readPrivateKey(file, explicit, agentAvailable, label);
+    const pending = this.readPrivateKey(file, explicit, agent, label);
     this.privateKeys.set(file, pending);
     return pending;
   }
@@ -1425,7 +1435,7 @@ class AuthLadder {
   private async readPrivateKey(
     file: string,
     explicit: boolean,
-    agentAvailable: boolean,
+    agent: string | undefined,
     label: string,
   ): Promise<ParsedKey | undefined> {
     let content: Buffer;
@@ -1437,9 +1447,10 @@ class AuthLadder {
     }
     let parsed = parseSshKey(content);
     if (parsed instanceof Error && /passphrase|encrypted/i.test(parsed.message)) {
-      // Encrypted. Default (unconfigured) keys next to a running agent are
-      // skipped silently — the agent attempt already covered the loaded ones.
-      if (!explicit && agentAvailable) return undefined;
+      // Encrypted. A default (unconfigured) key the agent already holds was
+      // covered by the agent attempt — skip it silently. Anything else
+      // prompts for its passphrase, like ssh(1).
+      if (!explicit && agent && (await this.agentHoldsKey(file, agent))) return undefined;
       for (let i = 0; i < MAX_PASSPHRASE_ATTEMPTS && parsed instanceof Error; i++) {
         const response = await this.runInteraction(() =>
           this.io.prompt({
@@ -1458,6 +1469,22 @@ class AuthLadder {
       return undefined;
     }
     return parsed as ParsedKey;
+  }
+
+  /** True when the key's .pub sibling names an identity the agent holds. */
+  private async agentHoldsKey(file: string, agent: string): Promise<boolean> {
+    let fingerprint: string;
+    try {
+      const blob = fs.readFileSync(`${file}.pub`, 'utf8').trim().split(/\s+/)[1];
+      if (!blob) return false;
+      fingerprint = fingerprintSha256(Buffer.from(blob, 'base64'));
+    } catch {
+      return false; // no readable .pub — prompt rather than guess
+    }
+    this.agentIdentityPrints ??= listAgentKeys(agent).then(
+      (keys) => new Set(keys.map((k) => k.fingerprint)),
+    );
+    return (await this.agentIdentityPrints).has(fingerprint);
   }
 }
 

--- a/server/src/ssh/key-scan.ts
+++ b/server/src/ssh/key-scan.ts
@@ -53,8 +53,7 @@ export function resolveAgentSocket(identityAgent?: string): string | undefined {
   return identityAgent;
 }
 
-export async function listAgentKeys(): Promise<SshAgentKey[]> {
-  const sock = agentSocket();
+export async function listAgentKeys(sock = agentSocket()): Promise<SshAgentKey[]> {
   if (!sock) return [];
   return new Promise((resolve) => {
     try {

--- a/server/src/ssh/key-scan.ts
+++ b/server/src/ssh/key-scan.ts
@@ -53,29 +53,39 @@ export function resolveAgentSocket(identityAgent?: string): string | undefined {
   return identityAgent.replace(/^~(?=$|[\\/])/, os.homedir());
 }
 
-export async function listAgentKeys(sock = agentSocket()): Promise<SshAgentKey[]> {
-  if (!sock) return [];
+interface AgentKeyProbe {
+  available: boolean;
+  keys: SshAgentKey[];
+}
+
+async function probeAgentKeys(sock: string | undefined): Promise<AgentKeyProbe> {
+  if (!sock) return { available: false, keys: [] };
   return new Promise((resolve) => {
     try {
       (createAgent(sock) as BaseAgent<ParsedKey>).getIdentities((err, keys) => {
         if (err || !keys) {
-          resolve([]);
+          resolve({ available: false, keys: [] });
           return;
         }
         // Real agents hand back ParsedKey objects; skip anything else.
         const parsed = keys.filter((k): k is ParsedKey => !!k && typeof k === 'object' && 'getPublicSSH' in k);
-        resolve(
-          parsed.map((k) => ({
+        resolve({
+          available: true,
+          keys: parsed.map((k) => ({
             type: k.type,
             comment: k.comment || undefined,
             fingerprint: fingerprintSha256(k.getPublicSSH()),
           })),
-        );
+        });
       });
     } catch {
-      resolve([]);
+      resolve({ available: false, keys: [] });
     }
   });
+}
+
+export async function listAgentKeys(sock = agentSocket()): Promise<SshAgentKey[]> {
+  return (await probeAgentKeys(sock)).keys;
 }
 
 export async function listSshKeys(
@@ -88,7 +98,8 @@ export async function listSshKeys(
   } = {},
 ): Promise<SshKeysResponse> {
   const sock = resolveAgentSocket(identityAgent);
-  const agentKeys = sock ? await listAgentKeys(sock) : [];
+  const agent = await probeAgentKeys(sock);
+  const agentKeys = agent.keys;
   const agentPrints = new Set(agentKeys.map((k) => k.fingerprint));
   const keys: SshKeyInfo[] = [];
 
@@ -144,5 +155,5 @@ export async function listSshKeys(
     });
   }
 
-  return { agentAvailable: !!sock && (process.platform !== 'win32' || agentKeys.length > 0), agentKeys, keys };
+  return { agentAvailable: agent.available, agentKeys, keys };
 }

--- a/server/src/ssh/key-scan.ts
+++ b/server/src/ssh/key-scan.ts
@@ -50,7 +50,7 @@ export function resolveAgentSocket(identityAgent?: string): string | undefined {
     const name = braced?.[1] ?? identityAgent.slice(1);
     return process.env[name] || undefined;
   }
-  return identityAgent;
+  return identityAgent.replace(/^~(?=$|[\\/])/, os.homedir());
 }
 
 export async function listAgentKeys(sock = agentSocket()): Promise<SshAgentKey[]> {
@@ -78,8 +78,17 @@ export async function listAgentKeys(sock = agentSocket()): Promise<SshAgentKey[]
   });
 }
 
-export async function listSshKeys(dir = path.join(os.homedir(), '.ssh')): Promise<SshKeysResponse> {
-  const agentKeys = await listAgentKeys();
+export async function listSshKeys(
+  {
+    dir = path.join(os.homedir(), '.ssh'),
+    identityAgent,
+  }: {
+    dir?: string;
+    identityAgent?: string;
+  } = {},
+): Promise<SshKeysResponse> {
+  const sock = resolveAgentSocket(identityAgent);
+  const agentKeys = sock ? await listAgentKeys(sock) : [];
   const agentPrints = new Set(agentKeys.map((k) => k.fingerprint));
   const keys: SshKeyInfo[] = [];
 
@@ -135,5 +144,5 @@ export async function listSshKeys(dir = path.join(os.homedir(), '.ssh')): Promis
     });
   }
 
-  return { agentAvailable: !!agentSocket() && (process.platform !== 'win32' || agentKeys.length > 0), agentKeys, keys };
+  return { agentAvailable: !!sock && (process.platform !== 'win32' || agentKeys.length > 0), agentKeys, keys };
 }

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -758,6 +758,7 @@ export function listHosts(doc: ConfigDocument): SshHostEntry[] {
         identityFiles: resolved.identityFiles,
         certificateFiles: resolved.certificateFiles,
         identitiesOnly: resolved.identitiesOnly,
+        identityAgent: resolved.identityAgent,
         forwardAgent: resolved.forwardAgent,
         proxyJump: resolved.proxyJump,
         proxyCommand: resolved.proxyCommand,

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -330,6 +330,8 @@ export interface ResolvedHostSettings {
   /** User certificates paired with matching private IdentityFile keys. */
   certificateFiles: string[];
   identitiesOnly: boolean;
+  /** Effective authentication agent after applying all matching Host blocks. */
+  identityAgent?: string;
   forwardAgent: boolean;
   proxyJump: string[];
   /** Raw ProxyCommand after Host-pattern resolution; tokens expand at dial time. */

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -4,6 +4,7 @@ import {
   blankDraft,
   draftFromEntry,
   draftToRequest,
+  identityAgentForDetection,
 } from '../../../client/src/components/host-editor/draft.js';
 
 const entry: SshHostEntry = {
@@ -26,6 +27,7 @@ const entry: SshHostEntry = {
     identityFiles: ['/home/test/.ssh/cloud'],
     certificateFiles: ['/home/test/.ssh/cloud-cert.pub'],
     identitiesOnly: false,
+    identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
     forwardAgent: false,
     proxyJump: [],
     proxyCommand: 'cloudflared access ssh --hostname %h',
@@ -80,6 +82,24 @@ describe('SSH host editor draft', () => {
       remoteCommand: 'none',
       requestTty: 'auto',
     });
+  });
+
+  it('selects the current per-host agent for live key detection', () => {
+    const draft = blankDraft();
+    expect(identityAgentForDetection(draft, '${INHERITED_AGENT}')).toBe('${INHERITED_AGENT}');
+
+    draft.identityAgentMode = 'environment';
+    expect(identityAgentForDetection(draft, '${INHERITED_AGENT}')).toBe('SSH_AUTH_SOCK');
+
+    draft.identityAgentMode = 'custom';
+    draft.identityAgent = '  ~/.1password/agent.sock  ';
+    expect(identityAgentForDetection(draft, '${INHERITED_AGENT}')).toBe('~/.1password/agent.sock');
+
+    draft.identityAgent = ' ';
+    expect(identityAgentForDetection(draft, '${INHERITED_AGENT}')).toBe('none');
+
+    draft.identityAgentMode = 'none';
+    expect(identityAgentForDetection(draft, '${INHERITED_AGENT}')).toBe('none');
   });
 
   it('splits a prefilled quick-connect target, and leaves a bare name as the alias', () => {

--- a/tests/unit/electron/login-shell-environment.test.ts
+++ b/tests/unit/electron/login-shell-environment.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { importLoginShellEnvironment } from '../../../electron/src/login-shell-environment.js';
+
+describe('login shell environment', () => {
+  it('imports PATH and SSH_AUTH_SOCK for a Finder-launched macOS app', () => {
+    const environment = {
+      PATH: '/usr/bin',
+      SSH_AUTH_SOCK: '/private/tmp/com.apple.launchd/default-agent',
+    };
+
+    importLoginShellEnvironment(
+      'darwin',
+      environment,
+      () => ({
+        PATH: '/opt/homebrew/bin:/usr/bin',
+        SSH_AUTH_SOCK: '/Users/alice/Library/Group Containers/1password/agent.sock',
+      }),
+    );
+
+    expect(environment).toEqual({
+      PATH: '/opt/homebrew/bin:/usr/bin',
+      SSH_AUTH_SOCK: '/Users/alice/Library/Group Containers/1password/agent.sock',
+    });
+  });
+
+  it('does not replace the launch environment when the shell has no agent socket', () => {
+    const environment = {
+      PATH: '/usr/bin',
+      SSH_AUTH_SOCK: '/private/tmp/com.apple.launchd/default-agent',
+    };
+
+    importLoginShellEnvironment(
+      'darwin',
+      environment,
+      () => ({ PATH: '/opt/homebrew/bin:/usr/bin' }),
+    );
+
+    expect(environment.SSH_AUTH_SOCK).toBe('/private/tmp/com.apple.launchd/default-agent');
+  });
+
+  it('keeps SSH_AUTH_SOCK unchanged on Linux and skips shell startup on Windows', () => {
+    const linuxEnvironment = { PATH: '/usr/bin', SSH_AUTH_SOCK: '/run/user/1000/agent.sock' };
+    importLoginShellEnvironment(
+      'linux',
+      linuxEnvironment,
+      () => ({ PATH: '/home/alice/bin:/usr/bin', SSH_AUTH_SOCK: '/tmp/other.sock' }),
+    );
+    expect(linuxEnvironment).toEqual({
+      PATH: '/home/alice/bin:/usr/bin',
+      SSH_AUTH_SOCK: '/run/user/1000/agent.sock',
+    });
+
+    const readLoginEnvironment = vi.fn(() => ({ PATH: 'ignored' }));
+    const windowsEnvironment = { PATH: 'C:\\Windows\\System32' };
+    importLoginShellEnvironment('win32', windowsEnvironment, readLoginEnvironment);
+    expect(readLoginEnvironment).not.toHaveBeenCalled();
+    expect(windowsEnvironment.PATH).toBe('C:\\Windows\\System32');
+  });
+
+  it('leaves the current environment intact when shell startup fails', () => {
+    const environment = { PATH: '/usr/bin', SSH_AUTH_SOCK: '/tmp/current.sock' };
+    importLoginShellEnvironment(
+      'darwin',
+      environment,
+      () => {
+        throw new Error('shell failed');
+      },
+    );
+    expect(environment).toEqual({ PATH: '/usr/bin', SSH_AUTH_SOCK: '/tmp/current.sock' });
+  });
+});

--- a/tests/unit/server/agent-auth.test.ts
+++ b/tests/unit/server/agent-auth.test.ts
@@ -1,0 +1,257 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, copyFileSync } from 'node:fs';
+import type net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { generateKeyPairSync } from 'node:crypto';
+import ssh2, { Server } from 'ssh2';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { SshProfile } from '@muxus/shared/ws-protocol';
+import { SshConnectionManager, type ConnectIo } from '../../../server/src/ssh/connection-manager.js';
+import { KnownHostsStore } from '../../../server/src/ssh/known-hosts.js';
+import { loadConfigDocument } from '../../../server/src/ssh/ssh-config.js';
+
+const { utils } = ssh2;
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-agent-auth-'));
+const PASSWORD = 'fallback-password';
+const KEY_PASSPHRASE = 'k3y-pass';
+
+const HOST_KEY = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+}).privateKey;
+
+interface AuthEvent {
+  method: string;
+  accepted?: boolean;
+}
+
+let agentPid = '';
+let agentSock = '';
+let agentPub: ssh2.ParsedKey;
+const savedEnv = { HOME: process.env.HOME, SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK };
+
+/** sshd stand-in accepting one public key (none when null) or the password. */
+function startServer(
+  allowed: ssh2.ParsedKey | null,
+): Promise<{ server: Server; port: number; events: AuthEvent[] }> {
+  const events: AuthEvent[] = [];
+  const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
+    conn.on('error', () => undefined);
+    conn.on('authentication', (ctx) => {
+      if (ctx.method === 'publickey') {
+        const matches =
+          !!allowed && ctx.key.algo === allowed.type && ctx.key.data.equals(allowed.getPublicSSH());
+        const event: AuthEvent = { method: 'publickey' };
+        events.push(event);
+        if (matches) {
+          if (!ctx.signature) return ctx.accept(); // pk-ok probe
+          if (allowed.verify(ctx.blob!, ctx.signature, ctx.hashAlgo) === true) {
+            event.accepted = true;
+            return ctx.accept();
+          }
+        }
+        return ctx.reject(['publickey', 'password']);
+      }
+      if (ctx.method === 'password') {
+        events.push({ method: 'password', accepted: ctx.password === PASSWORD });
+        if (ctx.password === PASSWORD) return ctx.accept();
+        return ctx.reject(['publickey', 'password']);
+      }
+      if (ctx.method !== 'none') events.push({ method: ctx.method });
+      ctx.reject(['publickey', 'password']);
+    });
+    conn.on('ready', () => {
+      conn.on('session', (acceptSession) => {
+        const session = acceptSession();
+        session.on('pty', (acceptPty) => acceptPty?.());
+        session.on('shell', (acceptShell) => acceptShell().write('shell ok\n'));
+      });
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as net.AddressInfo).port, events });
+    });
+  });
+}
+
+let counter = 0;
+function makeManager(port: number): SshConnectionManager {
+  const configFile = path.join(tmp, `ssh_config-${counter++}`);
+  writeFileSync(
+    configFile,
+    ['Host lab', '  HostName 127.0.0.1', '  User tester', `  Port ${port}`, '  StrictHostKeyChecking no', ''].join('\n'),
+  );
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return new SshConnectionManager(log as never, {
+    knownHosts: new KnownHostsStore(
+      path.join(tmp, `known_hosts-${counter++}`),
+      path.join(tmp, 'no-global-known-hosts'),
+    ),
+    loadConfig: () => loadConfigDocument(configFile),
+  });
+}
+
+function makeIo(): ConnectIo & {
+  passwordPrompts: number;
+  passphrasePrompts: number;
+  statuses: string[];
+} {
+  const io = {
+    passwordPrompts: 0,
+    passphrasePrompts: 0,
+    statuses: [] as string[],
+    status: (message: string) => {
+      io.statuses.push(message);
+    },
+    prompt: (info: { prompts: Array<{ prompt: string }> }) => {
+      const answers = info.prompts.map((p) => {
+        if (/passphrase/i.test(p.prompt)) {
+          io.passphrasePrompts += 1;
+          return KEY_PASSPHRASE;
+        }
+        io.passwordPrompts += 1;
+        return PASSWORD;
+      });
+      return Promise.resolve({ answers });
+    },
+    hostKey: () => Promise.resolve(true),
+  };
+  return io as unknown as ConnectIo & {
+    passwordPrompts: number;
+    passphrasePrompts: number;
+    statuses: string[];
+  };
+}
+
+const profile: SshProfile = { kind: 'ssh', target: 'lab' };
+
+async function connectOnce(port: number, io: ConnectIo): Promise<void> {
+  const manager = makeManager(port);
+  const lease = await manager.connect(profile, io);
+  lease.release();
+  manager.closeAll();
+}
+
+// Drives a real ssh-agent; the Windows agent is a service and cannot be
+// spawned ad hoc, so this suite runs on POSIX only.
+describe.skipIf(process.platform === 'win32')('ssh-agent authentication', () => {
+  beforeAll(() => {
+    const keyPath = path.join(tmp, 'agent-key');
+    execFileSync('ssh-keygen', ['-t', 'ed25519', '-N', '', '-f', keyPath, '-C', 'muxus-test'], {
+      stdio: 'ignore',
+    });
+    const out = execFileSync('ssh-agent', ['-s']).toString();
+    const sock = /SSH_AUTH_SOCK=([^;]+);/.exec(out)?.[1];
+    const pid = /SSH_AGENT_PID=(\d+);/.exec(out)?.[1];
+    if (!sock || !pid) throw new Error(`unexpected ssh-agent output: ${out}`);
+    agentSock = sock;
+    agentPid = pid;
+    execFileSync('ssh-add', [keyPath], {
+      env: { ...process.env, SSH_AUTH_SOCK: agentSock },
+      stdio: 'ignore',
+    });
+    const parsed = utils.parseKey(readFileSync(`${keyPath}.pub`));
+    if (parsed instanceof Error) throw parsed;
+    agentPub = parsed;
+
+    // Isolate from the developer's ~/.ssh so no default identity files exist.
+    process.env.HOME = tmp;
+    process.env.SSH_AUTH_SOCK = agentSock;
+  });
+
+  afterAll(() => {
+    if (agentPid) execFileSync('kill', [agentPid]);
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('authenticates with a key held only by the agent, without any prompt', async () => {
+    const { server, port, events } = await startServer(agentPub);
+    const io = makeIo();
+
+    await connectOnce(port, io);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    expect(events.some((e) => e.method === 'publickey' && e.accepted)).toBe(true);
+    expect(events.some((e) => e.method === 'password')).toBe(false);
+    expect(io.passwordPrompts).toBe(0);
+    expect(io.passphrasePrompts).toBe(0);
+  }, 15_000);
+
+  it('falls back to the next method when the agent socket is unreachable', async () => {
+    process.env.SSH_AUTH_SOCK = path.join(tmp, 'no-such-agent.sock');
+    try {
+      const { server, port, events } = await startServer(agentPub);
+      const io = makeIo();
+
+      await connectOnce(port, io);
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+
+      expect(io.statuses.some((s) => s.includes('ssh-agent unavailable'))).toBe(true);
+      expect(events.some((e) => e.method === 'password' && e.accepted)).toBe(true);
+      expect(io.passwordPrompts).toBe(1);
+    } finally {
+      process.env.SSH_AUTH_SOCK = agentSock;
+    }
+  }, 15_000);
+
+  it('prompts for the passphrase of a default key the agent does not hold', async () => {
+    const sshDir = path.join(tmp, '.ssh');
+    mkdirSync(sshDir, { recursive: true });
+    try {
+      const diskKey = path.join(sshDir, 'id_ed25519');
+      execFileSync('ssh-keygen', ['-t', 'ed25519', '-N', KEY_PASSPHRASE, '-f', diskKey], {
+        stdio: 'ignore',
+      });
+      const diskPub = utils.parseKey(readFileSync(`${diskKey}.pub`));
+      if (diskPub instanceof Error) throw diskPub;
+
+      const { server, port, events } = await startServer(diskPub);
+      const io = makeIo();
+
+      await connectOnce(port, io);
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+
+      expect(io.passphrasePrompts).toBe(1);
+      expect(events.some((e) => e.method === 'publickey' && e.accepted)).toBe(true);
+      expect(io.passwordPrompts).toBe(0);
+    } finally {
+      rmSync(sshDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('never asks for the passphrase of a default key the agent already holds', async () => {
+    const sshDir = path.join(tmp, '.ssh');
+    mkdirSync(sshDir, { recursive: true });
+    try {
+      // The agent key, re-encrypted on disk — the agent attempt covers it.
+      const diskKey = path.join(sshDir, 'id_ed25519');
+      copyFileSync(path.join(tmp, 'agent-key'), diskKey);
+      copyFileSync(path.join(tmp, 'agent-key.pub'), `${diskKey}.pub`);
+      execFileSync('ssh-keygen', ['-p', '-P', '', '-N', KEY_PASSPHRASE, '-f', diskKey], {
+        stdio: 'ignore',
+      });
+
+      // The server rejects every public key, so the ladder walks past both
+      // the agent and the identity files before landing on the password.
+      const { server, port, events } = await startServer(null);
+      const io = makeIo();
+
+      await connectOnce(port, io);
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+
+      expect(io.passphrasePrompts).toBe(0);
+      expect(events.some((e) => e.method === 'password' && e.accepted)).toBe(true);
+      expect(io.passwordPrompts).toBe(1);
+    } finally {
+      rmSync(sshDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/tests/unit/server/agent-socket.test.ts
+++ b/tests/unit/server/agent-socket.test.ts
@@ -1,3 +1,5 @@
+import os from 'node:os';
+import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveAgentSocket } from '../../../server/src/ssh/key-scan.js';
 
@@ -16,6 +18,9 @@ describe('resolveAgentSocket', () => {
 
   it('uses a configured socket path (1Password-style)', () => {
     expect(resolveAgentSocket('/home/user/.1password/agent.sock')).toBe('/home/user/.1password/agent.sock');
+    expect(resolveAgentSocket('~/.1password/agent.sock')).toBe(
+      path.join(os.homedir(), '.1password', 'agent.sock'),
+    );
   });
 
   it('dereferences $VAR, ${VAR}, and the literal SSH_AUTH_SOCK', () => {

--- a/tests/unit/server/ssh-config.test.ts
+++ b/tests/unit/server/ssh-config.test.ts
@@ -117,6 +117,7 @@ describe('listHosts', () => {
       remoteCommand: 'tmux new -A -s main',
       requestTty: 'yes',
     });
+    expect(hosts[0]!.resolved.identityAgent).toBe('${ONEPASSWORD_SSH_AUTH_SOCK}');
     expect(hosts[0]!.options.extras).toBeUndefined();
   });
 

--- a/tests/unit/server/ssh-routes.test.ts
+++ b/tests/unit/server/ssh-routes.test.ts
@@ -1,11 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildApp } from '../../../server/src/app.js';
 import { resolveConfig } from '../../../server/src/config.js';
 
 const TOKEN = 'ssh-route-test-token';
 let app: Awaited<ReturnType<typeof buildApp>>['app'];
+let home: string;
 
 beforeEach(async () => {
+  home = mkdtempSync(path.join(os.tmpdir(), 'muxus-ssh-routes-'));
+  vi.stubEnv('HOME', home);
   ({ app } = await buildApp(
     resolveConfig({
       token: TOKEN,
@@ -19,6 +25,8 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await app.close();
+  vi.unstubAllEnvs();
+  rmSync(home, { recursive: true, force: true });
 });
 
 const auth = () => ({ authorization: `Bearer ${TOKEN}` });
@@ -77,5 +85,44 @@ describe('OpenSSH host keyword metadata', () => {
     });
 
     expect(response.statusCode).toBe(400);
+  });
+});
+
+describe('OpenSSH agent routes', () => {
+  it('persists IdentityAgent from the validated host payload', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/ssh/config/hosts',
+      headers: {
+        ...auth(),
+        'content-type': 'application/json',
+      },
+      payload: {
+        aliases: ['muxus-identity-agent-route-test'],
+        options: {
+          hostname: 'example.test',
+          identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(readFileSync(path.join(home, '.ssh', 'config'), 'utf8')).toContain(
+      'IdentityAgent ${ONEPASSWORD_SSH_AUTH_SOCK}',
+    );
+  });
+
+  it('uses the requested host-editor agent source for key detection', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/ssh/keys?identityAgent=none',
+      headers: auth(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      agentAvailable: false,
+      agentKeys: [],
+    });
   });
 });

--- a/tests/unit/server/ssh-routes.test.ts
+++ b/tests/unit/server/ssh-routes.test.ts
@@ -125,4 +125,19 @@ describe('OpenSSH agent routes', () => {
       agentKeys: [],
     });
   });
+
+  it('reports an unreachable custom agent as unavailable', async () => {
+    const identityAgent = path.join(home, 'missing-agent.sock');
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/ssh/keys?identityAgent=${encodeURIComponent(identityAgent)}`,
+      headers: auth(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      agentAvailable: false,
+      agentKeys: [],
+    });
+  });
 });


### PR DESCRIPTION
Fixes #21

## Root cause

The auth ladder skips attempts the server did not advertise in its `USERAUTH_FAILURE` method list. Agent auth was matched against that list under its ssh2 client-side name `agent` — but on the wire agent auth is `publickey`, so no server ever advertises `agent` and the agent rung was skipped on every connection, on every platform.

On Linux this was masked whenever an unencrypted default key sits in `~/.ssh`: the identity-file rung (correctly matched as `publickey`) covered for it. On Windows and macOS keys typically live only in the agent, and encrypted default keys were skipped silently whenever an agent socket existed — so nothing key-based was ever tried and every connection fell through to a password prompt, while plain `ssh` in a terminal worked. Exactly the reported symptom.

Reproduced end-to-end against an in-process sshd with a real `ssh-agent`: a plain ssh2 client authenticated via the agent while the connection manager sent zero publickey attempts and prompted for a password.

## Changes

- Match the agent rung against the server's method list as `publickey`, its wire name.
- Treat an unreachable agent as non-fatal during auth, matching ssh2's own behaviour: report `ssh-agent unavailable` as a status line and let the ladder continue instead of aborting the dial. Without this, the first fix would turn a dead agent socket (e.g. the Windows pipe when the agent service is stopped) into a hard connection failure.
- Prompt for the passphrase of an encrypted default key the agent does not hold, like ssh(1), instead of silently skipping every encrypted default key whenever an agent socket exists. Keys whose `.pub` fingerprint is already loaded in the agent are still skipped silently — the agent attempt covered them, so there is no double prompt. `listAgentKeys` now takes an optional socket so the ladder can query the per-host agent, including `IdentityAgent` overrides.

## Tests

New `agent-auth.test.ts` suite driving the real connection manager against an in-process sshd with a live `ssh-agent` (POSIX-only; the Windows agent is a service and cannot be spawned ad hoc):

1. A key held only by the agent authenticates with zero prompts.
2. A dead agent socket surfaces a status message and falls back to password instead of aborting.
3. An encrypted default key the agent does not hold gets exactly one passphrase prompt and logs in with the key.
4. An encrypted default key the agent does hold is never passphrase-prompted (no double ask).

Full suite: 582 passed / 3 skipped; all workspace typechecks and oxlint clean.

