### PR TITLE
Add font color preference for terminal text

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -241,6 +241,7 @@ function AppearanceSection() {
   const prefs = usePrefsStore();
   const zoomInChord = useChordLabel('terminal.zoom-in');
   const zoomOutChord = useChordLabel('terminal.zoom-out');
+  const schemeForeground = terminalScheme(prefs.terminalScheme).theme.foreground ?? '#cccccc';
 
   return (
     <Stack spacing={3}>
@@ -355,6 +356,45 @@ function AppearanceSection() {
               />
             </Box>
           </Stack>
+          <Box>
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                Font color
+              </Typography>
+              <Box
+                component="input"
+                type="color"
+                aria-label="Font color"
+                value={prefs.fontColor || schemeForeground}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  prefs.set({ fontColor: event.target.value })
+                }
+                sx={{
+                  width: 30,
+                  height: 26,
+                  p: 0.25,
+                  border: 1,
+                  borderColor: 'divider',
+                  borderRadius: 0.75,
+                  bgcolor: 'transparent',
+                  cursor: 'pointer',
+                }}
+              />
+              {prefs.fontColor ? (
+                <Button size="small" onClick={() => prefs.set({ fontColor: '' })}>
+                  Use scheme color
+                </Button>
+              ) : (
+                <Typography variant="caption" color="text.secondary">
+                  Following the color scheme
+                </Typography>
+              )}
+            </Stack>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+              Replaces the scheme's default text color. Output that picks its own
+              ANSI colors keeps the scheme palette.
+            </Typography>
+          </Box>
         </Stack>
       </Box>
     </Stack>

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -43,6 +43,7 @@ import { useTabsStore, type SessionTab } from '../state/tabs.js';
 import {
   TERMINAL_MINIMUM_CONTRAST_RATIO,
   terminalScheme,
+  themeWithFontColor,
 } from '../terminal/palette.js';
 import { attachCommandTracker } from '../terminal/shell-integration.js';
 import {
@@ -156,6 +157,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const cursorStyle = usePrefsStore((s) => s.cursorStyle);
   const scrollback = usePrefsStore((s) => s.scrollback);
   const schemeId = usePrefsStore((s) => s.terminalScheme);
+  const fontColor = usePrefsStore((s) => s.fontColor);
   const globalKeywordHighlights = usePrefsStore((s) => s.keywordHighlights);
   const scheme = terminalScheme(schemeId);
   const { data: sshConfig } = useSshConfig(tab.profile.kind === 'ssh' && tab.profile.useConfig !== false);
@@ -282,7 +284,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       allowProposedApi: true,
       // ImageAddon uses a bottom layer for negative-z Kitty placements.
       allowTransparency: true,
-      theme: terminalScheme(prefs.terminalScheme).theme,
+      theme: themeWithFontColor(terminalScheme(prefs.terminalScheme).theme, prefs.fontColor),
       // ANSI uses the same palette entries for foregrounds and backgrounds,
       // so combinations chosen by remote tools are not always legible in
       // every theme. Let xterm adjust only the rendered foreground as needed.
@@ -882,9 +884,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     term.options.cursorBlink = cursorBlink;
     term.options.cursorStyle = cursorStyle;
     term.options.scrollback = scrollback;
-    term.options.theme = scheme.theme;
+    term.options.theme = themeWithFontColor(scheme.theme, fontColor);
     fitTerminal();
-  }, [monoFontSize, fontFamily, lineHeight, cursorBlink, cursorStyle, scrollback, scheme, generation]);
+  }, [monoFontSize, fontFamily, lineHeight, cursorBlink, cursorStyle, scrollback, scheme, fontColor, generation]);
 
   useEffect(() => {
     keywordHighlighterRef.current?.setRules(keywordHighlights);

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -37,6 +37,7 @@ const PREFERENCE_KEYS = [
   'fontFamily',
   'lineHeight',
   'terminalScheme',
+  'fontColor',
   'scrollback',
   'cursorBlink',
   'cursorStyle',
@@ -572,6 +573,9 @@ export function sanitizePreferences(input: BackupPreferences): Partial<PrefsStat
     input.terminalScheme.length <= 100
   ) {
     output.terminalScheme = input.terminalScheme;
+  }
+  if (input.fontColor === '' || validHexColor(input.fontColor)) {
+    output.fontColor = input.fontColor;
   }
   if (
     Number.isInteger(input.scrollback) &&

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -47,6 +47,8 @@ export interface PrefsState {
   lineHeight: number;
   /** Terminal color scheme id (see terminal/palette.ts). */
   terminalScheme: string;
+  /** Terminal text color; empty follows the color scheme's foreground. */
+  fontColor: string;
   /** Scrollback lines kept per terminal. */
   scrollback: number;
   cursorBlink: boolean;
@@ -161,6 +163,7 @@ export const usePrefsStore = create<PrefsState>()(
       fontFamily: 'JetBrains Mono',
       lineHeight: 1.0,
       terminalScheme: 'vscode-dark',
+      fontColor: '',
       scrollback: 10_000,
       cursorBlink: true,
       cursorStyle: 'block',

--- a/client/src/terminal/palette.ts
+++ b/client/src/terminal/palette.ts
@@ -417,3 +417,13 @@ const DEFAULT_SCHEME = SCHEMES_BY_ID.get('vscode-dark')!;
 export function terminalScheme(id: string | undefined): TerminalScheme {
   return (id === undefined ? undefined : SCHEMES_BY_ID.get(id)) ?? DEFAULT_SCHEME;
 }
+
+/**
+ * The scheme's theme with the user's font color replacing the default
+ * foreground. Only unstyled text changes; ANSI-colored output keeps the
+ * scheme palette. An empty or malformed override leaves the theme alone,
+ * so a stale stored value cannot blank the terminal.
+ */
+export function themeWithFontColor(theme: ITheme, fontColor: string): ITheme {
+  return /^#[0-9a-f]{6}$/i.test(fontColor) ? { ...theme, foreground: fontColor } : theme;
+}

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -202,6 +202,23 @@ describe('restoring sidebar folder preferences', () => {
   });
 });
 
+describe('restoring the font color preference', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores a hex override and the explicit scheme-default empty string', () => {
+    expect(sanitizePreferences(prefs({ fontColor: '#AABB00' }))).toMatchObject({
+      fontColor: '#AABB00',
+    });
+    expect(sanitizePreferences(prefs({ fontColor: '' }))).toMatchObject({ fontColor: '' });
+  });
+
+  it('drops a malformed font color rather than importing it', () => {
+    expect(sanitizePreferences(prefs({ fontColor: 'red' })).fontColor).toBeUndefined();
+    expect(sanitizePreferences(prefs({ fontColor: '#fff' })).fontColor).toBeUndefined();
+    expect(sanitizePreferences(prefs({ fontColor: 42 })).fontColor).toBeUndefined();
+  });
+});
+
 describe('restoring manual folder order', () => {
   const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
 

--- a/tests/unit/client/terminal-palette.test.ts
+++ b/tests/unit/client/terminal-palette.test.ts
@@ -3,6 +3,7 @@ import {
   TERMINAL_MINIMUM_CONTRAST_RATIO,
   TERMINAL_SCHEMES,
   terminalScheme,
+  themeWithFontColor,
 } from '../../../client/src/terminal/palette.js';
 
 const NEW_LIGHT_SCHEME_IDS = [
@@ -89,5 +90,24 @@ describe('terminal palettes', () => {
   it('keeps VS Code dark as the fallback even though light schemes are listed first', () => {
     expect(terminalScheme(undefined).id).toBe('vscode-dark');
     expect(terminalScheme('unknown').id).toBe('vscode-dark');
+  });
+});
+
+describe('themeWithFontColor', () => {
+  const theme = terminalScheme('vscode-dark').theme;
+
+  it('replaces only the foreground when a font color is set', () => {
+    const overridden = themeWithFontColor(theme, '#FF8800');
+
+    expect(overridden.foreground).toBe('#FF8800');
+    expect({ ...overridden, foreground: theme.foreground }).toEqual(theme);
+    // The shared scheme object is never mutated.
+    expect(theme.foreground).toBe('#cccccc');
+  });
+
+  it('leaves the scheme alone for the empty default and malformed values', () => {
+    expect(themeWithFontColor(theme, '')).toBe(theme);
+    expect(themeWithFontColor(theme, 'orange')).toBe(theme);
+    expect(themeWithFontColor(theme, '#ff0')).toBe(theme);
   });
 });


### PR DESCRIPTION
## What

Adds a **Font color** setting to Settings → Appearance → Font: a color picker that overrides the terminal color scheme's default foreground, with a one-click "Use scheme color" reset.

## Behavior

- Only unstyled text changes — output that picks its own ANSI colors keeps the scheme palette, so prompts, `ls` listings and highlighted logs stay intact.
- Applies live to already-open terminals, like every other appearance preference.
- Included in backup/restore; malformed values are dropped by the existing sanitize barrier, and a malformed stored value leaves the scheme untouched rather than blanking the terminal.
- Empty (the default) follows the selected color scheme, so existing setups are unaffected.

## Implementation

- `fontColor` preference in the prefs store (empty string = scheme default).
- `themeWithFontColor()` in `terminal/palette.ts` validates the hex and swaps only `foreground`, leaving the shared scheme objects unmutated.
- Wired into terminal creation and the live-apply effect in `TerminalViewImpl`.

## Testing

- Unit tests for the palette helper and the backup sanitizer.
- Verified end-to-end in the sandbox (`hack/demo-env.mjs`): seeded override colors plain text at open, changing the picker recolors a live session, ANSI prompt colors stay, and reset returns to the scheme foreground.