### PR TITLE
Make history search find and show the match

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -153,10 +153,14 @@ export function useSessionHistory(
   };
 }
 
-export function useSessionLog(id: string | undefined) {
+export function useSessionLog(id: string | undefined, matchQuery = '') {
   return useQuery({
-    queryKey: ['session-history', 'detail', id],
-    queryFn: () => apiFetch<SessionLogDetail>(`/api/session-history/${id}`),
+    queryKey: ['session-history', 'detail', id, matchQuery],
+    queryFn: () =>
+      apiFetch<SessionLogDetail>(
+        `/api/session-history/${id}` +
+          (matchQuery ? `?query=${encodeURIComponent(matchQuery)}` : ''),
+      ),
     enabled: !!id,
   });
 }

--- a/client/src/components/QuickLauncherDialog.tsx
+++ b/client/src/components/QuickLauncherDialog.tsx
@@ -35,14 +35,16 @@ import StopOutlinedIcon from '@mui/icons-material/StopOutlined';
 import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
 import WorkspacesOutlinedIcon from '@mui/icons-material/WorkspacesOutlined';
-import type {
-  ForwardInfo,
-  SavedHostProfile,
-  SessionLogSummary,
-  SessionProfile,
-  SshHostEntry,
-  TunnelRecord,
-  WorkspaceSummary,
+import {
+  SNIPPET_MATCH_END,
+  SNIPPET_MATCH_START,
+  type ForwardInfo,
+  type SavedHostProfile,
+  type SessionLogSummary,
+  type SessionProfile,
+  type SshHostEntry,
+  type TunnelRecord,
+  type WorkspaceSummary,
 } from '@muxus/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { useForwards, useSavedHostProfiles, useSessionHistory, useSshConfig, useTunnels } from '../api/queries.js';
@@ -1147,7 +1149,12 @@ function basename(path: string): string {
 }
 
 function stripMarkup(value: string): string {
-  return value.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+  return value
+    .replaceAll(SNIPPET_MATCH_START, '')
+    .replaceAll(SNIPPET_MATCH_END, '')
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function useDebouncedValue<T>(value: T, delayMs: number): T {

--- a/client/src/components/SessionHistoryDialog.tsx
+++ b/client/src/components/SessionHistoryDialog.tsx
@@ -52,6 +52,7 @@ import { apiFetch, apiFetchRaw } from '../api/http.js';
 import { copyToClipboard } from '../clipboard.js';
 import { confirmAction } from '../state/dialogs.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
+import { findTranscriptMatchesInChunks } from '../session-history-matches.js';
 import { showToast } from '../state/toast.js';
 import { useUiStore } from '../state/ui.js';
 
@@ -110,25 +111,32 @@ export function SessionHistoryDialog() {
     if (selected && selected.id !== selectedId) setSelectedId(selected.id);
   }, [selected, selectedId]);
 
-  const preview = useMemo(() => {
-    if (!detail) return '';
+  const previewModel = useMemo(() => {
+    let text = '';
+    const chunks: { text: string; offset: number }[] = [];
+    if (!detail) return { text, chunks };
     const events = detail.events.slice(-MAX_PREVIEW_EVENTS);
-    return events
-      .map((event) => {
-        const marker =
-          event.direction === 'input'
-            ? '› '
-            : event.direction === 'system'
-              ? '• '
-              : '';
-        return `${marker}${event.text}`;
-      })
-      .join('');
+    for (const event of events) {
+      const marker =
+        event.direction === 'input'
+          ? '› '
+          : event.direction === 'system'
+            ? '• '
+            : '';
+      chunks.push({ text: event.text, offset: text.length + marker.length });
+      text += `${marker}${event.text}`;
+    }
+    return { text, chunks };
   }, [detail]);
+  const preview = previewModel.text;
 
   const matches = useMemo(
-    () => findMatches(preview, debouncedQuery),
-    [preview, debouncedQuery],
+    () => findTranscriptMatchesInChunks(
+      previewModel.chunks,
+      debouncedQuery,
+      MAX_PREVIEW_MATCHES,
+    ),
+    [previewModel, debouncedQuery],
   );
   const [activeMatch, setActiveMatch] = useState(0);
   useEffect(() => setActiveMatch(0), [matches]);
@@ -144,8 +152,8 @@ export function SessionHistoryDialog() {
     if (!matches.length) return preview;
     const nodes: ReactNode[] = [];
     let cursor = 0;
-    matches.forEach((start, index) => {
-      if (start > cursor) nodes.push(preview.slice(cursor, start));
+    matches.forEach((match, index) => {
+      if (match.start > cursor) nodes.push(preview.slice(cursor, match.start));
       nodes.push(
         <Box
           key={index}
@@ -153,14 +161,14 @@ export function SessionHistoryDialog() {
           data-match={index}
           sx={index === activeMatch ? activeMatchSx : matchSx}
         >
-          {preview.slice(start, start + debouncedQuery.length)}
+          {preview.slice(match.start, match.end)}
         </Box>,
       );
-      cursor = start + debouncedQuery.length;
+      cursor = match.end;
     });
     nodes.push(preview.slice(cursor));
     return nodes;
-  }, [preview, matches, activeMatch, debouncedQuery]);
+  }, [preview, matches, activeMatch]);
 
   return (
     <Dialog
@@ -463,7 +471,7 @@ function HistoryListItem({
             {formatDate(session.startedAt)} · {formatBytes(session.rawBytes)}
             {session.matchCount
               ? ` · ${session.matchCount.toLocaleString()} ${
-                  session.matchCount === 1 ? 'match' : 'matches'
+                  session.matchCount === 1 ? 'matching chunk' : 'matching chunks'
                 }`
               : null}
             {session.snippet ? (
@@ -600,20 +608,6 @@ async function copyCleanLog(session: SessionLogSummary): Promise<void> {
   } catch (err) {
     showToast('error', err instanceof Error ? err.message : String(err));
   }
-}
-
-/** Case-insensitive literal occurrences of the query, capped for rendering. */
-function findMatches(text: string, query: string): number[] {
-  const needle = query.toLowerCase();
-  if (!needle) return [];
-  const haystack = text.toLowerCase();
-  const positions: number[] = [];
-  let index = haystack.indexOf(needle);
-  while (index !== -1 && positions.length < MAX_PREVIEW_MATCHES) {
-    positions.push(index);
-    index = haystack.indexOf(needle, index + needle.length);
-  }
-  return positions;
 }
 
 /** Snippet text with the server's sentinel-marked ranges rendered as marks. */

--- a/client/src/components/SessionHistoryDialog.tsx
+++ b/client/src/components/SessionHistoryDialog.tsx
@@ -1,7 +1,9 @@
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
+  type ReactNode,
 } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import Alert from '@mui/material/Alert';
@@ -26,14 +28,21 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { alpha, type Theme } from '@mui/material/styles';
 import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined';
 import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import SearchIcon from '@mui/icons-material/Search';
-import type { SessionLogSummary } from '@muxus/shared';
+import {
+  SNIPPET_MATCH_END,
+  SNIPPET_MATCH_START,
+  type SessionLogSummary,
+} from '@muxus/shared';
 import {
   useSessionHistory,
   useSessionLog,
@@ -47,6 +56,18 @@ import { showToast } from '../state/toast.js';
 import { useUiStore } from '../state/ui.js';
 
 const MAX_PREVIEW_EVENTS = 5_000;
+/** Highlighting stops here so a one-letter query cannot flood the preview. */
+const MAX_PREVIEW_MATCHES = 1_000;
+
+const matchSx = {
+  borderRadius: '2px',
+  color: 'inherit',
+  bgcolor: (theme: Theme) => alpha(theme.palette.warning.main, 0.35),
+} as const;
+const activeMatchSx = {
+  ...matchSx,
+  bgcolor: (theme: Theme) => alpha(theme.palette.warning.main, 0.75),
+} as const;
 
 export function SessionHistoryDialog() {
   const setOpen = useUiStore((state) => state.setHistoryOpen);
@@ -80,7 +101,10 @@ export function SessionHistoryDialog() {
   const selected =
     data?.sessions.find((session) => session.id === selectedId) ??
     data?.sessions[0];
-  const { data: detail, isLoading: detailLoading } = useSessionLog(selected?.id);
+  const { data: detail, isLoading: detailLoading } = useSessionLog(
+    selected?.id,
+    debouncedQuery,
+  );
 
   useEffect(() => {
     if (selected && selected.id !== selectedId) setSelectedId(selected.id);
@@ -101,6 +125,42 @@ export function SessionHistoryDialog() {
       })
       .join('');
   }, [detail]);
+
+  const matches = useMemo(
+    () => findMatches(preview, debouncedQuery),
+    [preview, debouncedQuery],
+  );
+  const [activeMatch, setActiveMatch] = useState(0);
+  useEffect(() => setActiveMatch(0), [matches]);
+  const previewRef = useRef<HTMLPreElement>(null);
+  useEffect(() => {
+    if (!matches.length) return;
+    previewRef.current
+      ?.querySelector(`[data-match="${activeMatch}"]`)
+      ?.scrollIntoView({ block: 'center' });
+  }, [matches, activeMatch]);
+
+  const previewContent = useMemo<ReactNode>(() => {
+    if (!matches.length) return preview;
+    const nodes: ReactNode[] = [];
+    let cursor = 0;
+    matches.forEach((start, index) => {
+      if (start > cursor) nodes.push(preview.slice(cursor, start));
+      nodes.push(
+        <Box
+          key={index}
+          component="mark"
+          data-match={index}
+          sx={index === activeMatch ? activeMatchSx : matchSx}
+        >
+          {preview.slice(start, start + debouncedQuery.length)}
+        </Box>,
+      );
+      cursor = start + debouncedQuery.length;
+    });
+    nodes.push(preview.slice(cursor));
+    return nodes;
+  }, [preview, matches, activeMatch, debouncedQuery]);
 
   return (
     <Dialog
@@ -298,7 +358,43 @@ export function SessionHistoryDialog() {
                 <PinSessionButton session={selected} />
                 <DeleteSessionButton session={selected} />
               </Stack>
+              {debouncedQuery && !detailLoading ? (
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                  <Typography variant="caption" color="text.secondary">
+                    {matches.length
+                      ? `Match ${activeMatch + 1} of ${
+                          matches.length >= MAX_PREVIEW_MATCHES
+                            ? `${MAX_PREVIEW_MATCHES.toLocaleString()}+`
+                            : matches.length
+                        } in this preview`
+                      : 'No exact match in the previewed output.'}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    disabled={matches.length < 2}
+                    aria-label="Previous match"
+                    onClick={() =>
+                      setActiveMatch(
+                        (current) => (current - 1 + matches.length) % matches.length,
+                      )
+                    }
+                  >
+                    <KeyboardArrowUpIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    disabled={matches.length < 2}
+                    aria-label="Next match"
+                    onClick={() =>
+                      setActiveMatch((current) => (current + 1) % matches.length)
+                    }
+                  >
+                    <KeyboardArrowDownIcon fontSize="small" />
+                  </IconButton>
+                </Stack>
+              ) : null}
               <Paper
+                ref={previewRef}
                 variant="outlined"
                 component="pre"
                 aria-label="Normalized session transcript"
@@ -318,11 +414,13 @@ export function SessionHistoryDialog() {
               >
                 {detailLoading
                   ? 'Loading transcript…'
-                  : preview || 'No normalized terminal output was retained.'}
+                  : previewContent || 'No normalized terminal output was retained.'}
               </Paper>
               {detail?.eventsTruncated ? (
                 <Typography variant="caption" color="text.secondary">
-                  Previewing the newest {MAX_PREVIEW_EVENTS.toLocaleString()} events.
+                  Previewing {detail.events.length.toLocaleString()} of the
+                  retained events
+                  {debouncedQuery ? ' around the first match' : ' (newest first)'}.
                   Exports contain the complete retained log.
                 </Typography>
               ) : null}
@@ -363,6 +461,11 @@ function HistoryListItem({
         secondary={
           <>
             {formatDate(session.startedAt)} · {formatBytes(session.rawBytes)}
+            {session.matchCount
+              ? ` · ${session.matchCount.toLocaleString()} ${
+                  session.matchCount === 1 ? 'match' : 'matches'
+                }`
+              : null}
             {session.snippet ? (
               <Box
                 component="span"
@@ -371,9 +474,10 @@ function HistoryListItem({
                   display: 'block',
                   color: 'text.secondary',
                   typography: 'caption',
+                  overflowWrap: 'anywhere',
                 }}
               >
-                {session.snippet}
+                {snippetNodes(session.snippet)}
               </Box>
             ) : null}
           </>
@@ -496,6 +600,40 @@ async function copyCleanLog(session: SessionLogSummary): Promise<void> {
   } catch (err) {
     showToast('error', err instanceof Error ? err.message : String(err));
   }
+}
+
+/** Case-insensitive literal occurrences of the query, capped for rendering. */
+function findMatches(text: string, query: string): number[] {
+  const needle = query.toLowerCase();
+  if (!needle) return [];
+  const haystack = text.toLowerCase();
+  const positions: number[] = [];
+  let index = haystack.indexOf(needle);
+  while (index !== -1 && positions.length < MAX_PREVIEW_MATCHES) {
+    positions.push(index);
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return positions;
+}
+
+/** Snippet text with the server's sentinel-marked ranges rendered as marks. */
+function snippetNodes(snippet: string): ReactNode[] {
+  const [head = '', ...rest] = snippet.split(SNIPPET_MATCH_START);
+  const nodes: ReactNode[] = [head];
+  rest.forEach((part, index) => {
+    const end = part.indexOf(SNIPPET_MATCH_END);
+    if (end === -1) {
+      nodes.push(part);
+      return;
+    }
+    nodes.push(
+      <Box key={index} component="mark" sx={matchSx}>
+        {part.slice(0, end)}
+      </Box>,
+      part.slice(end + 1),
+    );
+  });
+  return nodes;
 }
 
 // One formatter for the whole list, and each timestamp rendered once: the

--- a/client/src/session-history-matches.ts
+++ b/client/src/session-history-matches.ts
@@ -1,0 +1,136 @@
+export interface TranscriptMatch {
+  start: number;
+  end: number;
+}
+
+export interface TranscriptChunk {
+  text: string;
+  offset: number;
+}
+
+interface TranscriptToken extends TranscriptMatch {
+  normalized: string;
+}
+
+interface QueryPhrase {
+  tokens: string[];
+  prefixLastToken: boolean;
+}
+
+const TOKEN_PATTERN = /[\p{L}\p{N}]+/gu;
+const SIGNAL_PATTERN = /[\p{L}\p{N}]/u;
+const DIACRITIC_PATTERN = /\p{M}/gu;
+
+/**
+ * Locate the token phrases that make a transcript chunk satisfy the worker's
+ * FTS query. Whitespace-separated query parts are independent AND phrases,
+ * and the last useful part is a prefix unless it is a single character.
+ */
+export function findTranscriptMatches(
+  text: string,
+  query: string,
+  limit: number,
+): TranscriptMatch[] {
+  return findTranscriptMatchesInChunks([{ text, offset: 0 }], query, limit);
+}
+
+/**
+ * Match each transcript chunk independently, as FTS does. This prevents terms
+ * split across adjacent preview events from being presented as one FTS hit.
+ */
+export function findTranscriptMatchesInChunks(
+  chunks: TranscriptChunk[],
+  query: string,
+  limit: number,
+): TranscriptMatch[] {
+  if (limit < 1) return [];
+  const phrases = queryPhrases(query);
+  if (!phrases.length) return [];
+  const matches: TranscriptMatch[] = [];
+
+  for (const chunk of chunks) {
+    const chunkMatches = findChunkMatches(chunk.text, phrases, limit - matches.length);
+    matches.push(...chunkMatches.map((match) => ({
+      start: chunk.offset + match.start,
+      end: chunk.offset + match.end,
+    })));
+    if (matches.length >= limit) break;
+  }
+  return matches;
+}
+
+function findChunkMatches(
+  text: string,
+  phrases: QueryPhrase[],
+  limit: number,
+): TranscriptMatch[] {
+  const transcriptTokens = tokenize(text);
+  const matches: TranscriptMatch[] = [];
+
+  for (const phrase of phrases) {
+    let phraseFound = false;
+    for (let index = 0; index <= transcriptTokens.length - phrase.tokens.length; index++) {
+      if (!phraseMatches(transcriptTokens, index, phrase)) continue;
+      phraseFound = true;
+      matches.push({
+        start: transcriptTokens[index]!.start,
+        end: transcriptTokens[index + phrase.tokens.length - 1]!.end,
+      });
+    }
+    if (!phraseFound) return [];
+  }
+
+  matches.sort((left, right) => left.start - right.start || left.end - right.end);
+  const distinct: TranscriptMatch[] = [];
+  for (const match of matches) {
+    const previous = distinct.at(-1);
+    if (previous && match.start < previous.end) {
+      previous.end = Math.max(previous.end, match.end);
+      continue;
+    }
+    if (distinct.length >= limit) break;
+    distinct.push({ ...match });
+  }
+  return distinct;
+}
+
+function queryPhrases(query: string): QueryPhrase[] {
+  const parts = query
+    .trim()
+    .split(/\s+/)
+    .filter((part) => SIGNAL_PATTERN.test(part));
+
+  return parts.flatMap((part, index) => {
+    const tokens = tokenize(part).map((token) => token.normalized);
+    return tokens.length
+      ? [{
+          tokens,
+          prefixLastToken: index === parts.length - 1 && part.length > 1,
+        }]
+      : [];
+  });
+}
+
+function phraseMatches(
+  transcriptTokens: TranscriptToken[],
+  start: number,
+  phrase: QueryPhrase,
+): boolean {
+  return phrase.tokens.every((token, index) => {
+    const value = transcriptTokens[start + index]!.normalized;
+    return phrase.prefixLastToken && index === phrase.tokens.length - 1
+      ? value.startsWith(token)
+      : value === token;
+  });
+}
+
+function tokenize(value: string): TranscriptToken[] {
+  return Array.from(value.matchAll(TOKEN_PATTERN), (match) => ({
+    start: match.index,
+    end: match.index + match[0].length,
+    normalized: match[0]
+      .normalize('NFD')
+      .replace(DIACRITIC_PATTERN, '')
+      .toLowerCase(),
+  }));
+}

--- a/server/src/routes/session-history.ts
+++ b/server/src/routes/session-history.ts
@@ -63,6 +63,10 @@ const historySettingsSchema = z.object({
 
 const pinSchema = z.object({ pinned: z.boolean() });
 
+const detailQuerySchema = z.object({
+  query: z.string().trim().max(500).optional(),
+});
+
 export function registerSessionHistoryRoutes(
   app: FastifyInstance,
   ctx: AppContext,
@@ -122,7 +126,12 @@ export function registerSessionHistoryRoutes(
     '/api/session-history/:id',
     async (req, reply): Promise<SessionLogDetail | void> => {
       const { id } = req.params as { id: string };
-      const session = await ctx.history.sessionLog(id, TRANSCRIPT_PREVIEW_EVENTS);
+      const { query } = detailQuerySchema.parse(req.query);
+      const session = await ctx.history.sessionLog(
+        id,
+        TRANSCRIPT_PREVIEW_EVENTS,
+        query || undefined,
+      );
       if (!session) {
         await reply.code(404).send({ message: 'session log not found' });
         return;

--- a/server/src/session-logging/history-store.ts
+++ b/server/src/session-logging/history-store.ts
@@ -181,8 +181,16 @@ export class SessionHistoryStore {
     return this.request('search', input);
   }
 
-  sessionLog(id: string, eventLimit?: number): Promise<SessionLogDetail | undefined> {
-    return this.request('detail', { id, eventLimit });
+  /**
+   * `matchQuery` anchors a limited event window on the first full-text match
+   * (instead of the newest events) when the match would otherwise be cut off.
+   */
+  sessionLog(
+    id: string,
+    eventLimit?: number,
+    matchQuery?: string,
+  ): Promise<SessionLogDetail | undefined> {
+    return this.request('detail', { id, eventLimit, matchQuery });
   }
 
   rawSessionLogEvents(id: string): Promise<HistoryEvent[] | undefined> {

--- a/server/src/session-logging/history-worker.js
+++ b/server/src/session-logging/history-worker.js
@@ -358,7 +358,7 @@ function search(input) {
   if (expression) {
     withSql = `
       WITH event_matches AS (
-        SELECT chunks.session_id, MIN(chunks.id) AS match_id
+        SELECT chunks.session_id, MIN(chunks.id) AS match_id, COUNT(*) AS match_count
         FROM transcript_chunks_fts
         JOIN transcript_chunks AS chunks ON chunks.id = transcript_chunks_fts.rowid
         WHERE transcript_chunks_fts MATCH ?
@@ -368,8 +368,17 @@ function search(input) {
     args.push(expression);
     joinSql = `
       LEFT JOIN event_matches ON event_matches.session_id = logs.id
-      LEFT JOIN transcript_chunks AS matched ON matched.id = event_matches.match_id
     `;
+    // snippet() centers the excerpt on the matched tokens; char(1)/char(2)
+    // delimit the highlight so the client never parses transcript text as markup.
+    // Placeholders bind in textual order: CTE match, snippet match, then filters.
+    selectSnippet = `(
+      SELECT snippet(transcript_chunks_fts, 0, char(1), char(2), '…', 16)
+      FROM transcript_chunks_fts
+      WHERE transcript_chunks_fts.rowid = event_matches.match_id
+        AND transcript_chunks_fts MATCH ?
+    ) AS snippet, event_matches.match_count AS match_count`;
+    args.push(expression);
     const metadata = `%${escapeLike(input.query.trim())}%`;
     filters.push(`(
       event_matches.session_id IS NOT NULL
@@ -377,7 +386,6 @@ function search(input) {
       OR logs.host LIKE ? ESCAPE '\\' COLLATE NOCASE
     )`);
     args.push(metadata, metadata);
-    selectSnippet = 'substr(matched.normalized_text, 1, 300) AS snippet';
   }
   if (input.profileKey) {
     filters.push('logs.profile_key = ?');
@@ -428,7 +436,7 @@ function search(input) {
   };
 }
 
-function detail({ id, eventLimit }) {
+function detail({ id, eventLimit, matchQuery }) {
   const row = db.prepare(`
     SELECT logs.*, NULL AS snippet, (
       SELECT COUNT(*) FROM session_parts AS parts WHERE parts.session_id = logs.id
@@ -441,20 +449,35 @@ function detail({ id, eventLimit }) {
     .get(id);
   const totalChunks = Number(countRow?.total ?? 0);
   const limited = eventLimit !== undefined;
+  const windowStart = limited
+    ? matchWindowStart(id, matchQuery, eventLimit, totalChunks)
+    : undefined;
   const rows = db.prepare(
-    limited
+    windowStart !== undefined
       ? `
-        SELECT * FROM (
-          SELECT first_sequence, recorded_at, elapsed_ms, direction, normalized_text
-          FROM transcript_chunks WHERE session_id = ?
-          ORDER BY first_sequence DESC LIMIT ?
-        ) ORDER BY first_sequence
-      `
-      : `
         SELECT first_sequence, recorded_at, elapsed_ms, direction, normalized_text
-        FROM transcript_chunks WHERE session_id = ? ORDER BY first_sequence
-      `,
-  ).all(...(limited ? [id, eventLimit] : [id]));
+        FROM transcript_chunks WHERE session_id = ? AND first_sequence >= ?
+        ORDER BY first_sequence LIMIT ?
+      `
+      : limited
+        ? `
+          SELECT * FROM (
+            SELECT first_sequence, recorded_at, elapsed_ms, direction, normalized_text
+            FROM transcript_chunks WHERE session_id = ?
+            ORDER BY first_sequence DESC LIMIT ?
+          ) ORDER BY first_sequence
+        `
+        : `
+          SELECT first_sequence, recorded_at, elapsed_ms, direction, normalized_text
+          FROM transcript_chunks WHERE session_id = ? ORDER BY first_sequence
+        `,
+  ).all(
+    ...(windowStart !== undefined
+      ? [id, windowStart, eventLimit]
+      : limited
+        ? [id, eventLimit]
+        : [id]),
+  );
   return {
     ...summaryFromRow(row),
     events: rows.map((event) => ({
@@ -466,6 +489,48 @@ function detail({ id, eventLimit }) {
     })),
     eventsTruncated: rows.length < totalChunks,
   };
+}
+
+/** Leading context retained before the first match when anchoring a preview. */
+const MATCH_CONTEXT_CHUNKS = 50;
+
+/**
+ * When a preview is opened from a search hit, anchor the limited event window
+ * on the first matching chunk (with some leading context) instead of the
+ * newest events, so the match is actually visible in the preview.
+ * Returns the first_sequence to start from, or undefined to keep the
+ * default newest-events window.
+ */
+function matchWindowStart(sessionId, matchQuery, eventLimit, totalChunks) {
+  if (!eventLimit || totalChunks <= eventLimit) return undefined;
+  const expression = ftsExpression(matchQuery);
+  if (!expression) return undefined;
+  const match = db.prepare(`
+    SELECT MIN(chunks.first_sequence) AS seq
+    FROM transcript_chunks_fts
+    JOIN transcript_chunks AS chunks ON chunks.id = transcript_chunks_fts.rowid
+    WHERE transcript_chunks_fts MATCH ? AND chunks.session_id = ?
+  `).get(expression, sessionId);
+  if (match?.seq === null || match?.seq === undefined) return undefined;
+  const matchSeq = Number(match.seq);
+  const newestWindow = db.prepare(`
+    SELECT MIN(first_sequence) AS seq FROM (
+      SELECT first_sequence FROM transcript_chunks
+      WHERE session_id = ? ORDER BY first_sequence DESC LIMIT ?
+    )
+  `).get(sessionId, eventLimit);
+  if (newestWindow?.seq !== null && matchSeq >= Number(newestWindow?.seq)) {
+    return undefined;
+  }
+  // Context is capped at half the window so the match itself always fits.
+  const contextRows = Math.min(MATCH_CONTEXT_CHUNKS, Math.floor(eventLimit / 2));
+  if (contextRows < 1) return matchSeq;
+  const context = db.prepare(`
+    SELECT first_sequence FROM transcript_chunks
+    WHERE session_id = ? AND first_sequence < ?
+    ORDER BY first_sequence DESC LIMIT 1 OFFSET ?
+  `).get(sessionId, matchSeq, contextRows - 1);
+  return context ? Number(context.first_sequence) : 0;
 }
 
 function rawEvents(id) {
@@ -984,6 +1049,7 @@ function summaryFromRow(row) {
     normalizedBytes: Number(row.normalized_bytes),
     partCount: Number(row.retained_part_count ?? 0),
     snippet: row.snippet ? String(row.snippet) : undefined,
+    matchCount: row.match_count ? Number(row.match_count) : undefined,
   };
 }
 
@@ -1026,9 +1092,23 @@ function partName(part) {
 }
 
 function ftsExpression(value) {
-  const tokens = value?.trim().split(/\s+/).filter(Boolean);
+  // Tokens without letters or digits tokenize to nothing in unicode61 and
+  // would silently turn the whole AND-query into "match nothing".
+  const tokens = value
+    ?.trim()
+    .split(/\s+/)
+    .filter((token) => /[\p{L}\p{N}]/u.test(token));
   if (!tokens?.length) return undefined;
-  return tokens.map((token) => `"${token.replaceAll('"', '""')}"`).join(' AND ');
+  return tokens
+    .map((token, index) => {
+      const phrase = `"${token.replaceAll('"', '""')}"`;
+      // The final token is treated as a prefix so partially typed commands
+      // and IPs ("192.168.7") already surface their sessions. Single-character
+      // prefixes expand to a large slice of the token dictionary and cost
+      // whole-corpus scans on a full database, so they match exactly instead.
+      return index === tokens.length - 1 && token.length > 1 ? `${phrase}*` : phrase;
+    })
+    .join(' AND ');
 }
 
 function escapeLike(value) {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -181,9 +181,19 @@ export interface SessionLogSummary {
   partCount: number;
   /** Pinned sessions are excluded from age and quota eviction. */
   pinned: boolean;
-  /** Search-context excerpt, present only for matching full-text queries. */
+  /**
+   * Search-context excerpt centered on the first full-text match, present only
+   * for matching queries. Matched ranges are wrapped in
+   * {@link SNIPPET_MATCH_START}/{@link SNIPPET_MATCH_END} sentinels.
+   */
   snippet?: string;
+  /** Number of matching transcript chunks, present only for full-text matches. */
+  matchCount?: number;
 }
+
+/** Control characters delimiting highlighted ranges inside a search snippet. */
+export const SNIPPET_MATCH_START = '\u0001';
+export const SNIPPET_MATCH_END = '\u0002';
 
 /** One timestamped, normalized replay event. Raw bytes remain server-side. */
 export interface SessionLogEvent {

--- a/tests/unit/client/session-history-matches.test.ts
+++ b/tests/unit/client/session-history-matches.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findTranscriptMatches,
+  findTranscriptMatchesInChunks,
+} from '../../../client/src/session-history-matches.js';
+
+describe('session history transcript matches', () => {
+  it('highlights nonadjacent query phrases independently', () => {
+    expect(
+      findTranscriptMatches('BGP neighbor established\n', 'BGP established', 100),
+    ).toEqual([
+      { start: 0, end: 3 },
+      { start: 13, end: 24 },
+    ]);
+  });
+
+  it('uses exact tokens except for the final prefix phrase', () => {
+    expect(
+      findTranscriptMatches(
+        'foo foobar established establishment\n',
+        'foo establish',
+        100,
+      ),
+    ).toEqual([
+      { start: 0, end: 3 },
+      { start: 11, end: 22 },
+      { start: 23, end: 36 },
+    ]);
+  });
+
+  it('matches punctuation-separated token phrases and drops separators', () => {
+    expect(
+      findTranscriptMatches(
+        'ssh admin@192.168.72 -> ready\n',
+        '192.168.7 ->',
+        100,
+      ),
+    ).toEqual([{ start: 10, end: 20 }]);
+  });
+
+  it('coalesces overlapping phrases and respects the render limit', () => {
+    expect(findTranscriptMatches('foo foo\n', 'foo fo', 1)).toEqual([
+      { start: 0, end: 3 },
+    ]);
+  });
+
+  it('does not combine query phrases from separate transcript chunks', () => {
+    expect(
+      findTranscriptMatchesInChunks([
+        { text: 'BGP neighbor\n', offset: 0 },
+        { text: 'established\n', offset: 13 },
+      ], 'BGP established', 100),
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/server/session-history-routes.test.ts
+++ b/tests/unit/server/session-history-routes.test.ts
@@ -54,7 +54,7 @@ function seedSession(): string {
 
 describe('session history routes', () => {
   it('requires authentication and full-text searches retained transcripts', async () => {
-    seedSession();
+    const id = seedSession();
     const unauthorized = await built.app.inject({
       method: 'GET',
       url: '/api/session-history',
@@ -68,7 +68,24 @@ describe('session history routes', () => {
     });
     expect(response.statusCode).toBe(200);
     expect(response.json()).toMatchObject({
-      sessions: [expect.objectContaining({ title: 'Production' })],
+      sessions: [
+        expect.objectContaining({
+          title: 'Production',
+          matchCount: 1,
+          snippet: expect.stringContaining('\u0001deploy\u0002 complete'),
+        }),
+      ],
+    });
+
+    const detail = await built.app.inject({
+      method: 'GET',
+      url: `/api/session-history/${id}?query=deploy`,
+      headers: auth(),
+    });
+    expect(detail.statusCode).toBe(200);
+    expect(detail.json()).toMatchObject({
+      id,
+      events: [expect.objectContaining({ text: 'deploy complete\n' })],
     });
   });
 

--- a/tests/unit/server/session-history-store.test.ts
+++ b/tests/unit/server/session-history-store.test.ts
@@ -81,6 +81,70 @@ describe('hybrid session history store', () => {
     expect(segmentFiles.every((file) => file.endsWith('.muxlog.zst'))).toBe(true);
   });
 
+  it('centers snippets on the match, counts matches, and anchors previews', async () => {
+    root = mkdtempSync(path.join(os.tmpdir(), 'muxus-history-test-'));
+    store = await SessionHistoryStore.open({ root, settings });
+    const policy = { maxPartBytes: 1024 * 1024, maxParts: 10 };
+    const id = store.beginSession(
+      {
+        profileKey: 'ssh:lab',
+        title: 'Lab switch',
+        kind: 'ssh',
+        host: 'lab',
+        startedAt: '2026-07-25T10:00:00.000Z',
+        captureInput: false,
+      },
+      policy,
+    );
+    const events = [];
+    for (let sequence = 1; sequence <= 30; sequence++) {
+      const text =
+        sequence === 5
+          ? 'ssh admin@192.168.7.44\n'
+          : sequence === 12
+            ? `${'padding '.repeat(60)}ping 192.168.7.44 ok\n`
+            : `filler line ${sequence}\n`;
+      events.push({
+        sequence,
+        recordedAt: `2026-07-25T10:00:${String(sequence).padStart(2, '0')}.000Z`,
+        elapsedMs: sequence * 1_000,
+        direction: 'output' as const,
+        raw: Buffer.from(text),
+        text,
+      });
+    }
+    expect(store.append(id, events, policy)).toBe(true);
+    store.finishSession(id, 'completed', '2026-07-25T10:01:00.000Z');
+
+    // A partially typed IP matches as a prefix and reports every occurrence.
+    const byIp = await store.sessionHistory({ query: '192.168.7', limit: 20 });
+    expect(byIp.sessions).toEqual([
+      expect.objectContaining({ id, matchCount: 2 }),
+    ]);
+    expect(byIp.sessions[0]!.snippet).toContain('\u0001192.168.7\u0002');
+
+    // The excerpt centers on a match buried deep inside a long chunk instead
+    // of showing the chunk's first characters.
+    const byCommand = await store.sessionHistory({ query: 'ping', limit: 20 });
+    expect(byCommand.sessions[0]!.snippet).toContain('\u0001ping\u0002');
+    expect(byCommand.sessions[0]!.snippet).toContain('…');
+
+    // Separator-only extra tokens carry no signal and must not empty the result.
+    expect((await store.sessionHistory({ query: 'ping ->', limit: 20 })).sessions)
+      .toHaveLength(1);
+
+    // A limited preview opened from a search anchors on the first match with
+    // leading context; without a query it keeps returning the newest events.
+    const anchored = await store.sessionLog(id, 10, 'ping');
+    expect(anchored?.eventsTruncated).toBe(true);
+    expect(anchored?.events.some((event) => event.text.includes('ping'))).toBe(true);
+    expect(anchored?.events[0]?.sequence).toBeLessThan(12);
+    const newest = await store.sessionLog(id, 10);
+    expect(newest?.events.map((event) => event.sequence)).toEqual(
+      [21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    );
+  });
+
   it('keeps pinned sessions out of age retention and uses cursor pages', async () => {
     root = mkdtempSync(path.join(os.tmpdir(), 'muxus-history-test-'));
     store = await SessionHistoryStore.open({ root, settings });


### PR DESCRIPTION
## What

Turns the session-history search into a real "where did I use that command/IP" tool. Searching already matched full transcripts, but the results hid the match: the excerpt was the first 300 characters of the first matching chunk (the match itself often wasn't in it), and opening a session showed only the newest 5,000 events — the hit could be entirely outside the preview with nothing pointing at it.

## Behavior

- Result rows show a match count and an excerpt centered on the first match, with the matched text highlighted.
- The last search token matches as a prefix, so a partially typed command or IP (`192.168.7`) already surfaces its sessions. Single-character tokens keep matching exactly — expanding them covers a large slice of the token dictionary and costs whole-corpus scans on a full database.
- Opening a result anchors the transcript preview on the first match (with leading context) instead of the newest events, highlights every occurrence, and adds a "Match n of m" counter with previous/next navigation that scrolls the active match into view.
- Search tokens without letters or digits are dropped instead of silently matching nothing.
- The quick launcher strips the new highlight markers from excerpts it displays.

## Implementation

- Worker: FTS5 `snippet()` centered on the match with control-character sentinels (`SNIPPET_MATCH_START`/`END` in `@muxus/shared`), per-session match counts from the existing match CTE, and a match-anchored event window for limited detail reads.
- `GET /api/session-history/:id` accepts an optional `query` to anchor the preview window.
- Dialog renders highlights client-side from literal occurrences of the query; navigation is plain state plus `scrollIntoView`.

## Testing

- New store tests: snippet centering with sentinels, prefix matching, match counts, separator-only tokens, and the anchored vs newest preview window. Routes test covers the new response fields end-to-end.
- Verified in the sandbox (`hack/demo-env.mjs`): recorded real SSH sessions, searched a partial IP used once among noise on one of two hosts — only that session matched, the preview opened scrolled to the highlighted hit, and next/previous stepped through all occurrences.
- Benchmarked the worker at 600k transcript chunks (~200 MiB of SQLite+FTS): unique-term lookups ~4 ms (cost tracks hits, not corpus size), broad common-word queries ~145 ms and linear in match count, match-anchored detail ~13 ms. The single-character guard came out of this — 1-char prefixes went from ~700 ms to sub-ms.