### PR TITLE
Preserve SSH config symlinks on write

### DIFF
--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -92,6 +92,9 @@ When a host is saved:
 2. The file is written **atomically**, by writing and then renaming into place.
 3. The previous contents are kept next to it as `<file>.muxus.bak`.
 
+If a config file is a symbolic link, Muxus writes the link target atomically and
+leaves the symbolic link itself intact.
+
 Comments, blank lines, ordering, `Match` blocks and every other host are left as they were.
 Deleting a host removes only its block.
 

--- a/server/src/ssh/ssh-config-edit.ts
+++ b/server/src/ssh/ssh-config-edit.ts
@@ -249,18 +249,40 @@ function ensureIncluded(doc: ConfigDocument, targetFile: string): boolean {
   return true;
 }
 
+/** Follow the final path component so an atomic rename does not replace a symlink. */
+function resolveWriteTarget(filePath: string): string {
+  let target = path.resolve(filePath);
+  const seen = new Set<string>();
+
+  while (true) {
+    if (seen.has(target)) throw new Error(`symbolic link cycle while resolving ${filePath}`);
+    seen.add(target);
+
+    try {
+      const stat = fs.lstatSync(target);
+      if (!stat.isSymbolicLink()) return target;
+      const link = fs.readlinkSync(target);
+      target = path.resolve(path.dirname(target), link);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return target;
+      throw err;
+    }
+  }
+}
+
 function writeConfigFile(filePath: string, lines: string[]): void {
-  const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const writeTarget = resolveWriteTarget(filePath);
+  fs.mkdirSync(path.dirname(writeTarget), { recursive: true, mode: 0o700 });
   let mode = 0o600;
   try {
-    mode = fs.statSync(filePath).mode & 0o777;
-    fs.copyFileSync(filePath, `${filePath}.muxus.bak`);
+    mode = fs.statSync(writeTarget).mode & 0o777;
+    fs.copyFileSync(writeTarget, `${filePath}.muxus.bak`);
     fs.chmodSync(`${filePath}.muxus.bak`, 0o600);
   } catch {
     // New file — nothing to back up.
   }
-  const tmp = `${filePath}.muxus.tmp`;
+  const tmp = `${writeTarget}.muxus.tmp`;
   fs.writeFileSync(tmp, lines.length ? `${lines.join('\n')}\n` : '', { mode });
-  fs.renameSync(tmp, filePath);
+  fs.renameSync(tmp, writeTarget);
 }

--- a/tests/unit/server/ssh-config-edit.test.ts
+++ b/tests/unit/server/ssh-config-edit.test.ts
@@ -1,4 +1,14 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
@@ -153,6 +163,24 @@ describe('upsertHost', () => {
   it('keeps a .muxus.bak of the previous content', () => {
     const root = seed(['Host web', '  User old', ''].join('\n'));
     upsertHost(req({ previousAlias: 'web' }), root);
+    expect(readFileSync(`${root}.muxus.bak`, 'utf8')).toContain('User old');
+  });
+
+  it.skipIf(process.platform === 'win32')('preserves a config symlink and atomically replaces its target', () => {
+    const home = path.join(tmp, `home-${counter++}`);
+    const sshDir = path.join(home, '.ssh');
+    const targetDir = path.join(home, 'dotfiles');
+    const target = path.join(targetDir, 'ssh-config');
+    const root = path.join(sshDir, 'config');
+    mkdirSync(sshDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(target, ['Host web', '  User old', ''].join('\n'));
+    symlinkSync(path.relative(sshDir, target), root);
+
+    upsertHost(req({ previousAlias: 'web' }), root);
+
+    expect(lstatSync(root).isSymbolicLink()).toBe(true);
+    expect(readFileSync(target, 'utf8')).toContain('HostName web.example.com');
     expect(readFileSync(`${root}.muxus.bak`, 'utf8')).toContain('User old');
   });
 });


### PR DESCRIPTION
## Summary

- preserve SSH config symlinks when saving or deleting hosts
- atomically replace the resolved link target while retaining file permissions and the existing `.muxus.bak` behavior
- add regression coverage for relative symlinks and document the behavior

## Root cause

The atomic write path renamed the temporary file onto the configured path. When that path was a symbolic link, the rename replaced the link itself instead of updating its target.

## Impact

Users who manage `~/.ssh/config` through a dotfiles symlink can now edit hosts without losing that symlink.

## Validation

- full unit suite: 599 passed, 3 skipped
- server and test TypeScript checks
- lint and `git diff --check`

Closes #19