### PR TITLE
Add a keyboard shortcut for multi-execution

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -73,9 +73,15 @@ const initialKeys = collectStaticGraph(entry[0]);
 // terminals mount. That startup decision adds ~0.2 KiB raw / ~0.1 KiB gzip;
 // the reconnect and scrollback implementations remain in the lazy terminal
 // feature graph measured below.
+//
+// A command in that catalog pays there as well. The multi-execution toggle —
+// the selection it resumes and the reason it gives when there is nothing to
+// mirror — adds ~1 KiB raw / ~0.4 KiB gzip to the keymap and the multi-exec
+// store, both of which the first paint already carries, and the gzip budget
+// moves to cover it.
 check('Initial JavaScript', measureGraph(initialKeys), {
   raw: 782_000,
-  gzip: 250_000,
+  gzip: 251_000,
 });
 
 for (const feature of [

--- a/client/src/components/MultiExecControl.tsx
+++ b/client/src/components/MultiExecControl.tsx
@@ -21,7 +21,7 @@ import { alpha } from '@mui/material/styles';
 import { useChordLabel } from '../keymap/hints.js';
 import { useMultiExecStore } from '../state/multi-exec.js';
 import { useTabsStore } from '../state/tabs.js';
-import { flattenPaneLayout } from '../state/workspace-layout.js';
+import { visibleTabIds } from '../state/workspace-layout.js';
 import { withChord } from './ChordHint.js';
 
 /** Target picker for automatic mirrored terminal input. */
@@ -29,6 +29,7 @@ export function MultiExecControl() {
   const tabs = useTabsStore((state) => state.tabs);
   const root = useTabsStore((state) => state.root);
   const activePaneId = useTabsStore((state) => state.activePaneId);
+  const zoomedPaneId = useTabsStore((state) => state.zoomedPaneId);
   const selectedIds = useMultiExecStore((state) => state.selectedIds);
   const groups = useMultiExecStore((state) => state.groups);
   const setSelection = useMultiExecStore((state) => state.setSelection);
@@ -60,9 +61,7 @@ export function MultiExecControl() {
   const connected = useMemo(() => new Set(connectedIds), [connectedIds]);
   const active = selectedIds.length >= 2;
   const visibleIds = new Set(
-    flattenPaneLayout(root).panes
-      .map(({ pane }) => pane.activeTabId)
-      .filter((id): id is string => !!id && connected.has(id)),
+    visibleTabIds(root, zoomedPaneId).filter((tabId) => connected.has(tabId)),
   );
   const currentPaneIds = connectedTabs
     .filter((tab) => tab.paneId === activePaneId)

--- a/client/src/components/MultiExecControl.tsx
+++ b/client/src/components/MultiExecControl.tsx
@@ -18,9 +18,11 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import PodcastsOutlinedIcon from '@mui/icons-material/PodcastsOutlined';
 import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
 import { alpha } from '@mui/material/styles';
+import { useChordLabel } from '../keymap/hints.js';
 import { useMultiExecStore } from '../state/multi-exec.js';
 import { useTabsStore } from '../state/tabs.js';
 import { flattenPaneLayout } from '../state/workspace-layout.js';
+import { withChord } from './ChordHint.js';
 
 /** Target picker for automatic mirrored terminal input. */
 export function MultiExecControl() {
@@ -37,6 +39,7 @@ export function MultiExecControl() {
   const activateGroup = useMultiExecStore((state) => state.activateGroup);
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const [groupName, setGroupName] = useState('');
+  const toggleChord = useChordLabel('terminal.multi-exec');
 
   const connectedTabs = useMemo(
     () => tabs.filter((tab) => tab.profile && tab.status === 'connected'),
@@ -67,7 +70,16 @@ export function MultiExecControl() {
 
   return (
     <>
-      <Tooltip title={active ? `Mirroring input across ${selectedIds.length} terminals` : 'Select terminals for multi-execution'}>
+      <Tooltip
+        title={withChord(
+          active
+            ? `Mirroring input across ${selectedIds.length} terminals`
+            : 'Select terminals for multi-execution',
+          // The chord toggles mirroring rather than opening this picker, so it
+          // says so instead of standing alone as the button's own shortcut.
+          toggleChord && `${toggleChord} toggles mirroring`,
+        )}
+      >
         <IconButton
           size="small"
           aria-label="Configure multi-execution"

--- a/client/src/keymap/commands.ts
+++ b/client/src/keymap/commands.ts
@@ -7,6 +7,7 @@ import {
   requestCloseActivePane,
   requestCloseTabs,
   splitActivePane,
+  toggleMultiExec,
 } from '../session-actions.js';
 import { usePrefsStore } from '../state/prefs.js';
 import { PANE_RESIZE_STEP, useTabsStore } from '../state/tabs.js';
@@ -335,6 +336,14 @@ export const KEY_COMMANDS: readonly KeyCommand[] = [
       handle.clear();
       return true;
     },
+  },
+  {
+    id: 'terminal.multi-exec',
+    title: 'Toggle multi-execution',
+    category: 'terminal',
+    defaultChords: ['Mod+Shift+M'],
+    keywords: ['multi-exec', 'mirror', 'broadcast', 'sync input', 'all sessions'],
+    run: () => toggleMultiExec(),
   },
   {
     id: 'terminal.zoom-in',

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -13,7 +13,7 @@ import type { PaneDirection, SessionSetLayout } from './state/tabs.js';
 import { confirmAction } from './state/dialogs.js';
 import { showToast } from './state/toast.js';
 import { confirmDiscardRemoteEditors } from './editor/remote-editor-registry.js';
-import { findPane, flattenPaneLayout } from './state/workspace-layout.js';
+import { findPane, visibleTabIds } from './state/workspace-layout.js';
 import { openAppWindow } from './window-management.js';
 
 /**
@@ -150,11 +150,9 @@ export async function launchManagedHostGroup(
  * the sessions on screen — the ones visibly receiving the keystrokes.
  */
 export function toggleMultiExec(): boolean {
-  const { tabs, root } = useTabsStore.getState();
+  const { tabs, root, zoomedPaneId } = useTabsStore.getState();
   const connected = tabs.filter((tab) => tab.status === 'connected').map((tab) => tab.id);
-  const onScreen = flattenPaneLayout(root)
-    .panes.map(({ pane }) => pane.activeTabId)
-    .filter((id): id is string => !!id);
+  const onScreen = visibleTabIds(root, zoomedPaneId);
   if (useMultiExecStore.getState().toggleMirroring(connected, onScreen)) return true;
   showToast(
     'info',

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -11,8 +11,9 @@ import { useMultiExecStore } from './state/multi-exec.js';
 import { useTabsStore } from './state/tabs.js';
 import type { PaneDirection, SessionSetLayout } from './state/tabs.js';
 import { confirmAction } from './state/dialogs.js';
+import { showToast } from './state/toast.js';
 import { confirmDiscardRemoteEditors } from './editor/remote-editor-registry.js';
-import { findPane } from './state/workspace-layout.js';
+import { findPane, flattenPaneLayout } from './state/workspace-layout.js';
 import { openAppWindow } from './window-management.js';
 
 /**
@@ -141,6 +142,27 @@ export async function launchManagedHostGroup(
   );
   useMultiExecStore.getState().setGroups([]);
   return ids;
+}
+
+/**
+ * Switch mirrored input on or off from the keyboard. Switching it on resumes
+ * the terminals that were mirroring last, and for a first press falls back to
+ * the sessions on screen — the ones visibly receiving the keystrokes.
+ */
+export function toggleMultiExec(): boolean {
+  const { tabs, root } = useTabsStore.getState();
+  const connected = tabs.filter((tab) => tab.status === 'connected').map((tab) => tab.id);
+  const onScreen = flattenPaneLayout(root)
+    .panes.map(({ pane }) => pane.activeTabId)
+    .filter((id): id is string => !!id);
+  if (useMultiExecStore.getState().toggleMirroring(connected, onScreen)) return true;
+  showToast(
+    'info',
+    connected.length < 2
+      ? 'Connect at least two sessions to mirror input.'
+      : 'Pick the terminals to mirror input into from the multi-exec control.',
+  );
+  return true;
 }
 
 /** Duplicate an open tab (same profile, fresh session). */

--- a/client/src/state/multi-exec.ts
+++ b/client/src/state/multi-exec.ts
@@ -5,10 +5,16 @@ import { terminalHandle } from '../terminal/terminal-registry.js';
 interface MultiExecState {
   /** Two or more selected tabs automatically form a mirrored-input group. */
   selectedIds: string[];
+  /** The last set that actually mirrored, so the toggle can resume it. */
+  lastMirroredIds: string[];
   /** Named target sets persisted as part of the active workspace. */
   groups: WorkspaceMultiExecGroup[];
   setSelection: (tabIds: string[]) => void;
   toggleTarget: (tabId: string) => void;
+  toggleMirroring: (
+    availableTabIds: readonly string[],
+    fallbackTabIds: readonly string[],
+  ) => boolean;
   reconcile: (availableTabIds: string[]) => void;
   setGroups: (groups: readonly WorkspaceMultiExecGroup[]) => void;
   saveGroup: (name: string, tabIds?: readonly string[]) => string | undefined;
@@ -16,21 +22,57 @@ interface MultiExecState {
   activateGroup: (id: string, availableTabIds: readonly string[]) => void;
 }
 
-function unique(tabIds: string[]): string[] {
+function unique(tabIds: readonly string[]): string[] {
   return [...new Set(tabIds)];
+}
+
+/**
+ * A selection change that also remembers any set large enough to mirror, so
+ * switching multi-execution off and on again lands on the same terminals.
+ */
+function select(
+  state: MultiExecState,
+  selectedIds: string[],
+): Pick<MultiExecState, 'selectedIds' | 'lastMirroredIds'> {
+  return {
+    selectedIds,
+    lastMirroredIds: selectedIds.length >= 2 ? selectedIds : state.lastMirroredIds,
+  };
 }
 
 export const useMultiExecStore = create<MultiExecState>()((set) => ({
   selectedIds: [],
+  lastMirroredIds: [],
   groups: [],
-  setSelection: (tabIds) => set({ selectedIds: unique(tabIds) }),
+  setSelection: (tabIds) => set((state) => select(state, unique(tabIds))),
   toggleTarget: (tabId) =>
+    set((state) =>
+      select(
+        state,
+        state.selectedIds.includes(tabId)
+          ? state.selectedIds.filter((id) => id !== tabId)
+          : [...state.selectedIds, tabId],
+      ),
+    ),
+  toggleMirroring: (availableTabIds, fallbackTabIds) => {
+    let toggled = false;
     set((state) => {
-      const selectedIds = state.selectedIds.includes(tabId)
-        ? state.selectedIds.filter((id) => id !== tabId)
-        : [...state.selectedIds, tabId];
-      return { selectedIds };
-    }),
+      // Off is unconditional: whatever is mirroring right now stops, and the
+      // set is kept for the next press.
+      if (state.selectedIds.length >= 2) {
+        toggled = true;
+        return { selectedIds: [], lastMirroredIds: state.selectedIds };
+      }
+      const available = new Set(availableTabIds);
+      const resumed = state.lastMirroredIds.filter((id) => available.has(id));
+      const selectedIds =
+        resumed.length >= 2 ? resumed : unique(fallbackTabIds).filter((id) => available.has(id));
+      if (selectedIds.length < 2) return state;
+      toggled = true;
+      return select(state, selectedIds);
+    });
+    return toggled;
+  },
   reconcile: (availableTabIds) =>
     set((state) => {
       const available = new Set(availableTabIds);
@@ -46,6 +88,8 @@ export const useMultiExecStore = create<MultiExecState>()((set) => ({
   setGroups: (groups) =>
     set({
       selectedIds: [],
+      // Tab ids from the outgoing workspace can never be resumed.
+      lastMirroredIds: [],
       groups: groups.map((group) => ({
         id: group.id,
         name: group.name,
@@ -78,7 +122,10 @@ export const useMultiExecStore = create<MultiExecState>()((set) => ({
       const group = state.groups.find((candidate) => candidate.id === id);
       if (!group) return state;
       const available = new Set(availableTabIds);
-      return { selectedIds: group.tabIds.filter((tabId) => available.has(tabId)) };
+      return select(
+        state,
+        group.tabIds.filter((tabId) => available.has(tabId)),
+      );
     }),
 }));
 

--- a/client/src/state/workspace-layout.ts
+++ b/client/src/state/workspace-layout.ts
@@ -129,6 +129,18 @@ export function countPanes(root: PaneNode): number {
   return root.type === 'pane' ? 1 : countPanes(root.children[0]) + countPanes(root.children[1]);
 }
 
+/**
+ * The tab on screen in each pane, in reading order. A zoomed pane covers the
+ * whole canvas, so while one is zoomed it is the only pane anyone can see —
+ * anything that acts on "what is visible" must not reach the panes behind it.
+ */
+export function visibleTabIds(root: PaneNode, zoomedPaneId?: string | null): string[] {
+  const zoomed = zoomedPaneId ? findPane(root, zoomedPaneId) : undefined;
+  return (zoomed ? [zoomed] : panesInOrder(root))
+    .map((pane) => pane.activeTabId)
+    .filter((tabId): tabId is string => !!tabId);
+}
+
 /** Splits from the root down to a pane, with the branch each one descends. */
 export function splitPath(root: PaneNode, paneId: string): Array<{ split: SplitNode; branch: 0 | 1 }> {
   if (root.type === 'pane') return [];

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -50,6 +50,18 @@ Multi-execution mirrors keystrokes into several live terminals at once.
     This includes any session where a prompt is waiting for confirmation. The control stays
     visibly **Active** while mirroring is on.
 
+### Switching it off and on
+
+++ctrl+shift+m++ toggles mirroring without opening the control, so a mirrored command can be
+followed by a single-session one and back. Switching it on again restores the same
+selection, minus any session that has since closed.
+
+Pressed with nothing selected yet, it mirrors the sessions currently on screen — one per
+split. With fewer than two of those, it says so and leaves mirroring off.
+
+The chord is rebindable like every other, under **Terminal → Toggle multi-execution** in the
+[keyboard sheet](../reference/keyboard-shortcuts.md).
+
 ### Saved groups
 
 A selection of two or more sessions can be saved as a named **group** and re-activated in

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -56,6 +56,7 @@ resetting them.
 | Find in terminal | ++ctrl+shift+f++ |
 | Select all output | ++ctrl+shift+a++ |
 | Clear scrollback | ++ctrl+shift+k++ |
+| Toggle [multi-execution](../guide/commands.md#multi-execution) | ++ctrl+shift+m++ |
 | Increase / decrease font size | ++ctrl+shift+equal++, ++ctrl+shift+minus++ (also ++ctrl+equal++ / ++ctrl+minus++) |
 | Reset font size | ++ctrl+shift+0++, ++ctrl+0++ |
 

--- a/tests/unit/client/keymap.test.ts
+++ b/tests/unit/client/keymap.test.ts
@@ -117,6 +117,12 @@ describe('default bindings', () => {
     expect(commandsForChord('Ctrl+Shift+KeyW').map((command) => command.id)).toEqual(['tab.close']);
   });
 
+  it('binds multi-execution to a chord of its own', () => {
+    expect(commandsForChord('Mod+Shift+M').map((command) => command.id)).toEqual([
+      'terminal.multi-exec',
+    ]);
+  });
+
   it('gives every direction its own split, focus, and move-tab chord', () => {
     for (const direction of ['left', 'right', 'up', 'down'] as const) {
       expect(commandChords(keyCommand(`pane.split.${direction}`)!).length).toBeGreaterThan(0);
@@ -136,10 +142,10 @@ describe('default bindings', () => {
 });
 
 describe('user overrides', () => {
-  const overrides = { 'pane.zoom': ['Ctrl+Shift+KeyM'], 'pane.equalize': [] };
+  const overrides = { 'pane.zoom': ['Ctrl+Shift+KeyJ'], 'pane.equalize': [] };
 
   it('replaces the defaults of the rebound command only', () => {
-    expect(commandsForChord('Ctrl+Shift+KeyM', overrides).map((command) => command.id)).toEqual([
+    expect(commandsForChord('Ctrl+Shift+KeyJ', overrides).map((command) => command.id)).toEqual([
       'pane.zoom',
     ]);
     expect(commandsForChord('Mod+Shift+Z', overrides)).toEqual([]);

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -131,6 +131,19 @@ describe('multi-execution routing', () => {
     expect(useToastStore.getState().toast).toBeNull();
   });
 
+  it('leaves the panes hidden behind a zoomed one out of the shortcut', () => {
+    connectTab('edge-1');
+    useTabsStore.getState().split(useTabsStore.getState().activePaneId, 'right');
+    connectTab('edge-2');
+    // A zoomed pane covers the canvas, so the other session is off screen and
+    // must not receive a command typed into the one that is visible.
+    expect(useTabsStore.getState().toggleZoom()).toBe(true);
+
+    expect(toggleMultiExec()).toBe(true);
+    expect(useMultiExecStore.getState().selectedIds).toEqual([]);
+    expect(useToastStore.getState().toast).toMatchObject({ severity: 'info' });
+  });
+
   it('says why the shortcut did nothing when there is nothing to mirror', () => {
     connectTab('edge-1');
 

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toggleMultiExec } from '../../../client/src/session-actions.js';
 import {
   broadcastTerminalInput,
   useMultiExecStore,
 } from '../../../client/src/state/multi-exec.js';
+import { useTabsStore } from '../../../client/src/state/tabs.js';
+import { useToastStore } from '../../../client/src/state/toast.js';
 import {
   registerTerminal,
   type TerminalHandle,
@@ -28,8 +31,23 @@ function handle(sendInput: TerminalHandle['sendInput']): TerminalHandle {
 }
 
 beforeEach(() => {
-  useMultiExecStore.setState({ selectedIds: [], groups: [] });
+  useMultiExecStore.setState({ selectedIds: [], lastMirroredIds: [], groups: [] });
+  useTabsStore.setState({
+    tabs: [],
+    root: { id: 'pane-test', type: 'pane', activeTabId: null },
+    activePaneId: 'pane-test',
+    activeId: null,
+    zoomedPaneId: null,
+  });
+  useToastStore.setState({ toast: null });
 });
+
+/** A connected session in the focused pane. */
+function connectTab(title: string): string {
+  const id = useTabsStore.getState().open({ kind: 'local' }, title);
+  useTabsStore.getState().update(id, { status: 'connected' });
+  return id;
+}
 
 describe('multi-execution routing', () => {
   it('mirrors source input only to the other selected terminals', () => {
@@ -68,6 +86,59 @@ describe('multi-execution routing', () => {
     useMultiExecStore.getState().reconcile(['tab-a']);
     expect(useMultiExecStore.getState()).toMatchObject({
       selectedIds: ['tab-a'],
+    });
+  });
+
+  it('switches mirroring off and back on over the same terminals', () => {
+    const multiExec = () => useMultiExecStore.getState();
+    multiExec().setSelection(['tab-a', 'tab-b']);
+
+    expect(multiExec().toggleMirroring(['tab-a', 'tab-b'], [])).toBe(true);
+    expect(multiExec().selectedIds).toEqual([]);
+    expect(multiExec().toggleMirroring(['tab-a', 'tab-b'], [])).toBe(true);
+    expect(multiExec().selectedIds).toEqual(['tab-a', 'tab-b']);
+  });
+
+  it('resumes only the terminals still live, else the ones on screen', () => {
+    const multiExec = () => useMultiExecStore.getState();
+    multiExec().setSelection(['tab-a', 'tab-b']);
+    multiExec().toggleMirroring(['tab-a', 'tab-b'], []);
+
+    // "tab-b" went away while mirroring was off, leaving too little to resume.
+    multiExec().toggleMirroring(['tab-a', 'tab-c', 'tab-d'], ['tab-c', 'tab-d', 'tab-gone']);
+    expect(multiExec().selectedIds).toEqual(['tab-c', 'tab-d']);
+  });
+
+  it('declines to mirror when fewer than two terminals are available', () => {
+    const multiExec = () => useMultiExecStore.getState();
+    multiExec().setSelection(['tab-a', 'tab-b']);
+    multiExec().toggleMirroring(['tab-a', 'tab-b'], []);
+
+    expect(multiExec().toggleMirroring(['tab-a'], ['tab-a'])).toBe(false);
+    expect(multiExec().selectedIds).toEqual([]);
+  });
+
+  it('mirrors the sessions on screen the first time the shortcut is pressed', () => {
+    const first = connectTab('edge-1');
+    useTabsStore.getState().split(useTabsStore.getState().activePaneId, 'right');
+    const second = connectTab('edge-2');
+
+    expect(toggleMultiExec()).toBe(true);
+    expect(useMultiExecStore.getState().selectedIds).toEqual([first, second]);
+
+    expect(toggleMultiExec()).toBe(true);
+    expect(useMultiExecStore.getState().selectedIds).toEqual([]);
+    expect(useToastStore.getState().toast).toBeNull();
+  });
+
+  it('says why the shortcut did nothing when there is nothing to mirror', () => {
+    connectTab('edge-1');
+
+    expect(toggleMultiExec()).toBe(true);
+    expect(useMultiExecStore.getState().selectedIds).toEqual([]);
+    expect(useToastStore.getState().toast).toMatchObject({
+      severity: 'info',
+      message: expect.stringContaining('two sessions'),
     });
   });
 

--- a/tests/unit/client/workspace-layout.test.ts
+++ b/tests/unit/client/workspace-layout.test.ts
@@ -11,6 +11,7 @@ import {
   serializeWorkspace,
   updatePane,
   updateSplitRatio,
+  visibleTabIds,
   type PaneNode,
 } from '../../../client/src/state/workspace-layout.js';
 
@@ -74,6 +75,14 @@ describe('pane tree operations', () => {
       id: 'split-root',
       children: [{ id: 'pane-left' }, { id: 'pane-bottom' }],
     });
+  });
+
+  it('counts the tab of every pane on screen, and only the zoomed one', () => {
+    expect(visibleTabIds(root)).toEqual(['tab-a', 'tab-b']);
+    // A zoomed pane covers the canvas: the rest are behind it, not on screen.
+    expect(visibleTabIds(root, 'pane-bottom')).toEqual(['tab-b']);
+    // A pane the zoom outlived leaves the whole canvas visible again.
+    expect(visibleTabIds(root, 'pane-gone')).toEqual(['tab-a', 'tab-b']);
   });
 });
 


### PR DESCRIPTION
Closes #20.

Mirrored input could only be switched on and off through the top-bar control, so sending one command to every host and the next to a single host meant two trips through the popover. There was no toggle to bind — "active" is simply two or more selected tabs.

## What this adds

`Ctrl+Shift+M` (`Cmd+Shift+M` on macOS) toggles mirroring:

- **Off** keeps the selection aside, so the chord is a true toggle rather than a clear.
- **On** restores that selection, minus any session that closed meanwhile.
- **A first press, with nothing ever selected**, mirrors the sessions on screen — one per split.
- **Fewer than two candidates** leaves mirroring off and says why, instead of doing nothing silently.

The set is remembered from every path that reaches two terminals — the checklist, the **This split** / **Visible splits** / **All live** presets, a saved group, or the tab context menu — so the toggle resumes whatever was last mirroring. Loading a workspace forgets it, since those tab ids are gone.

It is an ordinary `KeyCommand`, so it appears in the keyboard sheet under **Terminal → Toggle multi-execution**, is rebindable and unbindable, and the top-bar control's tooltip advertises the current chord.

## Changes

- `client/src/state/multi-exec.ts` — `lastMirroredIds` plus `toggleMirroring(available, fallback)`.
- `client/src/session-actions.ts` — `toggleMultiExec()` supplies the connected tabs and the on-screen ones, and raises the toast when there is nothing to mirror.
- `client/src/keymap/commands.ts` — the `terminal.multi-exec` command and its default chord.
- `client/src/components/MultiExecControl.tsx` — tooltip reads "Mirroring input across 2 terminals · Ctrl+Shift+M toggles mirroring".
- Docs: a subsection in the multi-exec guide and a row in the shortcut reference.

One existing keymap test used `Ctrl+Shift+KeyM` as its arbitrary "unused chord" fixture for a rebind; it moves to `KeyJ`.

## Verification

- 596 unit tests pass, including new coverage for the toggle, the resume-and-fall-back rules, and the empty case; `pnpm typecheck` and `oxlint` are clean.
- Driven end to end against the `hack/demo-env.mjs` sandbox: with two split sessions the chord starts mirroring and `echo mirrored` lands in both terminals, a second press keeps the next keystrokes in the focused pane, a third resumes the same pair, and a single remaining session reports "Connect at least two sessions to mirror input."