### PR TITLE
Add debug mode with in-app log viewer and export

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AppWindowLaunch } from '@muxus/shared';
+import { setDebugLogging } from './api/logs.js';
 import { applyInterfaceZoom } from './interface-zoom.js';
 import { buildTheme } from './theme.js';
 import { setTitleBarMode } from './titlebar-overlay.js';
@@ -29,6 +30,7 @@ import {
   loadSettingsDialog,
   loadShortcutsDialog,
   loadSessionHistoryDialog,
+  loadLogViewerDialog,
   loadQuickLauncherDialog,
   loadWorkspaceDialog,
 } from './lazy-features.js';
@@ -69,6 +71,9 @@ const ShortcutsDialog = lazy(() =>
 const SessionHistoryDialog = lazy(() =>
   loadSessionHistoryDialog().then((module) => ({ default: module.SessionHistoryDialog })),
 );
+const LogViewerDialog = lazy(() =>
+  loadLogViewerDialog().then((module) => ({ default: module.LogViewerDialog })),
+);
 const QuickLauncherDialog = lazy(() =>
   loadQuickLauncherDialog().then((module) => ({ default: module.QuickLauncherDialog })),
 );
@@ -82,6 +87,7 @@ const SftpWindow = lazy(() =>
 export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const themeMode = usePrefsStore((s) => s.themeMode);
   const interfaceZoom = usePrefsStore((s) => s.interfaceZoom);
+  const debugMode = usePrefsStore((s) => s.debugMode);
   const hostEditorOpen = useUiStore((s) => !!s.hostEditor);
   const hostOrganizerOpen = useUiStore((s) => !!s.hostOrganizer);
   const folderDialogOpen = useUiStore((s) => !!s.folderDialog);
@@ -89,6 +95,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const commandButtonsOpen = useUiStore((s) => s.commandButtonsOpen);
   const shortcutsOpen = useUiStore((s) => s.shortcutsOpen);
   const historyOpen = useUiStore((s) => s.historyOpen);
+  const logViewerOpen = useUiStore((s) => s.logViewerOpen);
   const quickLauncherOpen = useUiStore((s) => s.quickLauncherOpen);
   const workspacesOpen = useUiStore((s) => s.workspacesOpen);
   const dialogOpen = useDialogStore((s) => s.queue.length > 0);
@@ -107,6 +114,11 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   useLayoutEffect(() => {
     applyInterfaceZoom(interfaceZoom);
   }, [interfaceZoom]);
+  useEffect(() => {
+    // The debug pref lives client-side; tell the server its log level on boot
+    // and on every toggle. Failures are ignored — the pref re-syncs next time.
+    void setDebugLogging(debugMode).catch(() => undefined);
+  }, [debugMode]);
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = (e: MediaQueryListEvent) => setOsTheme(e.matches ? 'dark' : 'light');
@@ -133,6 +145,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
         {commandButtonsOpen ? <CommandButtonsDialog /> : null}
         {shortcutsOpen ? <ShortcutsDialog /> : null}
         {historyOpen ? <SessionHistoryDialog /> : null}
+        {logViewerOpen ? <LogViewerDialog /> : null}
         {quickLauncherOpen ? <QuickLauncherDialog /> : null}
         {workspacesOpen ? <WorkspaceDialog /> : null}
         {!launch ? <PasswordVaultStartupUnlock onReady={finishStartup} /> : null}

--- a/client/src/api/logs.ts
+++ b/client/src/api/logs.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import type { AppLogEntry, AppLogsResponse } from '@muxus/shared';
+import { apiFetch } from './http.js';
+
+export function fetchAppLogs(): Promise<AppLogsResponse> {
+  return apiFetch<AppLogsResponse>('/api/logs');
+}
+
+/** Diagnostic log buffer, polled while the viewer is open. */
+export function useAppLogs(enabled: boolean) {
+  return useQuery({
+    queryKey: ['app-logs'],
+    queryFn: fetchAppLogs,
+    enabled,
+    refetchInterval: 2_000,
+  });
+}
+
+/** Raise (or restore) the server's log level; idempotent per window. */
+export function setDebugLogging(debugEnabled: boolean): Promise<{ debugEnabled: boolean }> {
+  return apiFetch<{ debugEnabled: boolean }>('/api/logs/settings', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ debugEnabled }),
+  });
+}
+
+export function clearAppLogs(): Promise<{ cleared: boolean }> {
+  return apiFetch<{ cleared: boolean }>('/api/logs', { method: 'DELETE' });
+}
+
+/** One text line per entry, shared by the viewer, copy, and export. */
+export function formatLogEntry(entry: AppLogEntry): string {
+  const context = entry.context ? ` ${JSON.stringify(entry.context)}` : '';
+  return `${new Date(entry.ts).toISOString()} ${entry.level.toUpperCase().padEnd(5)} ${entry.source.padEnd(6)} ${entry.msg}${context}`;
+}

--- a/client/src/components/LogViewerDialog.tsx
+++ b/client/src/components/LogViewerDialog.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import type { AppLogEntry, AppLogLevel } from '@muxus/shared';
+import { clearAppLogs, formatLogEntry, useAppLogs } from '../api/logs.js';
+import { copyToClipboard } from '../clipboard.js';
+import { exportFilename, saveTextFile } from '../save-file.js';
+import { showErrorToast, showToast } from '../state/toast.js';
+import { useUiStore } from '../state/ui.js';
+
+type LevelFilter = 'all' | 'debug' | 'info' | 'warn' | 'error';
+
+/** Minimum severity per filter choice; 'all' shows trace upward. */
+const LEVEL_RANK: Record<AppLogLevel, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+  fatal: 5,
+};
+
+const FILTER_RANK: Record<LevelFilter, number> = {
+  all: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};
+
+function levelColor(level: AppLogLevel): string {
+  if (level === 'error' || level === 'fatal') return 'error.main';
+  if (level === 'warn') return 'warning.main';
+  if (level === 'debug' || level === 'trace') return 'text.secondary';
+  return 'text.primary';
+}
+
+function matches(entry: AppLogEntry, filter: LevelFilter, query: string): boolean {
+  if (LEVEL_RANK[entry.level] < FILTER_RANK[filter]) return false;
+  if (!query) return true;
+  return formatLogEntry(entry).toLowerCase().includes(query);
+}
+
+/** Diagnostic log viewer over the server's in-memory buffer (settings → debug). */
+export function LogViewerDialog() {
+  const open = useUiStore((s) => s.logViewerOpen);
+  const setOpen = useUiStore((s) => s.setLogViewerOpen);
+  const { data, refetch } = useAppLogs(open);
+  const [filter, setFilter] = useState<LevelFilter>('all');
+  const [query, setQuery] = useState('');
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const pinnedToEnd = useRef(true);
+
+  const entries = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return (data?.entries ?? []).filter((entry) => matches(entry, filter, needle));
+  }, [data?.entries, filter, query]);
+
+  // Follow new output like a terminal until the user scrolls back up.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && pinnedToEnd.current) el.scrollTop = el.scrollHeight;
+  }, [entries]);
+
+  const exportText = () =>
+    [
+      `# Muxus diagnostic log — exported ${new Date().toISOString()}`,
+      `# ${entries.length} entries, debug logging ${data?.debugEnabled ? 'on' : 'off'}`,
+      ...entries.map(formatLogEntry),
+    ].join('\n');
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => setOpen(false)}
+      maxWidth="lg"
+      fullWidth
+      slotProps={{ paper: { sx: { height: '80vh' } } }}
+      aria-labelledby="log-viewer-title"
+    >
+      <DialogTitle id="log-viewer-title" sx={{ pb: 1 }}>
+        Logs
+      </DialogTitle>
+      <DialogContent dividers sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, p: 2 }}>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+          <TextField
+            select
+            size="small"
+            label="Level"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value as LevelFilter)}
+            sx={{ width: 130 }}
+          >
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="debug">Debug +</MenuItem>
+            <MenuItem value="info">Info +</MenuItem>
+            <MenuItem value="warn">Warning +</MenuItem>
+            <MenuItem value="error">Error</MenuItem>
+          </TextField>
+          <TextField
+            size="small"
+            label="Filter"
+            placeholder="host, message, error …"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            sx={{ flex: 1, maxWidth: 360 }}
+          />
+          <Box sx={{ flex: 1 }} />
+          <Typography variant="caption" color="text.secondary">
+            {entries.length} of {data?.entries.length ?? 0} entries
+          </Typography>
+        </Stack>
+        {data && !data.debugEnabled ? (
+          <Alert severity="info" sx={{ py: 0 }}>
+            Debug logging is off — only informational messages, warnings and errors are
+            captured. Turn on debug mode in the settings for connection-level detail.
+          </Alert>
+        ) : null}
+        <Box
+          ref={scrollRef}
+          onScroll={(e) => {
+            const el = e.currentTarget;
+            pinnedToEnd.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+          }}
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflow: 'auto',
+            borderRadius: 1,
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'background.default',
+            p: 1.5,
+            fontFamily: 'monospace',
+            fontSize: 12,
+            lineHeight: 1.6,
+          }}
+        >
+          {entries.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              Nothing captured yet. Connection attempts, warnings and errors show up
+              here as they happen.
+            </Typography>
+          ) : (
+            entries.map((entry, index) => (
+              <Box
+                key={`${entry.ts}-${index}`}
+                sx={{
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  color: levelColor(entry.level),
+                  contentVisibility: 'auto',
+                }}
+              >
+                {formatLogEntry(entry)}
+              </Box>
+            ))
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          size="small"
+          startIcon={<DeleteOutlineOutlinedIcon />}
+          onClick={() => {
+            clearAppLogs()
+              .then(() => refetch())
+              .catch(showErrorToast);
+          }}
+        >
+          Clear
+        </Button>
+        <Button
+          size="small"
+          startIcon={<ContentCopyOutlinedIcon />}
+          disabled={entries.length === 0}
+          onClick={() => {
+            void copyToClipboard(exportText()).then((ok) => {
+              if (ok) showToast('success', 'Log copied to the clipboard.');
+            });
+          }}
+        >
+          Copy
+        </Button>
+        <Button
+          size="small"
+          startIcon={<DownloadOutlinedIcon />}
+          disabled={entries.length === 0}
+          onClick={() => saveTextFile(exportFilename('debug log', 'log'), exportText())}
+        >
+          Export
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Button variant="contained" onClick={() => setOpen(false)}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -26,6 +26,8 @@ import Tooltip from '@mui/material/Tooltip';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
+import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
+import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
@@ -39,6 +41,7 @@ import TerminalIcon from '@mui/icons-material/Terminal';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
 import type { UpdateCheckResult } from '@muxus/shared';
 import { checkForUpdate } from '../api/app.js';
+import { fetchAppLogs, formatLogEntry } from '../api/logs.js';
 import {
   useSaveSessionHistorySettings,
   useSaveSessionLoggingPolicy,
@@ -61,7 +64,8 @@ import {
 } from '../interface-zoom.js';
 import { useChordLabel } from '../keymap/hints.js';
 import { usePrefsStore, type RightClickAction, type ThemeMode } from '../state/prefs.js';
-import { showToast } from '../state/toast.js';
+import { exportFilename, saveTextFile } from '../save-file.js';
+import { showErrorToast, showToast } from '../state/toast.js';
 import { confirmAction } from '../state/dialogs.js';
 import { useUiStore } from '../state/ui.js';
 import { TERMINAL_SCHEMES, terminalScheme, type TerminalScheme } from '../terminal/palette.js';
@@ -81,6 +85,7 @@ type Section =
   | 'keyboard'
   | 'passwords'
   | 'data'
+  | 'debug'
   | 'about';
 
 const SECTIONS: Array<{ id: Section; label: string; icon: React.ReactNode }> = [
@@ -92,6 +97,7 @@ const SECTIONS: Array<{ id: Section; label: string; icon: React.ReactNode }> = [
   { id: 'keyboard', label: 'Keyboard', icon: <KeyboardOutlinedIcon fontSize="small" /> },
   { id: 'passwords', label: 'Passwords', icon: <PasswordOutlinedIcon fontSize="small" /> },
   { id: 'data', label: 'Backup & data', icon: <BackupOutlinedIcon fontSize="small" /> },
+  { id: 'debug', label: 'Debug', icon: <BugReportOutlinedIcon fontSize="small" /> },
   { id: 'about', label: 'About', icon: <InfoOutlinedIcon fontSize="small" /> },
 ];
 
@@ -198,6 +204,7 @@ export function SettingsDialog() {
                 onImportMobaXterm={() => setMobaXtermImportOpen(true)}
               />
             )}
+            {section === 'debug' && <DebugSection />}
             {section === 'about' && <AboutSection />}
           </Box>
           <DialogActions sx={{ borderTop: 1, borderColor: 'divider' }}>
@@ -933,6 +940,82 @@ function updateReasonLabel(reason?: string): string {
         ? `The update manifest returned ${reason.replace('manifest-', '')}.`
         : 'The update check could not be completed.';
   }
+}
+
+/** Diagnostic logging: the verbose-capture toggle plus log viewer and export. */
+function DebugSection() {
+  const debugMode = usePrefsStore((s) => s.debugMode);
+  const set = usePrefsStore((s) => s.set);
+  const setLogViewerOpen = useUiStore((s) => s.setLogViewerOpen);
+
+  const exportLogs = () => {
+    fetchAppLogs()
+      .then((logs) => {
+        saveTextFile(
+          exportFilename('debug log', 'log'),
+          [
+            `# Muxus diagnostic log — exported ${new Date().toISOString()}`,
+            `# ${logs.entries.length} entries, debug logging ${logs.debugEnabled ? 'on' : 'off'}`,
+            ...logs.entries.map(formatLogEntry),
+          ].join('\n'),
+        );
+      })
+      .catch(showErrorToast);
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <SectionTitle>Debug mode</SectionTitle>
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={debugMode}
+              onChange={(e) => set({ debugMode: e.target.checked })}
+            />
+          }
+          label={
+            <Box>
+              <Typography variant="body2">Capture verbose diagnostic logs</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Records connection-level detail: every dial, authentication step,
+                SSH agent wait and the raw error behind a failure. Warnings and
+                errors are always captured, even while this is off.
+              </Typography>
+            </Box>
+          }
+        />
+      </Box>
+      <Box>
+        <SectionTitle>Logs</SectionTitle>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<ArticleOutlinedIcon />}
+            onClick={() => setLogViewerOpen(true)}
+          >
+            View logs
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<DownloadOutlinedIcon />}
+            onClick={exportLogs}
+          >
+            Export logs
+          </Button>
+        </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          Covers app startup and every connection attempt since launch. Logs are
+          held in memory on this machine only and never leave it unless you export
+          them. If the app fails to launch entirely, the desktop shell also writes
+          logs/main.log in its data directory.
+        </Typography>
+      </Box>
+    </Stack>
+  );
 }
 
 function AboutSection() {

--- a/client/src/lazy-features.ts
+++ b/client/src/lazy-features.ts
@@ -8,6 +8,7 @@ export const loadSettingsDialog = () => import('./components/SettingsDialog.js')
 export const loadCommandButtonsDialog = () => import('./components/CommandButtonsDialog.js');
 export const loadShortcutsDialog = () => import('./components/ShortcutsDialog.js');
 export const loadSessionHistoryDialog = () => import('./components/SessionHistoryDialog.js');
+export const loadLogViewerDialog = () => import('./components/LogViewerDialog.js');
 export const loadQuickLauncherDialog = () => import('./components/QuickLauncherDialog.js');
 export const loadWorkspaceDialog = () => import('./components/WorkspaceDialog.js');
 export const loadForwardingPanel = () => import('./components/ForwardingPanel.js');

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -97,6 +97,8 @@ export interface PrefsState {
   sidebarEmptyFolders: string[];
   /** Width of the per-session remote file browser. */
   sftpPanelWidth: number;
+  /** Verbose diagnostic logging plus access to the log viewer and export. */
+  debugMode: boolean;
   toggleTheme: () => void;
   set: (patch: Partial<Omit<PrefsState, 'set' | 'toggleTheme'>>) => void;
 }
@@ -181,6 +183,7 @@ export const usePrefsStore = create<PrefsState>()(
       sidebarFolderOrder: {},
       sidebarEmptyFolders: [],
       sftpPanelWidth: DEFAULT_SFTP_PANEL_WIDTH,
+      debugMode: false,
       toggleTheme: () =>
         set((s) => ({ themeMode: s.themeMode === 'light' ? 'dark' : s.themeMode === 'dark' ? 'os' : 'light' })),
       set: (patch) => set(patch),

--- a/client/src/state/ui.ts
+++ b/client/src/state/ui.ts
@@ -39,6 +39,8 @@ interface UiState {
   folderDialog: FolderDialogState;
   /** Global forwarding side panel (saved tunnels + live forwards). */
   forwardingOpen: boolean;
+  /** Diagnostic log viewer (settings → debug). */
+  logViewerOpen: boolean;
   setSettingsOpen: (open: boolean) => void;
   setCommandButtonsOpen: (open: boolean) => void;
   setShortcutsOpen: (open: boolean) => void;
@@ -50,6 +52,7 @@ interface UiState {
   setHostOrganizer: (value: SshHostEntry | SavedHostProfile | false) => void;
   setFolderDialog: (value: FolderDialogState) => void;
   setForwardingOpen: (open: boolean) => void;
+  setLogViewerOpen: (open: boolean) => void;
 }
 
 export const useUiStore = create<UiState>()((set) => ({
@@ -64,6 +67,7 @@ export const useUiStore = create<UiState>()((set) => ({
   hostOrganizer: false,
   folderDialog: false,
   forwardingOpen: false,
+  logViewerOpen: false,
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
   setCommandButtonsOpen: (commandButtonsOpen) => set({ commandButtonsOpen }),
   setShortcutsOpen: (shortcutsOpen) => set({ shortcutsOpen }),
@@ -80,4 +84,5 @@ export const useUiStore = create<UiState>()((set) => ({
   setHostOrganizer: (hostOrganizer) => set({ hostOrganizer }),
   setFolderDialog: (folderDialog) => set({ folderDialog }),
   setForwardingOpen: (forwardingOpen) => set({ forwardingOpen }),
+  setLogViewerOpen: (logViewerOpen) => set({ logViewerOpen }),
 }));

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -128,6 +128,26 @@ client. Muxus-only settings remain in the backup.
 
     Private key files, passwords and recorded session history are never part of a backup.
 
+## Debug
+
+**Debug mode** raises the app's logging to connection-level detail: every dial, each
+authentication method as it is tried, waits on the SSH agent, host key verification, and
+the raw error behind a failed connection. Warnings and errors are always captured, even
+while debug mode is off — a failure can be inspected after the fact, and turning on debug
+mode is only needed for the verbose detail around the next attempt.
+
+**View logs** opens a live viewer with level and text filters; **Export logs** saves
+everything as a text file. Logs live in a small, bounded in-memory buffer on this machine
+only — they reset when the app quits and are never written to disk or sent anywhere
+unless exported.
+
+!!! tip "When the app will not start"
+
+    The desktop shell also writes startup milestones and crashes to `logs/main.log` in
+    its application-data directory (for example `~/.config/Muxus` on Linux,
+    `~/Library/Application Support/Muxus` on macOS, `%APPDATA%\Muxus` on Windows).
+    A failed launch shows a dialog pointing at this file.
+
 ## About
 
 Version and platform information, a link to the source repository, and a manual update

--- a/electron/src/login-shell-environment.ts
+++ b/electron/src/login-shell-environment.ts
@@ -13,13 +13,17 @@ export function importLoginShellEnvironment(
   platform = process.platform,
   environment: Environment = process.env,
   readLoginEnvironment: ReadLoginEnvironment = shellEnvSync,
+  onError?: (err: unknown) => void,
 ): void {
   if (platform === 'win32') return;
 
   let loginEnvironment: Readonly<Record<string, string>>;
   try {
     loginEnvironment = readLoginEnvironment();
-  } catch {
+  } catch (err) {
+    // A broken login shell means PATH and SSH_AUTH_SOCK stay at launch values
+    // — connections may fail later; leave a trace of why.
+    onError?.(err);
     return;
   }
 

--- a/electron/src/main-log.ts
+++ b/electron/src/main-log.ts
@@ -1,0 +1,72 @@
+import { appendFileSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { appendAppLog } from '@muxus/server';
+
+/**
+ * Main-process diagnostics. Every entry goes two places: the in-process log
+ * buffer behind /api/logs (visible in the app's log viewer once a window is
+ * up) and a plain-text file under userData — the only trace left when the
+ * app never gets that far.
+ */
+
+const MAX_LOG_BYTES = 1024 * 1024;
+
+let logFile: string | undefined;
+
+export function initMainLog(userDataDir: string): void {
+  try {
+    const dir = path.join(userDataDir, 'logs');
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'main.log');
+    try {
+      if (statSync(file).size > MAX_LOG_BYTES) {
+        renameSync(file, path.join(dir, 'main.old.log'));
+      }
+    } catch {
+      // First run: no file yet.
+    }
+    logFile = file;
+  } catch {
+    // Diagnostics never block startup; the in-memory mirror still works.
+  }
+}
+
+export function mainLogPath(): string | undefined {
+  return logFile;
+}
+
+function describeError(err: unknown): string | undefined {
+  if (err === undefined) return undefined;
+  if (err instanceof Error) return err.stack ?? `${err.name}: ${err.message}`;
+  if (typeof err === 'string') return err;
+  if (typeof err === 'number' || typeof err === 'boolean' || typeof err === 'bigint') {
+    return String(err);
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return Object.prototype.toString.call(err);
+  }
+}
+
+export function mainLog(level: 'info' | 'warn' | 'error', msg: string, err?: unknown): void {
+  const detail = describeError(err);
+  appendAppLog(level, msg, detail ? { err: detail } : undefined);
+  if (!logFile) return;
+  const line = `${new Date().toISOString()} ${level.toUpperCase()} ${msg}${detail ? `\n  ${detail.replaceAll('\n', '\n  ')}` : ''}\n`;
+  try {
+    appendFileSync(logFile, line);
+  } catch {
+    // Never let logging take the app down.
+  }
+}
+
+/** Last-resort capture: without this, a main-process crash leaves no trace. */
+export function installCrashCapture(): void {
+  process.on('uncaughtException', (err) => {
+    mainLog('error', 'uncaught exception in the main process', err);
+  });
+  process.on('unhandledRejection', (reason) => {
+    mainLog('error', 'unhandled promise rejection in the main process', reason);
+  });
+}

--- a/electron/src/main-log.ts
+++ b/electron/src/main-log.ts
@@ -63,10 +63,15 @@ export function mainLog(level: 'info' | 'warn' | 'error', msg: string, err?: unk
 
 /** Last-resort capture: without this, a main-process crash leaves no trace. */
 export function installCrashCapture(): void {
-  process.on('uncaughtException', (err) => {
-    mainLog('error', 'uncaught exception in the main process', err);
-  });
-  process.on('unhandledRejection', (reason) => {
-    mainLog('error', 'unhandled promise rejection in the main process', reason);
+  // A monitor observes fatal errors without marking them as handled, so Node
+  // still terminates the main process after the synchronous log write.
+  process.on('uncaughtExceptionMonitor', (err, origin) => {
+    mainLog(
+      'error',
+      origin === 'unhandledRejection'
+        ? 'unhandled promise rejection in the main process'
+        : 'uncaught exception in the main process',
+      err,
+    );
   });
 }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -21,11 +21,21 @@ import type {
   UpdateCheckResult,
 } from '@muxus/shared';
 import { importLoginShellEnvironment } from './login-shell-environment.js';
+import { initMainLog, installCrashCapture, mainLog, mainLogPath } from './main-log.js';
 import { readLocalMobaXtermSessions } from './mobaxterm.js';
 
-importLoginShellEnvironment();
-
+// Name first: userData (and with it the log location) derives from it.
 app.setName('Muxus');
+initMainLog(app.getPath('userData'));
+installCrashCapture();
+mainLog(
+  'info',
+  `Muxus ${app.getVersion()} starting on ${process.platform}/${process.arch} (Electron ${process.versions.electron})`,
+);
+importLoginShellEnvironment(undefined, undefined, undefined, (err) =>
+  mainLog('warn', 'could not import the login shell environment', err),
+);
+
 // Keep the native Wayland app_id (and the X11 fallback's WM_CLASS) aligned
 // with the installed desktop file. Electron selects Wayland automatically
 // when the session supports it; no display-backend flag is needed.
@@ -295,6 +305,10 @@ function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
     managedWindows.delete(win);
     windowLaunches.delete(webContentsId);
     if (primaryWindow === win) primaryWindow = undefined;
+  });
+  // A dead renderer looks like "the app won't start" — leave its exit trace.
+  win.webContents.on('render-process-gone', (_event, details) => {
+    mainLog('error', `window renderer gone (${details.reason}, exit code ${details.exitCode})`);
   });
   win.webContents.setWindowOpenHandler(({ url: external }) => {
     openAllowedExternalUrl(external);
@@ -590,10 +604,18 @@ if (!app.requestSingleInstanceLock()) {
           : path.resolve(moduleDir, '../../client/dist'),
       });
     } catch (err) {
-      console.error('failed to start muxus server', err);
+      mainLog('error', 'the embedded server failed to start', err);
+      const logPath = mainLogPath();
+      dialog.showErrorBox(
+        'Muxus failed to start',
+        `${err instanceof Error ? err.message : String(err)}${
+          logPath ? `\n\nDetails were written to:\n${logPath}` : ''
+        }`,
+      );
       app.quit();
       return;
     }
+    mainLog('info', `server listening at ${server.url}`);
     buildMenu();
     const url = server.url;
     appUrl = url;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyBaseLogger, type FastifyInstance } from 'fastify';
+import pino from 'pino';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyStatic from '@fastify/static';
 import { TERMINAL_WS_PROTOCOL } from '@muxus/shared/ws-protocol';
@@ -24,6 +25,8 @@ import { registerProfileRoutes } from './routes/profiles.js';
 import { registerHostOrderRoutes } from './routes/host-order.js';
 import { registerSessionHistoryRoutes } from './routes/session-history.js';
 import { registerPasswordVaultRoutes } from './routes/password-vault.js';
+import { registerLogRoutes } from './routes/logs.js';
+import { appLogPinoSink } from './logging/log-buffer.js';
 import {
   defaultHistoryRoot,
   SessionHistoryStore,
@@ -56,13 +59,31 @@ const CONTENT_SECURITY_POLICY = [
   "frame-ancestors 'none'",
 ].join('; ');
 
+/** The level the server returns to when debug logging is switched off. */
+export function baseLogLevel(): string {
+  return process.env.LOG_LEVEL ?? 'info';
+}
+
+/**
+ * All records go both to the console and to the in-memory buffer behind
+ * /api/logs; the logger's own level is the only gate. Debug mode (settings)
+ * raises that level at runtime.
+ */
+function buildLogger(config: ServerConfig): FastifyBaseLogger {
+  const console = config.prettyLogs
+    ? pino.transport({ target: 'pino-pretty', options: { translateTime: 'HH:MM:ss' } }) as pino.DestinationStream
+    : process.stdout;
+  return pino(
+    { level: baseLogLevel() },
+    pino.multistream([
+      { level: 'trace', stream: console },
+      { level: 'trace', stream: appLogPinoSink() },
+    ]),
+  ) as FastifyBaseLogger;
+}
+
 export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInstance; ctx: AppContext }> {
-  const app = Fastify({
-    logger: {
-      level: process.env.LOG_LEVEL ?? 'info',
-      transport: config.prettyLogs ? { target: 'pino-pretty', options: { translateTime: 'HH:MM:ss' } } : undefined,
-    },
-  });
+  const app = Fastify({ loggerInstance: buildLogger(config) });
 
   const database = new MuxusDatabase(config.databasePath);
   const vault = new PasswordVault(database);
@@ -155,6 +176,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   registerHostOrderRoutes(app, ctx);
   registerSessionHistoryRoutes(app, ctx);
   registerPasswordVaultRoutes(app, ctx);
+  registerLogRoutes(app);
   registerTerminalSocket(app, ctx);
   registerSftpLeaseSocket(app, ctx);
 

--- a/server/src/logging/log-buffer.ts
+++ b/server/src/logging/log-buffer.ts
@@ -1,0 +1,113 @@
+import type { AppLogEntry, AppLogLevel } from '@muxus/shared';
+
+export const APP_LOG_CAPACITY = 5000;
+
+/** pino numeric levels → names; unknown values round down to 'info'. */
+const PINO_LEVELS: Array<[number, AppLogLevel]> = [
+  [60, 'fatal'],
+  [50, 'error'],
+  [40, 'warn'],
+  [30, 'info'],
+  [20, 'debug'],
+  [10, 'trace'],
+];
+
+function levelName(value: unknown): AppLogLevel {
+  if (typeof value !== 'number') return 'info';
+  for (const [threshold, name] of PINO_LEVELS) {
+    if (value >= threshold) return name;
+  }
+  return 'trace';
+}
+
+/** Record fields that describe the process, not the event. */
+const NOISE_KEYS = new Set(['level', 'time', 'msg', 'pid', 'hostname']);
+
+class AppLogBuffer {
+  private readonly slots: Array<AppLogEntry | undefined> = Array.from({ length: APP_LOG_CAPACITY });
+  private next = 0;
+  private size = 0;
+
+  append(entry: AppLogEntry): void {
+    this.slots[this.next] = entry;
+    this.next = (this.next + 1) % APP_LOG_CAPACITY;
+    if (this.size < APP_LOG_CAPACITY) this.size++;
+  }
+
+  list(): AppLogEntry[] {
+    const start = (this.next - this.size + APP_LOG_CAPACITY) % APP_LOG_CAPACITY;
+    const out: AppLogEntry[] = [];
+    for (let i = 0; i < this.size; i++) {
+      const entry = this.slots[(start + i) % APP_LOG_CAPACITY];
+      if (entry) out.push(entry);
+    }
+    return out;
+  }
+
+  clear(): void {
+    this.slots.fill(undefined);
+    this.next = 0;
+    this.size = 0;
+  }
+}
+
+/**
+ * One buffer per process. The Electron shell bundles the server into its main
+ * process, so shell milestones and backend logs land in the same timeline the
+ * log viewer and export read.
+ */
+const buffer = new AppLogBuffer();
+
+export function appLogEntries(): AppLogEntry[] {
+  return buffer.list();
+}
+
+export function clearAppLog(): void {
+  buffer.clear();
+}
+
+/** Direct entry point for the desktop shell (and anything else without pino). */
+export function appendAppLog(
+  level: AppLogLevel,
+  msg: string,
+  context?: Record<string, unknown>,
+): void {
+  buffer.append({
+    ts: Date.now(),
+    level,
+    source: 'app',
+    msg,
+    ...(context ? { context } : {}),
+  });
+}
+
+/** A pino destination that mirrors every serialized record into the buffer. */
+export function appLogPinoSink(): { write(line: string): void } {
+  return {
+    write(line: string): void {
+      let record: Record<string, unknown>;
+      try {
+        record = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      // Fastify's per-request lines would flush real events out of the ring
+      // within minutes of routine client polling. Request *errors* stay.
+      if (record.msg === 'incoming request' || record.msg === 'request completed') return;
+      const context: Record<string, unknown> = {};
+      let hasContext = false;
+      for (const [key, value] of Object.entries(record)) {
+        if (NOISE_KEYS.has(key)) continue;
+        context[key] = value;
+        hasContext = true;
+      }
+      buffer.append({
+        ts: typeof record.time === 'number' ? record.time : Date.now(),
+        level: levelName(record.level),
+        source: 'server',
+        msg: typeof record.msg === 'string' ? record.msg : '',
+        ...(hasContext ? { context } : {}),
+      });
+    },
+  };
+}

--- a/server/src/routes/logs.ts
+++ b/server/src/routes/logs.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type { AppLogsResponse } from '@muxus/shared';
+import { baseLogLevel } from '../app.js';
+import {
+  APP_LOG_CAPACITY,
+  appLogEntries,
+  clearAppLog,
+} from '../logging/log-buffer.js';
+import { sendError, HttpProblem } from '../util/errors.js';
+
+const settingsSchema = z.object({ debugEnabled: z.boolean() });
+
+function debugEnabled(app: FastifyInstance): boolean {
+  return app.log.level === 'debug' || app.log.level === 'trace';
+}
+
+export function registerLogRoutes(app: FastifyInstance): void {
+  app.get('/api/logs', (): AppLogsResponse => ({
+    entries: appLogEntries(),
+    debugEnabled: debugEnabled(app),
+    capacity: APP_LOG_CAPACITY,
+  }));
+
+  app.put('/api/logs/settings', async (req, reply) => {
+    const parsed = settingsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendError(reply, new HttpProblem(400, 'debugEnabled must be a boolean'));
+    }
+    const base = baseLogLevel();
+    const wasEnabled = debugEnabled(app);
+    // An explicit LOG_LEVEL=trace stays trace; the toggle never lowers it.
+    app.log.level = parsed.data.debugEnabled
+      ? base === 'trace' ? 'trace' : 'debug'
+      : base;
+    if (parsed.data.debugEnabled !== wasEnabled) {
+      app.log.info(
+        parsed.data.debugEnabled ? 'debug logging enabled' : 'debug logging disabled',
+      );
+    }
+    return { debugEnabled: debugEnabled(app) };
+  });
+
+  app.delete('/api/logs', () => {
+    clearAppLog();
+    return { cleared: true };
+  });
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,6 +4,10 @@ import { resolveConfig, type ServerConfig } from './config.js';
 import { buildApp } from './app.js';
 import { serverUrls } from './auth.js';
 
+// The Electron shell logs its own milestones (boot, crashes) into the same
+// in-process buffer the /api/logs viewer reads.
+export { appendAppLog } from './logging/log-buffer.js';
+
 export interface RunningServer {
   app: FastifyInstance;
   port: number;

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -311,6 +311,10 @@ export class SshConnectionManager {
     const target = chain[chain.length - 1]!;
     const configForwards = target.resolved.forwards;
     const label = `${target.user}@${target.resolved.hostname}:${target.port}`;
+    this.log.debug(
+      { target: profile.target, label, hops: chain.length, owner },
+      'ssh connect requested',
+    );
 
     if (!opts.freshTransport) {
       const shared = this.acquireShared(key, owner, target);
@@ -319,6 +323,7 @@ export class SshConnectionManager {
           shared.connection.configForwards,
           configForwards,
         );
+        this.log.debug({ label, connId: shared.connection.id }, 'reusing multiplexed ssh transport');
         io.status(`Reusing the SSH connection to ${label} (multiplexed).`, { transient: true });
         return shared;
       }
@@ -455,6 +460,11 @@ export class SshConnectionManager {
         if (next) sock = await openJumpChannel(client, next.resolved.hostname, next.port);
       }
     } catch (err) {
+      // dial() already logged the raw failure; this adds which hop died.
+      this.log.debug(
+        { err, hops: chain.length, dialed: clients.length },
+        'ssh dial chain aborted',
+      );
       stopHealth();
       for (const c of clients.reverse()) c.end();
       throw err;
@@ -593,13 +603,18 @@ export class SshConnectionManager {
         ? new ResponsiveAgent(ssh2.createAgent(agentSocket) as BaseAgent<ParsedKey>, {
             pauseDeadline: () => readyDeadline?.pause(),
             resumeDeadline: () => readyDeadline?.resume(),
-            onWaiting: (operation) =>
+            onWaiting: (operation) => {
+              this.log.info(
+                { host: hop.resolved.hostname, operation, agentSocket },
+                'waiting for the ssh agent to respond',
+              );
               io.status(
                 operation === 'sign'
                   ? 'Waiting for the SSH agent to approve signing…'
                   : 'Waiting for the SSH agent to list identities…',
                 { transient: true },
-              ),
+              );
+            },
             waitStatusMs: this.agentWaitStatusMs,
             operationTimeoutMs: this.agentOperationTimeoutMs,
           })
@@ -610,13 +625,30 @@ export class SshConnectionManager {
       this.vault,
       runInteraction,
       authAgent,
+      this.log,
     );
     const { algorithms, notes } = connectionAlgorithms(hop.resolved);
-    for (const note of notes) io.status(note);
+    for (const note of notes) {
+      this.log.debug({ host: hop.resolved.hostname }, note);
+      io.status(note);
+    }
     const proxySocket =
       !sock && hop.resolved.proxyCommand ? openProxyCommand(expandedProxyCommand(hop)!) : undefined;
     const transport = sock ?? proxySocket;
     const readyTimeoutMs = (hop.resolved.connectTimeout ?? 20) * 1000;
+    this.log.debug(
+      {
+        host: hop.resolved.hostname,
+        port: hop.port,
+        user: hop.user,
+        agent: !!agentSocket,
+        identitiesOnly: !!hop.resolved.identitiesOnly,
+        proxyCommand: !!hop.resolved.proxyCommand,
+        viaJump: !!sock,
+        readyTimeoutMs,
+      },
+      'dialing ssh host',
+    );
     const config: ConnectConfig = {
       username: hop.user,
       // ssh2's deadline includes time spent in UI prompts and cannot be
@@ -654,6 +686,12 @@ export class SshConnectionManager {
       const rejectBeforeReady = (err: Error) => {
         if (settled) return;
         settled = true;
+        // The raw error, before friendlyConnectError() rewrites it — an agent
+        // stall and a network timeout look identical to the user otherwise.
+        this.log.warn(
+          { err, host: hop.resolved.hostname, port: hop.port, user: hop.user },
+          'ssh dial failed',
+        );
         readyDeadline?.clear();
         auth.dispose();
         proxySocket?.destroy();
@@ -668,6 +706,10 @@ export class SshConnectionManager {
         if (settled) return;
         ready = true;
         settled = true;
+        this.log.debug(
+          { host: hop.resolved.hostname, port: hop.port, user: hop.user },
+          'ssh connection ready',
+        );
         readyDeadline?.clear();
         const postAuth = auth
           .commitRememberedPassword()
@@ -688,6 +730,10 @@ export class SshConnectionManager {
         if (!settled && err.level === 'agent') {
           // ssh2 reports an unreachable agent mid-auth and then moves on to
           // the next method itself; surface it without aborting the dial.
+          this.log.warn(
+            { err, host: hop.resolved.hostname },
+            'ssh-agent unavailable; trying other authentication methods',
+          );
           io.status(`ssh-agent unavailable (${err.message}) — trying other authentication methods`);
           return;
         }
@@ -730,13 +776,22 @@ export class SshConnectionManager {
     const port = hop.port;
     const store = this.knownHostsFor(hop);
     const verdict = store.verify(host, port, key);
+    this.log.debug(
+      { host, port, keyType: hostKeyType(key), verdict: verdict.state },
+      'host key verified against known_hosts',
+    );
     if (verdict.state === 'ok') return true;
     if (verdict.state === 'revoked') {
+      this.log.warn({ host, port }, 'host key is revoked in known_hosts');
       io.status(`HOST KEY REVOKED for ${host} — remove the @revoked entry from known_hosts if this is intentional.`);
       return false;
     }
     const strict = hop.resolved.strictHostKeyChecking ?? 'ask';
     if (strict === 'yes') {
+      this.log.warn(
+        { host, port, verdict: verdict.state },
+        'refusing host key under StrictHostKeyChecking=yes',
+      );
       io.status(
         verdict.state === 'changed'
           ? `HOST KEY CHANGED for ${host} and StrictHostKeyChecking is yes — refusing to connect.`
@@ -762,6 +817,7 @@ export class SshConnectionManager {
         hop: hop.hopLabel,
       }),
     ).catch(() => false);
+    this.log.debug({ host, port, accepted }, 'host key decision from the user');
     if (accepted) store.record(host, port, key);
     return accepted;
   }
@@ -1062,6 +1118,7 @@ class AuthLadder {
     private readonly runInteraction: InteractionRunner = (interaction) =>
       interaction(),
     private readonly agent?: BaseAgent<ParsedKey>,
+    private readonly log?: FastifyBaseLogger,
   ) {
     this.attempts = this.build();
   }
@@ -1084,8 +1141,13 @@ class AuthLadder {
     authsLeft: AuthenticationType[] | null,
     cb: (method: AnyAuthMethod | false) => void,
   ): void {
+    const host = this.hop.resolved.hostname;
     const attempt = this.attempts[this.index++];
     if (!attempt || this.cancelled) {
+      this.log?.debug(
+        { host, cancelled: this.cancelled },
+        'ssh auth ladder exhausted',
+      );
       cb(false);
       return;
     }
@@ -1093,14 +1155,26 @@ class AuthLadder {
     // Agent auth is publickey on the wire — servers never advertise "agent".
     const wireType = attempt.type === 'agent' ? 'publickey' : attempt.type;
     if (authsLeft && attempt.type !== 'none' && !authsLeft.includes(wireType)) {
+      this.log?.debug(
+        { host, method: attempt.type, authsLeft },
+        'ssh auth method not accepted by server; skipping',
+      );
       this.advance(authsLeft, cb);
       return;
     }
     attempt
       .get()
       .then((method) => {
-        if (method) cb(method);
-        else this.advance(authsLeft, cb);
+        if (method) {
+          this.log?.debug({ host, method: attempt.type }, 'trying ssh auth method');
+          cb(method);
+        } else {
+          this.log?.debug(
+            { host, method: attempt.type },
+            'ssh auth method unavailable; skipping',
+          );
+          this.advance(authsLeft, cb);
+        }
       })
       .catch(() => {
         this.cancelled = true;

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -21,6 +21,32 @@ export interface AppInfo {
   sshAlgorithms: Record<string, string[]>;
 }
 
+export type AppLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+/** One diagnostic log record from the in-memory app log buffer. */
+export interface AppLogEntry {
+  /** Unix epoch milliseconds. */
+  ts: number;
+  level: AppLogLevel;
+  /** 'server' — the embedded backend; 'app' — the desktop shell's main process. */
+  source: 'server' | 'app';
+  msg: string;
+  /** Structured fields attached to the record (host, err, …). */
+  context?: Record<string, unknown>;
+}
+
+export interface AppLogsResponse {
+  entries: AppLogEntry[];
+  /** True while the server logs at debug level or below. */
+  debugEnabled: boolean;
+  /** Ring-buffer size; older entries beyond it are dropped. */
+  capacity: number;
+}
+
+export interface AppLogSettingsInput {
+  debugEnabled: boolean;
+}
+
 /** Public metadata for one SSH password encrypted in the local password vault. */
 export interface PasswordVaultCredential {
   id: string;

--- a/tests/unit/electron/login-shell-environment.test.ts
+++ b/tests/unit/electron/login-shell-environment.test.ts
@@ -68,4 +68,18 @@ describe('login shell environment', () => {
     );
     expect(environment).toEqual({ PATH: '/usr/bin', SSH_AUTH_SOCK: '/tmp/current.sock' });
   });
+
+  it('reports a failed shell startup to the diagnostics hook', () => {
+    const failure = new Error('shell failed');
+    const onError = vi.fn();
+    importLoginShellEnvironment(
+      'darwin',
+      { PATH: '/usr/bin' },
+      () => {
+        throw failure;
+      },
+      onError,
+    );
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
 });

--- a/tests/unit/server/log-buffer.test.ts
+++ b/tests/unit/server/log-buffer.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  APP_LOG_CAPACITY,
+  appLogEntries,
+  appLogPinoSink,
+  appendAppLog,
+  clearAppLog,
+} from '../../../server/src/logging/log-buffer.js';
+
+beforeEach(() => {
+  clearAppLog();
+});
+
+describe('app log buffer', () => {
+  it('stores shell entries with level, source and context', () => {
+    appendAppLog('error', 'the embedded server failed to start', { err: 'EADDRINUSE' });
+
+    const entries = appLogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      level: 'error',
+      source: 'app',
+      msg: 'the embedded server failed to start',
+      context: { err: 'EADDRINUSE' },
+    });
+    expect(entries[0]!.ts).toBeGreaterThan(0);
+  });
+
+  it('drops the oldest entries beyond the capacity', () => {
+    for (let i = 0; i < APP_LOG_CAPACITY + 10; i++) {
+      appendAppLog('info', `entry ${i}`);
+    }
+
+    const entries = appLogEntries();
+    expect(entries).toHaveLength(APP_LOG_CAPACITY);
+    expect(entries[0]!.msg).toBe('entry 10');
+    expect(entries[entries.length - 1]!.msg).toBe(`entry ${APP_LOG_CAPACITY + 9}`);
+  });
+
+  it('clears on demand', () => {
+    appendAppLog('info', 'before');
+    clearAppLog();
+    expect(appLogEntries()).toEqual([]);
+  });
+
+  it('parses serialized pino records into server entries', () => {
+    const sink = appLogPinoSink();
+    sink.write(
+      JSON.stringify({
+        level: 40,
+        time: 1753862400000,
+        pid: 4242,
+        hostname: 'box',
+        host: 'db.example.com',
+        err: { type: 'Error', message: 'agent did not respond' },
+        msg: 'ssh dial failed',
+      }),
+    );
+
+    const entries = appLogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      ts: 1753862400000,
+      level: 'warn',
+      source: 'server',
+      msg: 'ssh dial failed',
+      context: {
+        host: 'db.example.com',
+        err: { type: 'Error', message: 'agent did not respond' },
+      },
+    });
+  });
+
+  it('skips fastify per-request noise and unparseable lines', () => {
+    const sink = appLogPinoSink();
+    sink.write(JSON.stringify({ level: 30, time: 1, msg: 'incoming request', reqId: 'req-1' }));
+    sink.write(JSON.stringify({ level: 30, time: 2, msg: 'request completed', reqId: 'req-1' }));
+    sink.write('not json\n');
+    sink.write(JSON.stringify({ level: 50, time: 3, msg: 'request errored', reqId: 'req-1' }));
+
+    const entries = appLogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ level: 'error', msg: 'request errored' });
+  });
+
+  it('maps unknown pino levels to sane names', () => {
+    const sink = appLogPinoSink();
+    sink.write(JSON.stringify({ level: 60, time: 1, msg: 'fatal thing' }));
+    sink.write(JSON.stringify({ level: 5, time: 2, msg: 'below trace' }));
+    sink.write(JSON.stringify({ level: 'nope', time: 3, msg: 'no level' }));
+
+    expect(appLogEntries().map((e) => e.level)).toEqual(['fatal', 'trace', 'info']);
+  });
+});

--- a/tests/unit/server/logs-routes.test.ts
+++ b/tests/unit/server/logs-routes.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../../../server/src/app.js';
+import { resolveConfig } from '../../../server/src/config.js';
+import { clearAppLog } from '../../../server/src/logging/log-buffer.js';
+
+const TOKEN = 'logs-route-test-token';
+let app: Awaited<ReturnType<typeof buildApp>>['app'];
+
+beforeEach(async () => {
+  clearAppLog();
+  ({ app } = await buildApp(
+    resolveConfig({
+      token: TOKEN,
+      databasePath: ':memory:',
+      openBrowser: false,
+      prettyLogs: false,
+      staticRoot: '/path/that/does/not/exist',
+    }),
+  ));
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+const auth = { authorization: `Bearer ${TOKEN}` };
+
+describe('log routes', () => {
+  it('serves buffered server log entries', async () => {
+    app.log.warn({ host: 'db.example.com' }, 'ssh dial failed');
+
+    const response = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.debugEnabled).toBe(false);
+    expect(body.capacity).toBeGreaterThan(0);
+    expect(body.entries).toContainEqual(
+      expect.objectContaining({
+        level: 'warn',
+        source: 'server',
+        msg: 'ssh dial failed',
+        context: { host: 'db.example.com' },
+      }),
+    );
+  });
+
+  it('does not capture debug records until debug mode is enabled', async () => {
+    app.log.debug('hidden detail');
+    const before = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    expect(before.json().entries).not.toContainEqual(
+      expect.objectContaining({ msg: 'hidden detail' }),
+    );
+
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: true },
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toEqual({ debugEnabled: true });
+
+    app.log.debug('visible detail');
+    const after = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    expect(after.json().debugEnabled).toBe(true);
+    expect(after.json().entries).toContainEqual(
+      expect.objectContaining({ level: 'debug', msg: 'visible detail' }),
+    );
+  });
+
+  it('restores the base level when debug mode is disabled', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: true },
+    });
+    const off = await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: false },
+    });
+    expect(off.json()).toEqual({ debugEnabled: false });
+    expect(app.log.level).toBe('info');
+
+    // Toggling leaves an audit trail in the buffer itself.
+    const logs = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    const messages = logs.json().entries.map((e: { msg: string }) => e.msg);
+    expect(messages).toContain('debug logging enabled');
+    expect(messages).toContain('debug logging disabled');
+  });
+
+  it('rejects a malformed settings body', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: 'yes' },
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('clears the buffer', async () => {
+    app.log.warn('to be cleared');
+    const cleared = await app.inject({ method: 'DELETE', url: '/api/logs', headers: auth });
+    expect(cleared.json()).toEqual({ cleared: true });
+
+    const logs = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    expect(logs.json().entries).not.toContainEqual(
+      expect.objectContaining({ msg: 'to be cleared' }),
+    );
+  });
+
+  it('requires authentication', async () => {
+    const response = await app.inject({ method: 'GET', url: '/api/logs' });
+    expect(response.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## What changed

- New **Settings → Debug** section: a debug-mode toggle that raises the server's log level to connection detail, a live log viewer with level and text filters, and plain-text export.
- Log records flow into a bounded in-memory ring buffer (5000 entries) behind `GET /api/logs`; `PUT /api/logs/settings` flips the level, `DELETE /api/logs` clears the buffer. Warnings and errors are always captured, even while debug mode is off, so a failure can be inspected after the fact; viewing and exporting work regardless of the toggle.
- The SSH dial path now logs the story behind a failed connect: the dial plan and per-hop dials, each auth-ladder rung as it is tried or skipped, SSH agent waits, host key verdicts, and the **raw error before `friendlyConnectError()` rewrites it** — an agent stall and a network timeout were previously indistinguishable in the surfaced message (see #28).
- The desktop shell writes startup milestones, renderer exits and uncaught main-process errors to `logs/main.log` under userData (rotated at 1 MB) and mirrors them into the same buffer, reports a failed login-shell import instead of swallowing it, and shows an error dialog pointing at the log file when the embedded server fails to start.

## Notes

- The buffer lives in process memory only: it resets on every launch, is hard-capped at ~1–2 MB, and nothing leaves the machine unless exported.
- Fastify's per-request `incoming request`/`request completed` lines are filtered from the buffer so routine client polling cannot flush real events out; request errors are kept. Stdout logging is unchanged.
- The debug preference is client-side and re-syncs the server level on boot and on toggle; disabling restores the `LOG_LEVEL` baseline.

## Validation

- Workspace TypeScript checks, lint, full production build (including the bundled desktop main process)
- Full test suite: 619 passed, 3 platform-specific tests skipped (15 new tests: ring buffer parsing/capacity, log routes incl. auth and level toggling, login-shell error hook)
- Sandbox run against `hack/demo-env.mjs`: verified the complete dial trail in the viewer (connect requested → dialing → host key ok → auth `none` → auth `agent` → ready → session established) and the settings/viewer UI