### PR TITLE
Fix SSH agent stalls for specific-key connections

### DIFF
--- a/client/src/components/host-editor/AuthSection.tsx
+++ b/client/src/components/host-editor/AuthSection.tsx
@@ -201,10 +201,10 @@ export function AuthSection({
               </IconButton>
             </Stack>
           </Stack>
-          <FormControlLabel
-            control={<Switch size="small" checked={draft.identitiesOnly} onChange={(e) => set({ identitiesOnly: e.target.checked })} />}
-            label={<Labeled title="IdentitiesOnly" sub="Never offer other agent keys — avoids 'too many authentication failures'" />}
-          />
+          <Typography variant="caption" color="text.secondary">
+            Only these key files are offered for login (IdentitiesOnly yes). The
+            agent can still be forwarded after connecting.
+          </Typography>
         </Stack>
       )}
 
@@ -214,7 +214,9 @@ export function AuthSection({
         <Box>
           <Typography variant="subtitle2">SSH agent</Typography>
           <Typography variant="caption" color="text.secondary">
-            Choose which local agent supplies keys for this host.
+            {draft.authMode === 'key'
+              ? 'Specific-key login does not use the agent. This source is still available for forwarding.'
+              : 'Choose which local agent supplies keys for this host.'}
           </Typography>
         </Box>
         <TextField

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -68,7 +68,9 @@ export function blankDraft(prefillTarget = ''): HostDraft {
     authMode: 'default',
     identityFiles: [],
     certificateFiles: [],
-    identitiesOnly: false,
+    // "Specific key file" is an exact-key mode. This stays dormant while the
+    // default auth mode is selected, then serializes as IdentitiesOnly yes.
+    identitiesOnly: true,
     identityAgentMode: 'default',
     identityAgent: '',
     forwardAgent: false,
@@ -191,7 +193,10 @@ export function draftToRequest(draft: HostDraft, previousAlias?: string): HostUp
         draft.authMode === 'key'
           ? draft.certificateFiles.map((f) => f.trim()).filter(Boolean)
           : undefined,
-      identitiesOnly: draft.authMode === 'key' && draft.identitiesOnly ? true : undefined,
+      // This editor mode promises that only the selected files are offered.
+      // OpenSSH still tries the agent first for IdentityFile alone, so the
+      // promise requires IdentitiesOnly yes.
+      identitiesOnly: draft.authMode === 'key' ? true : undefined,
       identityAgent:
         draft.identityAgentMode === 'environment'
           ? 'SSH_AUTH_SOCK'

--- a/docs/guide/adding-hosts.md
+++ b/docs/guide/adding-hosts.md
@@ -41,9 +41,10 @@ Three modes, matching OpenSSH behaviour:
 
 - **Agent & default keys** uses the OpenSSH order: agent first, then `~/.ssh/id_*`. Writes
   nothing, since this is the default.
-- **Specific key file** writes `IdentityFile`. The picker lists the keys found in `~/.ssh`
-  with their type and comment, badges the ones **loaded in the agent**, and marks the ones
-  that are **passphrase-protected**.
+- **Specific key file** writes `IdentityFile` and `IdentitiesOnly yes`, so login uses only
+  the selected files and never waits on the agent. The picker lists the keys found in
+  `~/.ssh` with their type and comment, badges the ones **loaded in the agent**, and marks
+  the ones that are **passphrase-protected**.
 - **Password / interactive** writes `PubkeyAuthentication no`, so public keys are skipped
   and a prompt is issued on connect.
 

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -53,6 +53,11 @@ succeeds:
 4. **Keyboard-interactive**: 2FA codes, challenge/response.
 5. **Password**, with retries.
 
+Agent approval time does not consume `ConnectTimeout`. If an agent accepts a request but
+never answers, Muxus shows what it is waiting for and moves to the next authentication
+method after a bounded wait. The host editor's **Specific key file** mode writes
+`IdentitiesOnly yes` and therefore skips the login agent entirely.
+
 <figure markdown="span">
   ![A keyboard-interactive prompt](../assets/screenshots/auth-prompt.png#only-light){ .shadow }
   ![A keyboard-interactive prompt](../assets/screenshots/auth-prompt-dark.png#only-dark){ .shadow }

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -3,10 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Duplex } from 'node:stream';
-import {
+import ssh2, {
   Client,
   type AnyAuthMethod,
   type AuthenticationType,
+  type BaseAgent,
   type ClientChannel,
   type ConnectConfig,
   type ParsedKey,
@@ -33,6 +34,11 @@ import {
 } from './certificates.js';
 import { KnownHostsStore, fingerprintSha256, hostKeyType } from './known-hosts.js';
 import { listAgentKeys, resolveAgentSocket } from './key-scan.js';
+import {
+  DEFAULT_AGENT_OPERATION_TIMEOUT_MS,
+  DEFAULT_AGENT_WAIT_STATUS_MS,
+  ResponsiveAgent,
+} from './responsive-agent.js';
 import {
   ConnectionLeaseRegistry,
   type ConnectionLeaseOwner,
@@ -237,6 +243,8 @@ export class SshConnectionManager {
   private readonly pendingDials = new Map<string, Promise<ManagedConnection>>();
   private readonly loadConfig: () => ConfigDocument;
   private readonly vault: PasswordVault | undefined;
+  private readonly agentOperationTimeoutMs: number;
+  private readonly agentWaitStatusMs: number;
   readonly knownHosts: KnownHostsStore;
 
   constructor(
@@ -245,11 +253,19 @@ export class SshConnectionManager {
       knownHosts?: KnownHostsStore;
       loadConfig?: () => ConfigDocument;
       vault?: PasswordVault;
+      /** Test seam; production uses the exported responsive-agent defaults. */
+      agentOperationTimeoutMs?: number;
+      /** Test seam; production uses the exported responsive-agent defaults. */
+      agentWaitStatusMs?: number;
     } = {},
   ) {
     this.knownHosts = options.knownHosts ?? new KnownHostsStore();
     this.loadConfig = options.loadConfig ?? (() => loadConfigDocument());
     this.vault = options.vault;
+    this.agentOperationTimeoutMs =
+      options.agentOperationTimeoutMs ?? DEFAULT_AGENT_OPERATION_TIMEOUT_MS;
+    this.agentWaitStatusMs =
+      options.agentWaitStatusMs ?? DEFAULT_AGENT_WAIT_STATUS_MS;
   }
 
   /** Acquire an independent consumer lease on an existing SSH transport. */
@@ -562,7 +578,7 @@ export class SshConnectionManager {
   }
 
   private dial(hop: ChainHop, sock: Duplex | undefined, io: ConnectIo): Promise<Client> {
-    const agent = resolveAgentSocket(hop.resolved.identityAgent);
+    const agentSocket = resolveAgentSocket(hop.resolved.identityAgent);
     let readyDeadline: PausableDeadline | undefined;
     const runInteraction: InteractionRunner = async (interaction) => {
       readyDeadline?.pause();
@@ -572,7 +588,29 @@ export class SshConnectionManager {
         readyDeadline?.resume();
       }
     };
-    const auth = new AuthLadder(hop, io, this.vault, runInteraction);
+    const authAgent =
+      agentSocket && !hop.resolved.identitiesOnly
+        ? new ResponsiveAgent(ssh2.createAgent(agentSocket) as BaseAgent<ParsedKey>, {
+            pauseDeadline: () => readyDeadline?.pause(),
+            resumeDeadline: () => readyDeadline?.resume(),
+            onWaiting: (operation) =>
+              io.status(
+                operation === 'sign'
+                  ? 'Waiting for the SSH agent to approve signing…'
+                  : 'Waiting for the SSH agent to list identities…',
+                { transient: true },
+              ),
+            waitStatusMs: this.agentWaitStatusMs,
+            operationTimeoutMs: this.agentOperationTimeoutMs,
+          })
+        : undefined;
+    const auth = new AuthLadder(
+      hop,
+      io,
+      this.vault,
+      runInteraction,
+      authAgent,
+    );
     const { algorithms, notes } = connectionAlgorithms(hop.resolved);
     for (const note of notes) io.status(note);
     const proxySocket =
@@ -588,7 +626,13 @@ export class SshConnectionManager {
       keepaliveCountMax: hop.resolved.serverAliveCountMax ?? 3,
       ...(algorithms ? { algorithms } : {}),
       hostVerifier: (key: Buffer, verify: (valid: boolean) => void) => {
-        void this.verifyHostKey(hop, key, io, runInteraction).then(verify);
+        void this.verifyHostKey(hop, key, io, runInteraction).then(verify, (err) => {
+          this.log.warn(
+            { err, host: hop.resolved.hostname },
+            'host key verification failed',
+          );
+          verify(false);
+        });
       },
       authHandler: (authsLeft, partialSuccess, next) => {
         auth.next(
@@ -598,7 +642,9 @@ export class SshConnectionManager {
         );
       },
       ...(transport ? { sock: transport } : { host: hop.resolved.hostname, port: hop.port }),
-      ...(agent ? { agent, agentForward: hop.resolved.forwardAgent } : {}),
+      ...(agentSocket
+        ? { agent: agentSocket, agentForward: hop.resolved.forwardAgent }
+        : {}),
     };
 
     return new Promise((resolve, reject) => {
@@ -1015,6 +1061,7 @@ class AuthLadder {
     private readonly vault?: PasswordVault,
     private readonly runInteraction: InteractionRunner = (interaction) =>
       interaction(),
+    private readonly agent?: BaseAgent<ParsedKey>,
   ) {
     this.attempts = this.build();
   }
@@ -1110,11 +1157,19 @@ class AuthLadder {
     const { resolved, user, hopLabel } = this.hop;
     const label = hopLabel ?? this.hop.spec.host;
     const attempts: AuthAttempt[] = [{ type: 'none', get: () => Promise.resolve({ type: 'none', username: user }) }];
-    const agent = resolveAgentSocket(resolved.identityAgent);
+    const agentSocket = resolveAgentSocket(resolved.identityAgent);
 
     if (!resolved.passwordOnly) {
-      if (agent && !resolved.identitiesOnly) {
-        attempts.push({ type: 'agent', get: () => Promise.resolve({ type: 'agent', username: user, agent }) });
+      if (agentSocket && this.agent && !resolved.identitiesOnly) {
+        attempts.push({
+          type: 'agent',
+          get: () =>
+            Promise.resolve({
+              type: 'agent',
+              username: user,
+              agent: this.agent!,
+            }),
+        });
       }
       const explicit = resolved.identityFiles.length > 0;
       const files = explicit ? resolved.identityFiles : defaultIdentityFiles();
@@ -1131,7 +1186,7 @@ class AuthLadder {
                 certificate,
                 files,
                 explicit || resolved.certificateFiles.length > 0,
-                agent,
+                agentSocket,
                 label,
               );
               if (!privateKey) return undefined;
@@ -1149,7 +1204,12 @@ class AuthLadder {
         attempts.push({
           type: 'publickey',
           get: async () => {
-            const key = await this.loadPrivateKey(file, explicit, agent, label);
+            const key = await this.loadPrivateKey(
+              file,
+              explicit,
+              agentSocket,
+              label,
+            );
             return key ? { type: 'publickey', username: user, key } : undefined;
           },
         });
@@ -1450,7 +1510,14 @@ class AuthLadder {
       // Encrypted. A default (unconfigured) key the agent already holds was
       // covered by the agent attempt — skip it silently. Anything else
       // prompts for its passphrase, like ssh(1).
-      if (!explicit && agent && (await this.agentHoldsKey(file, agent))) return undefined;
+      if (
+        !explicit &&
+        agent &&
+        this.agent &&
+        (await this.agentHoldsKey(file, agent, this.agent))
+      ) {
+        return undefined;
+      }
       for (let i = 0; i < MAX_PASSPHRASE_ATTEMPTS && parsed instanceof Error; i++) {
         const response = await this.runInteraction(() =>
           this.io.prompt({
@@ -1472,7 +1539,11 @@ class AuthLadder {
   }
 
   /** True when the key's .pub sibling names an identity the agent holds. */
-  private async agentHoldsKey(file: string, agent: string): Promise<boolean> {
+  private async agentHoldsKey(
+    file: string,
+    agentSocket: string,
+    agent: BaseAgent<ParsedKey>,
+  ): Promise<boolean> {
     let fingerprint: string;
     try {
       const blob = fs.readFileSync(`${file}.pub`, 'utf8').trim().split(/\s+/)[1];
@@ -1481,7 +1552,7 @@ class AuthLadder {
     } catch {
       return false; // no readable .pub — prompt rather than guess
     }
-    this.agentIdentityPrints ??= listAgentKeys(agent).then(
+    this.agentIdentityPrints ??= listAgentKeys(agentSocket, agent).then(
       (keys) => new Set(keys.map((k) => k.fingerprint)),
     );
     return (await this.agentIdentityPrints).has(fingerprint);

--- a/server/src/ssh/key-scan.ts
+++ b/server/src/ssh/key-scan.ts
@@ -8,6 +8,7 @@ import ssh2, { type BaseAgent, type ParsedKey } from 'ssh2';
 const { createAgent, utils } = ssh2;
 import type { SshAgentKey, SshKeyInfo, SshKeysResponse } from '@muxus/shared';
 import { fingerprintSha256 } from './known-hosts.js';
+import { ResponsiveAgent } from './responsive-agent.js';
 
 /**
  * Discover the user's SSH identities for the host editor's key picker: the
@@ -58,11 +59,22 @@ interface AgentKeyProbe {
   keys: SshAgentKey[];
 }
 
-async function probeAgentKeys(sock: string | undefined): Promise<AgentKeyProbe> {
+async function probeAgentKeys(
+  sock: string | undefined,
+  agent?: BaseAgent<ParsedKey>,
+): Promise<AgentKeyProbe> {
   if (!sock) return { available: false, keys: [] };
   return new Promise((resolve) => {
     try {
-      (createAgent(sock) as BaseAgent<ParsedKey>).getIdentities((err, keys) => {
+      const client =
+        agent ??
+        new ResponsiveAgent(createAgent(sock) as BaseAgent<ParsedKey>, {
+          // Discovery only supplies editor badges; it must never hold the form
+          // open waiting for an approval that may not be visible.
+          operationTimeoutMs: 2_000,
+          waitStatusMs: -1,
+        });
+      client.getIdentities((err, keys) => {
         if (err || !keys) {
           resolve({ available: false, keys: [] });
           return;
@@ -84,8 +96,11 @@ async function probeAgentKeys(sock: string | undefined): Promise<AgentKeyProbe> 
   });
 }
 
-export async function listAgentKeys(sock = agentSocket()): Promise<SshAgentKey[]> {
-  return (await probeAgentKeys(sock)).keys;
+export async function listAgentKeys(
+  sock = agentSocket(),
+  agent?: BaseAgent<ParsedKey>,
+): Promise<SshAgentKey[]> {
+  return (await probeAgentKeys(sock, agent)).keys;
 }
 
 export async function listSshKeys(

--- a/server/src/ssh/known-hosts.ts
+++ b/server/src/ssh/known-hosts.ts
@@ -88,6 +88,10 @@ export class KnownHostsStore {
   record(host: string, port: number, key: Buffer): void {
     const target = this.userFiles[0];
     if (!target) return; // UserKnownHostsFile none — nowhere to remember it
+    // OpenSSH users commonly select the null device to accept host keys
+    // without persisting them. Our atomic sibling-file rewrite cannot apply
+    // there, and the device already provides the intended discard semantics.
+    if (target === os.devNull) return;
     const names = hostNames(host, port);
     const keyType = hostKeyType(key);
     fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });

--- a/server/src/ssh/responsive-agent.ts
+++ b/server/src/ssh/responsive-agent.ts
@@ -1,0 +1,191 @@
+import { AgentProtocol, BaseAgent, type ParsedKey, type SigningRequestOptions } from 'ssh2';
+
+export const DEFAULT_AGENT_WAIT_STATUS_MS = 2_000;
+export const DEFAULT_AGENT_OPERATION_TIMEOUT_MS = 30_000;
+
+export interface ResponsiveAgentOptions {
+  /** Agent interaction is user time (approval/touch), not network dial time. */
+  pauseDeadline?: () => void;
+  resumeDeadline?: () => void;
+  /** Called once when an operation takes long enough to need user action. */
+  onWaiting?: (operation: 'identities' | 'sign') => void;
+  waitStatusMs?: number;
+  operationTimeoutMs?: number;
+}
+
+/**
+ * Runs ssh-agent requests over streams we own, so an agent that accepts a
+ * connection but never replies cannot trap ssh2's authentication state
+ * machine forever. The wrapped agent still supplies the platform-specific
+ * stream (OpenSSH socket, Cygwin or Pageant).
+ */
+export class ResponsiveAgent extends BaseAgent<ParsedKey> {
+  private unavailableError: Error | undefined;
+
+  constructor(
+    private readonly agent: BaseAgent<ParsedKey>,
+    private readonly options: ResponsiveAgentOptions = {},
+  ) {
+    super();
+  }
+
+  getIdentities(cb: (err: Error | undefined, keys?: ParsedKey[]) => void): void {
+    this.request(
+      'identities',
+      (protocol, done) => protocol.getIdentities(done),
+      cb,
+    );
+  }
+
+  sign(
+    pubKey: ParsedKey,
+    data: Buffer,
+    options: SigningRequestOptions,
+    cb?: (err?: Error | null, signature?: Buffer) => void,
+  ): void;
+  sign(
+    pubKey: ParsedKey,
+    data: Buffer,
+    cb: (err?: Error | null, signature?: Buffer) => void,
+  ): void;
+  sign(
+    pubKey: ParsedKey,
+    data: Buffer,
+    optionsOrCb:
+      | SigningRequestOptions
+      | ((err?: Error | null, signature?: Buffer) => void),
+    maybeCb?: (err?: Error | null, signature?: Buffer) => void,
+  ): void {
+    const options =
+      typeof optionsOrCb === 'function' ? undefined : optionsOrCb;
+    const cb = typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb;
+    if (!cb) return;
+    this.request(
+      'sign',
+      (protocol, done) => {
+        protocol.sign(pubKey, data, options, done);
+      },
+      cb,
+    );
+  }
+
+  /** Agent forwarding remains a transparent stream, independent of login auth. */
+  override getStream(cb: Parameters<NonNullable<BaseAgent['getStream']>>[0]): void {
+    if (!this.agent.getStream) {
+      cb(new Error('SSH agent does not support stream access'));
+      return;
+    }
+    this.agent.getStream(cb);
+  }
+
+  private request<T>(
+    operation: 'identities' | 'sign',
+    send: (
+      protocol: AgentProtocol,
+      done: (err?: Error | null, value?: T) => void,
+    ) => void,
+    cb: (err: Error | undefined, value?: T) => void,
+  ): void {
+    if (this.unavailableError) {
+      queueMicrotask(() => cb(this.unavailableError));
+      return;
+    }
+    if (!this.agent.getStream) {
+      queueMicrotask(() =>
+        cb(new Error('SSH agent does not support stream access')),
+      );
+      return;
+    }
+
+    const waitStatusMs =
+      this.options.waitStatusMs ?? DEFAULT_AGENT_WAIT_STATUS_MS;
+    const operationTimeoutMs =
+      this.options.operationTimeoutMs ?? DEFAULT_AGENT_OPERATION_TIMEOUT_MS;
+    let settled = false;
+    let stream: Awaited<Parameters<Parameters<NonNullable<BaseAgent['getStream']>>[0]>[1]>;
+    let protocol: AgentProtocol | undefined;
+
+    const waitTimer =
+      waitStatusMs >= 0
+        ? setTimeout(() => this.options.onWaiting?.(operation), waitStatusMs)
+        : undefined;
+    waitTimer?.unref?.();
+
+    const finish = (
+      err?: Error | null,
+      value?: T,
+      agentUnavailable = false,
+    ) => {
+      if (settled) return;
+      settled = true;
+      if (waitTimer) clearTimeout(waitTimer);
+      clearTimeout(timeoutTimer);
+      if (agentUnavailable && err) this.unavailableError = err;
+
+      try {
+        protocol?.unpipe(stream);
+        stream?.unpipe(protocol);
+        protocol?.destroy();
+        stream?.destroy();
+      } catch {
+        // The operation result is already known; cleanup is best-effort.
+      }
+      this.options.resumeDeadline?.();
+      cb(err ?? undefined, value);
+    };
+
+    const timeoutTimer = setTimeout(() => {
+      finish(
+        new Error(
+          `SSH agent did not respond while ${
+            operation === 'identities' ? 'listing identities' : 'signing'
+          }`,
+        ),
+        undefined,
+        true,
+      );
+    }, operationTimeoutMs);
+    timeoutTimer.unref?.();
+
+    this.options.pauseDeadline?.();
+    try {
+      this.agent.getStream((err, connectedStream) => {
+        if (settled) {
+          connectedStream?.destroy();
+          return;
+        }
+        if (err || !connectedStream) {
+          finish(err ?? new Error('Failed to connect to SSH agent'), undefined, true);
+          return;
+        }
+        stream = connectedStream;
+        protocol = new AgentProtocol(true);
+        const onTransportFailure = (failure?: Error) => {
+          finish(
+            failure ?? new Error('SSH agent connection closed before replying'),
+            undefined,
+            true,
+          );
+        };
+        protocol.once('error', onTransportFailure);
+        stream.once('close', onTransportFailure);
+        stream.once('end', onTransportFailure);
+        stream.once('error', onTransportFailure);
+        protocol.pipe(stream).pipe(protocol);
+        try {
+          send(protocol, (requestError, value) =>
+            finish(requestError, value, operation === 'identities' && !!requestError),
+          );
+        } catch (requestError) {
+          finish(
+            requestError instanceof Error
+              ? requestError
+              : new Error(String(requestError)),
+          );
+        }
+      });
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)), undefined, true);
+    }
+  }
+}

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -53,6 +53,7 @@ describe('SSH host editor draft', () => {
     expect(draftToRequest(draft, 'cloud').options).toMatchObject({
       identityFiles: ['~/.ssh/cloud'],
       certificateFiles: ['~/.ssh/cloud-cert.pub'],
+      identitiesOnly: true,
       identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
       proxyCommand: 'cloudflared access ssh --hostname %h',
       remoteCommand: 'tmux new -A -s main',
@@ -69,7 +70,22 @@ describe('SSH host editor draft', () => {
     expect(draft.remoteCommandMode).toBe('inherit');
     expect(draft.requestTty).toBe('inherit');
     expect(draft.strictHostKeyChecking).toBe('inherit');
+    expect(draft.identitiesOnly).toBe(true);
     expect(draftToRequest(draft).options.proxyCommand).toBeUndefined();
+  });
+
+  it('makes the specific-key promise independent of the SSH agent', () => {
+    const draft = blankDraft();
+    draft.authMode = 'key';
+    draft.identityFiles = ['~/.ssh/id_ed25519'];
+    // Old v0.3.0 drafts could carry false here. Saving the explicit editor
+    // mode must repair them instead of writing IdentityFile alone.
+    draft.identitiesOnly = false;
+
+    expect(draftToRequest(draft).options).toMatchObject({
+      identityFiles: ['~/.ssh/id_ed25519'],
+      identitiesOnly: true,
+    });
   });
 
   it('round-trips explicit agent and login-shell choices', () => {

--- a/tests/unit/server/agent-auth.test.ts
+++ b/tests/unit/server/agent-auth.test.ts
@@ -1,10 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, copyFileSync } from 'node:fs';
-import type net from 'node:net';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { generateKeyPairSync } from 'node:crypto';
-import ssh2, { Server } from 'ssh2';
+import ssh2, { AgentProtocol, Server } from 'ssh2';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { SshProfile } from '@muxus/shared/ws-protocol';
 import { SshConnectionManager, type ConnectIo } from '../../../server/src/ssh/connection-manager.js';
@@ -79,11 +79,30 @@ function startServer(
 }
 
 let counter = 0;
-function makeManager(port: number): SshConnectionManager {
+function makeManager(
+  port: number,
+  {
+    configLines = [],
+    agentOperationTimeoutMs,
+    agentWaitStatusMs,
+  }: {
+    configLines?: string[];
+    agentOperationTimeoutMs?: number;
+    agentWaitStatusMs?: number;
+  } = {},
+): SshConnectionManager {
   const configFile = path.join(tmp, `ssh_config-${counter++}`);
   writeFileSync(
     configFile,
-    ['Host lab', '  HostName 127.0.0.1', '  User tester', `  Port ${port}`, '  StrictHostKeyChecking no', ''].join('\n'),
+    [
+      'Host lab',
+      '  HostName 127.0.0.1',
+      '  User tester',
+      `  Port ${port}`,
+      '  StrictHostKeyChecking no',
+      ...configLines.map((line) => `  ${line}`),
+      '',
+    ].join('\n'),
   );
   const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
   return new SshConnectionManager(log as never, {
@@ -92,6 +111,8 @@ function makeManager(port: number): SshConnectionManager {
       path.join(tmp, 'no-global-known-hosts'),
     ),
     loadConfig: () => loadConfigDocument(configFile),
+    agentOperationTimeoutMs,
+    agentWaitStatusMs,
   });
 }
 
@@ -129,11 +150,73 @@ function makeIo(): ConnectIo & {
 
 const profile: SshProfile = { kind: 'ssh', target: 'lab' };
 
-async function connectOnce(port: number, io: ConnectIo): Promise<void> {
-  const manager = makeManager(port);
+async function connectOnce(
+  port: number,
+  io: ConnectIo,
+  options?: Parameters<typeof makeManager>[1],
+): Promise<void> {
+  const manager = makeManager(port, options);
   const lease = await manager.connect(profile, io);
   lease.release();
   manager.closeAll();
+}
+
+async function startTestAgent({
+  name,
+  identity,
+  hangIdentities = false,
+  hangSign = false,
+}: {
+  name: string;
+  identity?: ssh2.ParsedKey;
+  hangIdentities?: boolean;
+  hangSign?: boolean;
+}): Promise<{
+  socketPath: string;
+  identityRequests: () => number;
+  signRequests: () => number;
+  close: () => Promise<void>;
+}> {
+  const socketPath = path.join(tmp, `${name}-${counter++}.sock`);
+  const sockets = new Set<net.Socket>();
+  let identities = 0;
+  let signs = 0;
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    const protocol = new AgentProtocol(false);
+    protocol.on('identities', (request) => {
+      identities += 1;
+      if (!hangIdentities) {
+        protocol.getIdentitiesReply(request, identity ? [identity] : []);
+      }
+    });
+    protocol.on('sign', (request, key, data, options) => {
+      signs += 1;
+      if (hangSign || !identity) return;
+      const signature = identity.sign(data, options.hash);
+      if (signature instanceof Error) protocol.failureReply(request);
+      else protocol.signReply(request, signature);
+    });
+    protocol.pipe(socket).pipe(protocol);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  return {
+    socketPath,
+    identityRequests: () => identities,
+    signRequests: () => signs,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const socket of sockets) socket.destroy();
+        server.close(() => resolve());
+      }),
+  };
 }
 
 // Drives a real ssh-agent; the Windows agent is a service and cannot be
@@ -199,6 +282,100 @@ describe.skipIf(process.platform === 'win32')('ssh-agent authentication', () => 
       expect(io.passwordPrompts).toBe(1);
     } finally {
       process.env.SSH_AUTH_SOCK = agentSock;
+    }
+  }, 15_000);
+
+  it('does not contact the agent for an editor-style specific key', async () => {
+    const testAgent = await startTestAgent({
+      name: 'must-not-be-used',
+      hangIdentities: true,
+    });
+    process.env.SSH_AUTH_SOCK = testAgent.socketPath;
+    try {
+      const { server, port, events } = await startServer(agentPub);
+      const io = makeIo();
+
+      await connectOnce(port, io, {
+        configLines: [
+          `IdentityFile ${path.join(tmp, 'agent-key')}`,
+          'IdentitiesOnly yes',
+        ],
+        agentOperationTimeoutMs: 50,
+        agentWaitStatusMs: 5,
+      });
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+
+      expect(testAgent.identityRequests()).toBe(0);
+      expect(testAgent.signRequests()).toBe(0);
+      expect(events.some((e) => e.method === 'publickey' && e.accepted)).toBe(true);
+    } finally {
+      process.env.SSH_AUTH_SOCK = agentSock;
+      await testAgent.close();
+    }
+  }, 15_000);
+
+  it('times out a silent identity listing and falls through to the key file', async () => {
+    const testAgent = await startTestAgent({
+      name: 'silent-identities',
+      hangIdentities: true,
+    });
+    process.env.SSH_AUTH_SOCK = testAgent.socketPath;
+    try {
+      const { server, port, events } = await startServer(agentPub);
+      const io = makeIo();
+      const startedAt = Date.now();
+
+      await connectOnce(port, io, {
+        configLines: [
+          `IdentityFile ${path.join(tmp, 'agent-key')}`,
+          'ConnectTimeout 1',
+        ],
+        // Deliberately longer than ConnectTimeout: agent approval time must
+        // pause the network deadline, then fall through cleanly.
+        agentOperationTimeoutMs: 1_200,
+        agentWaitStatusMs: 20,
+      });
+      const elapsedMs = Date.now() - startedAt;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+
+      expect(elapsedMs).toBeGreaterThanOrEqual(1_100);
+      expect(elapsedMs).toBeLessThan(5_000);
+      expect(testAgent.identityRequests()).toBe(1);
+      expect(io.statuses.some((s) => s.includes('Waiting for the SSH agent'))).toBe(true);
+      expect(io.statuses.some((s) => s.includes('did not respond'))).toBe(true);
+      expect(events.some((e) => e.method === 'publickey' && e.accepted)).toBe(true);
+    } finally {
+      process.env.SSH_AUTH_SOCK = agentSock;
+      await testAgent.close();
+    }
+  }, 15_000);
+
+  it('times out a silent agent signature and falls through to the key file', async () => {
+    const testAgent = await startTestAgent({
+      name: 'silent-signature',
+      identity: agentPub,
+      hangSign: true,
+    });
+    process.env.SSH_AUTH_SOCK = testAgent.socketPath;
+    try {
+      const { server, port, events } = await startServer(agentPub);
+      const io = makeIo();
+
+      await connectOnce(port, io, {
+        configLines: [`IdentityFile ${path.join(tmp, 'agent-key')}`],
+        agentOperationTimeoutMs: 100,
+        agentWaitStatusMs: 10,
+      });
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+
+      expect(testAgent.identityRequests()).toBe(1);
+      expect(testAgent.signRequests()).toBe(1);
+      expect(io.statuses.some((s) => s.includes('approve signing'))).toBe(true);
+      expect(io.statuses.some((s) => s.includes('did not respond'))).toBe(true);
+      expect(events.some((e) => e.method === 'publickey' && e.accepted)).toBe(true);
+    } finally {
+      process.env.SSH_AUTH_SOCK = agentSock;
+      await testAgent.close();
     }
   }, 15_000);
 

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -191,6 +191,25 @@ describe('session settings from ssh config', () => {
     shell.lease.release();
   }, 15_000);
 
+  it('connects without persisting when UserKnownHostsFile is the null device', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    manager = makeManager(
+      writeConfig(started.port, [
+        '  StrictHostKeyChecking no',
+        `  UserKnownHostsFile ${os.devNull}`,
+      ]),
+    );
+
+    const io = makeIo({
+      hostKey: () => Promise.reject(new Error('must not prompt')),
+    });
+    const shell = await manager.connectShell(profile, io, 80, 24, 'xterm-256color');
+    expect(await firstData(shell.stream)).toContain('shell ok');
+    shell.stream.close();
+    shell.lease.release();
+  }, 15_000);
+
   it('fails promptly when the host-key interaction rejects', async () => {
     const started = await startCapturingServer();
     server = started.server;

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -191,6 +191,17 @@ describe('session settings from ssh config', () => {
     shell.lease.release();
   }, 15_000);
 
+  it('fails promptly when the host-key interaction rejects', async () => {
+    const started = await startCapturingServer();
+    server = started.server;
+    manager = makeManager(writeConfig(started.port, ['  ConnectTimeout 5']));
+    const io = makeIo({
+      hostKey: () => Promise.reject(new Error('host-key dialog closed')),
+    });
+
+    await expect(manager.connect(profile, io)).rejects.toThrow(/host/i);
+  }, 2_000);
+
   it('PasswordAuthentication no never prompts for or offers a password', async () => {
     const started = await startCapturingServer();
     server = started.server;

--- a/tests/unit/server/known-hosts.test.ts
+++ b/tests/unit/server/known-hosts.test.ts
@@ -58,6 +58,13 @@ describe('KnownHostsStore', () => {
     expect(store.verify('example.com', 22, key)).toEqual({ state: 'unknown' });
   });
 
+  it('UserKnownHostsFile set to the null device discards accepted keys', () => {
+    const store = new KnownHostsStore(os.devNull, missing);
+    const key = makeKey();
+    expect(() => store.record('example.com', 22, key)).not.toThrow();
+    expect(store.verify('example.com', 22, key)).toEqual({ state: 'unknown' });
+  });
+
   it('stores non-22 ports in [host]:port notation', () => {
     const file = freshFile();
     const store = new KnownHostsStore(file, missing);

--- a/tests/unit/server/ssh-config-edit.test.ts
+++ b/tests/unit/server/ssh-config-edit.test.ts
@@ -212,6 +212,7 @@ describe('previewHost', () => {
       req({
         options: {
           identityFiles: ['~/.ssh/app'],
+          identitiesOnly: true,
           certificateFiles: ['~/.ssh/app-cert.pub'],
           identityAgent: '${ONEPASSWORD_SSH_AUTH_SOCK}',
           proxyCommand: 'cloudflared access ssh --hostname %h',
@@ -223,6 +224,7 @@ describe('previewHost', () => {
       root,
     );
     expect(text).toContain('  IdentityFile ~/.ssh/app');
+    expect(text).toContain('  IdentitiesOnly yes');
     expect(text).toContain('  CertificateFile ~/.ssh/app-cert.pub');
     expect(text).toContain('  IdentityAgent ${ONEPASSWORD_SSH_AUTH_SOCK}');
     expect(text).toContain('  ProxyCommand cloudflared access ssh --hostname %h');


### PR DESCRIPTION
## What changed

- Make the host editor's **Specific key file** mode write `IdentitiesOnly yes`, matching its promise that only selected files are used for login.
- Add bounded SSH-agent identity and signing operations with visible wait status, deadline pausing, stream cleanup, and authentication fallback.
- Bound agent probing in the key picker so an unresponsive socket cannot hold the editor request open indefinitely.
- Handle rejected host-key verification promises cleanly.
- Update the authentication documentation.

## Root cause

Version 0.3.0 activated the agent authentication rung while the specific-key editor mode still wrote only `IdentityFile`. Under OpenSSH semantics, `IdentityFile` alone does not exclude the agent. If the selected agent accepted its socket connection but never replied to an identity or signing request, `ssh2` waited indefinitely and never reached the configured key file. Muxus's readiness deadline then surfaced the stall as a misleading host connection timeout.

## Impact

Specific-key profiles now skip the login agent and use their configured key files directly. Profiles that intentionally use an agent show a waiting status; agent interaction time no longer consumes `ConnectTimeout`, and a genuinely unresponsive agent falls through to the next authentication method after a bounded wait. Agent forwarding remains available.

## Validation

- Full production build
- Workspace TypeScript checks
- Lint and diff whitespace checks
- Full test suite: 604 passed, 3 platform-specific tests skipped
- Integration coverage for:
  - a real `ssh-agent`
  - an agent that hangs while listing identities
  - an agent that lists a key but hangs while signing
  - agent interaction lasting longer than `ConnectTimeout`
  - specific-key authentication making zero agent requests
  - rejected host-key interaction promises