### PR TITLE
Notify tabs about background terminal output

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -79,9 +79,13 @@ const initialKeys = collectStaticGraph(entry[0]);
 // mirror — adds ~1 KiB raw / ~0.4 KiB gzip to the keymap and the multi-exec
 // store, both of which the first paint already carries, and the gzip budget
 // moves to cover it.
+//
+// Background-output notifications also live in the tab store and tab strip,
+// both of which are required for first paint. The gzip budget moves by 1 KiB
+// to cover their state and visual treatment.
 check('Initial JavaScript', measureGraph(initialKeys), {
   raw: 782_000,
-  gzip: 251_000,
+  gzip: 252_000,
 });
 
 for (const feature of [

--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -72,6 +72,7 @@ export function TabStrip({
   zoomed: boolean;
 }) {
   const allTabs = useTabsStore((s) => s.tabs);
+  const unreadOutputIds = useTabsStore((s) => s.unreadOutputIds);
   const tabs = allTabs.filter((tab) => tab.paneId === paneId);
   const activeId = useTabsStore((s) => findPane(s.root, paneId)?.activeTabId ?? null);
   const canClosePane = useTabsStore((s) => s.root.type === 'split');
@@ -148,6 +149,7 @@ export function TabStrip({
     >
       {tabs.map((tab) => {
         const active = tab.id === activeId;
+        const hasUnreadOutput = unreadOutputIds.has(tab.id);
         const TabIcon =
           tab.profile === null
             ? AddIcon
@@ -160,6 +162,7 @@ export function TabStrip({
             direction="row"
             role="tab"
             aria-selected={active}
+            aria-label={hasUnreadOutput ? `${tab.title}, new terminal output` : tab.title}
             tabIndex={0}
             onClick={() => activate(tab.id)}
             onKeyDown={(e) => {
@@ -190,11 +193,17 @@ export function TabStrip({
               borderColor: 'divider',
               borderTop: 2,
               borderTopColor: tab.color ?? 'transparent',
-              bgcolor: active ? 'background.default' : 'transparent',
+              bgcolor: active
+                ? 'background.default'
+                : hasUnreadOutput
+                  ? alpha(theme.palette.info.main, 0.12)
+                  : 'transparent',
               borderBottom: active ? 'none' : undefined,
               backgroundImage: active && focused
                 ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.1)}, transparent 72%)`
-                : 'none',
+                : hasUnreadOutput
+                  ? `linear-gradient(180deg, ${alpha(theme.palette.info.main, 0.12)}, transparent 80%)`
+                  : 'none',
               transition: theme.transitions.create(['background-color', 'color'], {
                 duration: theme.transitions.duration.shortest,
               }),
@@ -206,10 +215,13 @@ export function TabStrip({
                 bottom: 0,
                 height: 2,
                 borderRadius: '2px 2px 0 0',
-                bgcolor: 'primary.main',
-                boxShadow: `0 -1px 8px ${alpha(theme.palette.primary.main, 0.32)}`,
-                opacity: active && focused ? 1 : 0,
-                transform: active && focused ? 'scaleX(1)' : 'scaleX(0.55)',
+                bgcolor: hasUnreadOutput ? 'info.main' : 'primary.main',
+                boxShadow: `0 -1px 8px ${alpha(
+                  hasUnreadOutput ? theme.palette.info.main : theme.palette.primary.main,
+                  0.32,
+                )}`,
+                opacity: (active && focused) || hasUnreadOutput ? 1 : 0,
+                transform: (active && focused) || hasUnreadOutput ? 'scaleX(1)' : 'scaleX(0.55)',
                 transition: theme.transitions.create(['opacity', 'transform'], {
                   duration: theme.transitions.duration.shortest,
                 }),
@@ -221,7 +233,34 @@ export function TabStrip({
               '&:hover .muxus-tab-close': { visibility: 'visible' },
             })}
           >
-            <TabIcon sx={{ fontSize: 15, color: active && focused ? 'primary.main' : 'text.secondary' }} />
+            <Box component="span" sx={{ position: 'relative', display: 'flex', flexShrink: 0 }}>
+              <TabIcon
+                sx={{
+                  fontSize: 15,
+                  color: hasUnreadOutput
+                    ? 'info.main'
+                    : active && focused
+                      ? 'primary.main'
+                      : 'text.secondary',
+                }}
+              />
+              {hasUnreadOutput ? (
+                <Box
+                  component="span"
+                  aria-label="New terminal output"
+                  sx={{
+                    position: 'absolute',
+                    top: -2,
+                    right: -3,
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    bgcolor: 'info.main',
+                    boxShadow: (theme) => `0 0 0 2px ${theme.palette.sidebar}`,
+                  }}
+                />
+              ) : null}
+            </Box>
             <Typography
               variant="body2"
               noWrap
@@ -232,7 +271,7 @@ export function TabStrip({
                 // tracking follow the sidebar labels (treeLabelSx).
                 fontWeight: 450,
                 letterSpacing: -0.1,
-                color: active ? 'text.primary' : 'text.secondary',
+                color: active ? 'text.primary' : hasUnreadOutput ? 'info.main' : 'text.secondary',
                 flex: 1,
                 minWidth: 0,
               }}

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -147,6 +147,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   );
   const lastReconnectRequestRef = useRef(reconnectRequest);
   const updateTab = useTabsStore((s) => s.update);
+  const notifyOutput = useTabsStore((s) => s.notifyOutput);
   const searchRequest = useTabsStore(
     (s) => s.tabs.find((candidate) => candidate.id === tab.id)?.searchRequest ?? 0,
   );
@@ -536,6 +537,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       ws.onmessage = (ev) => {
         if (ev.data instanceof ArrayBuffer) {
           clearTransientStatus();
+          notifyOutput(tab.id);
           receivedTerminalOutput = true;
           snapshotDirty = true;
           snapshotRevision += 1;

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -14,6 +14,7 @@ import {
   splitAxis,
   updatePane,
   updateSplitRatio,
+  visibleTabIds,
   type PaneDirection,
   type PaneLeaf,
   type PaneNode,
@@ -101,6 +102,8 @@ export const PANE_RESIZE_STEP = 0.04;
 
 interface TabsState {
   tabs: TerminalTab[];
+  /** Terminal tabs with output that arrived while they were not visible. */
+  unreadOutputIds: Set<string>;
   root: PaneNode;
   activePaneId: string;
   activeId: string | null;
@@ -143,6 +146,8 @@ interface TabsState {
   reconnect: (tabIds: readonly string[], options?: ReconnectOptions) => void;
   /** Reconnect every ended/restored session in the current workspace. */
   reconnectAll: (options?: ReconnectOptions) => void;
+  /** Record terminal output, notifying only while the tab is hidden. */
+  notifyOutput: (id: string) => void;
   update: (id: string, patch: TabUpdate) => void;
 }
 
@@ -187,8 +192,29 @@ function insertSplit(
   };
 }
 
+/** Drop notifications for every terminal currently visible on the canvas. */
+function clearVisibleOutput(
+  unreadOutputIds: Set<string>,
+  root: PaneNode,
+  zoomedPaneId: string | null,
+): Set<string> {
+  if (unreadOutputIds.size === 0) return unreadOutputIds;
+  const next = new Set(unreadOutputIds);
+  for (const id of visibleTabIds(root, zoomedPaneId)) next.delete(id);
+  return next.size === unreadOutputIds.size ? unreadOutputIds : next;
+}
+
+/** Remove one tab from the unread set without allocating when it is already read. */
+function clearOutput(unreadOutputIds: Set<string>, id: string): Set<string> {
+  if (!unreadOutputIds.has(id)) return unreadOutputIds;
+  const next = new Set(unreadOutputIds);
+  next.delete(id);
+  return next;
+}
+
 export const useTabsStore = create<TabsState>()((set, get) => ({
   tabs: [],
+  unreadOutputIds: new Set(),
   root: initial,
   activePaneId: initial.id,
   activeId: null,
@@ -292,10 +318,16 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       const collapsed = replacement === null ? collapsePane(state.root, closing.paneId) : undefined;
       if (collapsed) {
         const focused = state.activePaneId === closing.paneId;
+        const zoomedPaneId = state.zoomedPaneId === closing.paneId ? null : state.zoomedPaneId;
         return {
           tabs,
           root: collapsed.root,
-          zoomedPaneId: state.zoomedPaneId === closing.paneId ? null : state.zoomedPaneId,
+          unreadOutputIds: clearVisibleOutput(
+            clearOutput(state.unreadOutputIds, id),
+            collapsed.root,
+            zoomedPaneId,
+          ),
+          zoomedPaneId,
           activePaneId: focused ? collapsed.focus.id : state.activePaneId,
           activeId: focused ? collapsed.focus.activeTabId : state.activeId,
         };
@@ -305,6 +337,10 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       return {
         tabs,
         root: updatePane(state.root, closing.paneId, (leaf) => ({ ...leaf, activeTabId: paneActiveId })),
+        unreadOutputIds: clearOutput(
+          clearOutput(state.unreadOutputIds, id),
+          paneActiveId ?? '',
+        ),
         activeId: state.activeId === id ? paneActiveId : state.activeId,
       };
     }),
@@ -312,21 +348,26 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     set((state) => {
       const tab = state.tabs.find((candidate) => candidate.id === id);
       if (!tab) return state;
+      const root = updatePane(state.root, tab.paneId, (pane) => ({ ...pane, activeTabId: id }));
+      const zoomedPaneId = state.zoomedPaneId === tab.paneId ? state.zoomedPaneId : null;
       return {
-        root: updatePane(state.root, tab.paneId, (pane) => ({ ...pane, activeTabId: id })),
+        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, root, zoomedPaneId),
+        root,
         activePaneId: tab.paneId,
         activeId: id,
-        zoomedPaneId: state.zoomedPaneId === tab.paneId ? state.zoomedPaneId : null,
+        zoomedPaneId,
       };
     }),
   focusPane: (paneId) =>
     set((state) => {
       const pane = findPane(state.root, paneId);
       if (!pane) return state;
+      const zoomedPaneId = state.zoomedPaneId === paneId ? state.zoomedPaneId : null;
       return {
+        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.root, zoomedPaneId),
         activePaneId: paneId,
         activeId: pane.activeTabId,
-        zoomedPaneId: state.zoomedPaneId === paneId ? state.zoomedPaneId : null,
+        zoomedPaneId,
       };
     }),
   cycle: (backwards) =>
@@ -337,6 +378,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       const next = (index + (backwards ? -1 : 1) + paneTabs.length) % paneTabs.length;
       const activeId = paneTabs[next]!.id;
       return {
+        unreadOutputIds: clearOutput(state.unreadOutputIds, activeId),
         activeId,
         root: updatePane(state.root, state.activePaneId, (pane) => ({ ...pane, activeTabId: activeId })),
       };
@@ -368,7 +410,13 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       if (!findPane(state.root, paneId)) return state;
       const { root, pane } = insertSplit(state.root, paneId, direction);
       created = pane.id;
-      return { root, activePaneId: pane.id, activeId: null, zoomedPaneId: null };
+      return {
+        root,
+        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, root, null),
+        activePaneId: pane.id,
+        activeId: null,
+        zoomedPaneId: null,
+      };
     });
     return created;
   },
@@ -377,10 +425,18 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       const collapsed = collapsePane(state.root, paneId);
       if (!collapsed) return state;
       const focused = state.activePaneId === paneId;
+      const zoomedPaneId = state.zoomedPaneId === paneId ? null : state.zoomedPaneId;
+      const closedIds = new Set(
+        state.tabs.filter((tab) => tab.paneId === paneId).map((tab) => tab.id),
+      );
+      const remainingOutputIds = new Set(
+        [...state.unreadOutputIds].filter((id) => !closedIds.has(id)),
+      );
       return {
         tabs: state.tabs.filter((tab) => tab.paneId !== paneId),
         root: collapsed.root,
-        zoomedPaneId: state.zoomedPaneId === paneId ? null : state.zoomedPaneId,
+        unreadOutputIds: clearVisibleOutput(remainingOutputIds, collapsed.root, zoomedPaneId),
+        zoomedPaneId,
         activePaneId: focused ? collapsed.focus.id : state.activePaneId,
         activeId: focused ? collapsed.focus.activeTabId : state.activeId,
       };
@@ -441,12 +497,14 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
         if (zoomedPaneId === sourceId) zoomedPaneId = null;
       }
     }
+    const nextZoomedPaneId = zoomedPaneId === targetId ? zoomedPaneId : null;
     set({
       tabs,
       root,
+      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, root, nextZoomedPaneId),
       activePaneId: targetId,
       activeId: tab.id,
-      zoomedPaneId: zoomedPaneId === targetId ? zoomedPaneId : null,
+      zoomedPaneId: nextZoomedPaneId,
     });
     return true;
   },
@@ -456,8 +514,10 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     if (state.root.type === 'pane' && !state.zoomedPaneId) return false;
     const pane = findPane(state.root, target);
     if (!pane) return false;
+    const zoomedPaneId = state.zoomedPaneId === target ? null : target;
     set({
-      zoomedPaneId: state.zoomedPaneId === target ? null : target,
+      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.root, zoomedPaneId),
+      zoomedPaneId,
       activePaneId: target,
       activeId: pane.activeTabId,
     });
@@ -523,6 +583,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
         const pane = initialPane();
         return {
           tabs: [],
+          unreadOutputIds: new Set(),
           root: pane,
           activePaneId: pane.id,
           activeId: null,
@@ -534,6 +595,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       return {
         ...restored,
         zoomedPaneId: null,
+        unreadOutputIds: new Set(),
         tabs: restored.tabs.map((tab) => ({
           ...tab,
           restored: true,
@@ -592,6 +654,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     set({
       tabs,
       root,
+      unreadOutputIds: new Set(),
       activePaneId: activePane.id,
       activeId: activePane.activeTabId,
       zoomedPaneId: null,
@@ -634,6 +697,21 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           : tab,
       ),
     })),
+  notifyOutput: (id) =>
+    set((state) => {
+      const tab = state.tabs.find((candidate) => candidate.id === id);
+      if (!tab?.profile) return state;
+      const pane = findPane(state.root, tab.paneId);
+      const visible =
+        (!state.zoomedPaneId || state.zoomedPaneId === tab.paneId) &&
+        pane?.activeTabId === id;
+      const unread = state.unreadOutputIds.has(id);
+      if (unread === !visible) return state;
+      const unreadOutputIds = new Set(state.unreadOutputIds);
+      if (visible) unreadOutputIds.delete(id);
+      else unreadOutputIds.add(id);
+      return { unreadOutputIds };
+    }),
   update: (id, patch) =>
     set((state) => ({
       tabs: state.tabs.map((tab) => {

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -14,7 +14,6 @@ import {
   splitAxis,
   updatePane,
   updateSplitRatio,
-  visibleTabIds,
   type PaneDirection,
   type PaneLeaf,
   type PaneNode,
@@ -192,15 +191,31 @@ function insertSplit(
   };
 }
 
+/** Whether a terminal, rather than one of its editors, is visible on the canvas. */
+function terminalIsVisible(
+  tab: TerminalTab,
+  root: PaneNode,
+  zoomedPaneId: string | null,
+): boolean {
+  return (
+    !tab.activeEditorPath &&
+    (!zoomedPaneId || zoomedPaneId === tab.paneId) &&
+    findPane(root, tab.paneId)?.activeTabId === tab.id
+  );
+}
+
 /** Drop notifications for every terminal currently visible on the canvas. */
 function clearVisibleOutput(
   unreadOutputIds: Set<string>,
+  tabs: readonly TerminalTab[],
   root: PaneNode,
   zoomedPaneId: string | null,
 ): Set<string> {
   if (unreadOutputIds.size === 0) return unreadOutputIds;
   const next = new Set(unreadOutputIds);
-  for (const id of visibleTabIds(root, zoomedPaneId)) next.delete(id);
+  for (const tab of tabs) {
+    if (terminalIsVisible(tab, root, zoomedPaneId)) next.delete(tab.id);
+  }
   return next.size === unreadOutputIds.size ? unreadOutputIds : next;
 }
 
@@ -324,6 +339,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           root: collapsed.root,
           unreadOutputIds: clearVisibleOutput(
             clearOutput(state.unreadOutputIds, id),
+            tabs,
             collapsed.root,
             zoomedPaneId,
           ),
@@ -334,12 +350,15 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       }
       const pane = findPane(state.root, closing.paneId);
       const paneActiveId = pane?.activeTabId === id ? replacement : (pane?.activeTabId ?? null);
+      const root = updatePane(state.root, closing.paneId, (leaf) => ({ ...leaf, activeTabId: paneActiveId }));
       return {
         tabs,
-        root: updatePane(state.root, closing.paneId, (leaf) => ({ ...leaf, activeTabId: paneActiveId })),
-        unreadOutputIds: clearOutput(
+        root,
+        unreadOutputIds: clearVisibleOutput(
           clearOutput(state.unreadOutputIds, id),
-          paneActiveId ?? '',
+          tabs,
+          root,
+          state.zoomedPaneId,
         ),
         activeId: state.activeId === id ? paneActiveId : state.activeId,
       };
@@ -351,7 +370,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       const root = updatePane(state.root, tab.paneId, (pane) => ({ ...pane, activeTabId: id }));
       const zoomedPaneId = state.zoomedPaneId === tab.paneId ? state.zoomedPaneId : null;
       return {
-        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, root, zoomedPaneId),
+        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.tabs, root, zoomedPaneId),
         root,
         activePaneId: tab.paneId,
         activeId: id,
@@ -364,7 +383,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       if (!pane) return state;
       const zoomedPaneId = state.zoomedPaneId === paneId ? state.zoomedPaneId : null;
       return {
-        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.root, zoomedPaneId),
+        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.tabs, state.root, zoomedPaneId),
         activePaneId: paneId,
         activeId: pane.activeTabId,
         zoomedPaneId,
@@ -412,7 +431,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       created = pane.id;
       return {
         root,
-        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, root, null),
+        unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.tabs, root, null),
         activePaneId: pane.id,
         activeId: null,
         zoomedPaneId: null,
@@ -432,10 +451,11 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       const remainingOutputIds = new Set(
         [...state.unreadOutputIds].filter((id) => !closedIds.has(id)),
       );
+      const tabs = state.tabs.filter((tab) => tab.paneId !== paneId);
       return {
-        tabs: state.tabs.filter((tab) => tab.paneId !== paneId),
+        tabs,
         root: collapsed.root,
-        unreadOutputIds: clearVisibleOutput(remainingOutputIds, collapsed.root, zoomedPaneId),
+        unreadOutputIds: clearVisibleOutput(remainingOutputIds, tabs, collapsed.root, zoomedPaneId),
         zoomedPaneId,
         activePaneId: focused ? collapsed.focus.id : state.activePaneId,
         activeId: focused ? collapsed.focus.activeTabId : state.activeId,
@@ -501,7 +521,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     set({
       tabs,
       root,
-      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, root, nextZoomedPaneId),
+      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, tabs, root, nextZoomedPaneId),
       activePaneId: targetId,
       activeId: tab.id,
       zoomedPaneId: nextZoomedPaneId,
@@ -516,7 +536,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     if (!pane) return false;
     const zoomedPaneId = state.zoomedPaneId === target ? null : target;
     set({
-      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.root, zoomedPaneId),
+      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, state.tabs, state.root, zoomedPaneId),
       zoomedPaneId,
       activePaneId: target,
       activeId: pane.activeTabId,
@@ -565,8 +585,8 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       ),
     })),
   closeEditor: (tabId, path) =>
-    set((state) => ({
-      tabs: state.tabs.map((tab) => {
+    set((state) => {
+      const tabs = state.tabs.map((tab) => {
         if (tab.id !== tabId || !tab.editorPaths.includes(path)) return tab;
         const index = tab.editorPaths.indexOf(path);
         const editorPaths = tab.editorPaths.filter((candidate) => candidate !== path);
@@ -575,8 +595,17 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
             ? editorPaths[Math.min(index, editorPaths.length - 1)]
             : tab.activeEditorPath;
         return { ...tab, editorPaths, activeEditorPath };
-      }),
-    })),
+      });
+      return {
+        tabs,
+        unreadOutputIds: clearVisibleOutput(
+          state.unreadOutputIds,
+          tabs,
+          state.root,
+          state.zoomedPaneId,
+        ),
+      };
+    }),
   restore: (layout, options) =>
     set((state) => {
       if (!layout.root) {
@@ -701,10 +730,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     set((state) => {
       const tab = state.tabs.find((candidate) => candidate.id === id);
       if (!tab?.profile) return state;
-      const pane = findPane(state.root, tab.paneId);
-      const visible =
-        (!state.zoomedPaneId || state.zoomedPaneId === tab.paneId) &&
-        pane?.activeTabId === id;
+      const visible = terminalIsVisible(tab, state.root, state.zoomedPaneId);
       const unread = state.unreadOutputIds.has(id);
       if (unread === !visible) return state;
       const unreadOutputIds = new Set(state.unreadOutputIds);

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -19,6 +19,7 @@ const answerDialog = async (confirmed: boolean) => {
 beforeEach(() => {
   useTabsStore.setState({
     tabs: [],
+    unreadOutputIds: new Set(),
     root: { id: 'pane-test', type: 'pane', activeTabId: null },
     activePaneId: 'pane-test',
     activeId: null,
@@ -26,6 +27,73 @@ beforeEach(() => {
   });
   usePrefsStore.setState({ confirmCloseConnected: true, splitInheritsSession: true });
   useDialogStore.setState({ queue: [] });
+});
+
+describe('terminal output notifications', () => {
+  it('marks output on a hidden tab and clears it when the tab is activated', () => {
+    const store = useTabsStore.getState();
+    const backgroundId = store.open({ kind: 'local' }, 'Background');
+    const activeId = store.open({ kind: 'local' }, 'Active');
+
+    useTabsStore.getState().notifyOutput(backgroundId);
+    useTabsStore.getState().notifyOutput(activeId);
+
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set([backgroundId]));
+
+    useTabsStore.getState().activate(backgroundId);
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set());
+  });
+
+  it('does not update state again for subsequent output while a notification is unread', () => {
+    const store = useTabsStore.getState();
+    const backgroundId = store.open({ kind: 'local' }, 'Background');
+    store.open({ kind: 'local' }, 'Active');
+    useTabsStore.getState().notifyOutput(backgroundId);
+    const unreadOutputIds = useTabsStore.getState().unreadOutputIds;
+
+    useTabsStore.getState().notifyOutput(backgroundId);
+
+    expect(useTabsStore.getState().unreadOutputIds).toBe(unreadOutputIds);
+  });
+
+  it('clears notifications when cycling to or closing a background tab', () => {
+    const store = useTabsStore.getState();
+    const firstId = store.open({ kind: 'local' }, 'First');
+    const secondId = store.open({ kind: 'local' }, 'Second');
+    useTabsStore.getState().notifyOutput(firstId);
+
+    useTabsStore.getState().cycle(true);
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set());
+
+    useTabsStore.getState().notifyOutput(secondId);
+    useTabsStore.getState().close(secondId);
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set());
+  });
+
+  it('treats the selected tab in every split pane as visible', () => {
+    const store = useTabsStore.getState();
+    const leftId = store.open({ kind: 'local' }, 'Left');
+    store.split('pane-test', 'right');
+    useTabsStore.getState().open({ kind: 'local' }, 'Right');
+
+    useTabsStore.getState().notifyOutput(leftId);
+
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set());
+  });
+
+  it('notifies for panes hidden by zoom and clears when they become visible again', () => {
+    const store = useTabsStore.getState();
+    const leftId = store.open({ kind: 'local' }, 'Left');
+    store.split('pane-test', 'right');
+    useTabsStore.getState().open({ kind: 'local' }, 'Right');
+    useTabsStore.getState().toggleZoom();
+
+    useTabsStore.getState().notifyOutput(leftId);
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set([leftId]));
+
+    useTabsStore.getState().toggleZoom();
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set());
+  });
 });
 
 describe('blank session tabs', () => {

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -94,6 +94,32 @@ describe('terminal output notifications', () => {
     useTabsStore.getState().toggleZoom();
     expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set());
   });
+
+  it('treats a terminal covered by its remote editor as hidden', () => {
+    const store = useTabsStore.getState();
+    const id = store.open({ kind: 'ssh', target: 'router' }, 'Router');
+    store.openEditor(id, '/etc/hosts');
+
+    useTabsStore.getState().notifyOutput(id);
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set([id]));
+
+    useTabsStore.getState().closeEditor(id, '/etc/hosts');
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set());
+  });
+
+  it('preserves unread output for the selected tab in a zoom-hidden pane', () => {
+    const store = useTabsStore.getState();
+    const closingId = store.open({ kind: 'local' }, 'Closing');
+    const unreadId = store.open({ kind: 'local' }, 'Unread');
+    store.split('pane-test', 'right');
+    useTabsStore.getState().open({ kind: 'local' }, 'Zoomed');
+    useTabsStore.getState().toggleZoom();
+    useTabsStore.getState().notifyOutput(unreadId);
+
+    useTabsStore.getState().close(closingId);
+
+    expect(useTabsStore.getState().unreadOutputIds).toEqual(new Set([unreadId]));
+  });
 });
 
 describe('blank session tabs', () => {


### PR DESCRIPTION
## Summary

- track terminal output that arrives while a tab is hidden
- highlight unread tabs with a tint, underline, icon badge, and accessible label
- clear notifications when tabs become visible through selection, pane navigation, or zoom changes
- avoid repeated state updates while a notification remains unread

## Why

Terminal output was written directly to xterm without any tab-level activity state, so users working across several tabs had no visual signal that a background session had changed.

## Validation

- `pnpm --filter @muxus/tests exec vitest run unit/client/tabs.test.ts`
- full test suite: 633 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @muxus/client build`

Closes #34