### PR TITLE
Support OSC 52 clipboard writes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@mui/material": "^9.2.0",
     "@muxus/shared": "workspace:*",
     "@tanstack/react-query": "^5.101.2",
+    "@xterm/addon-clipboard": "^0.3.0-beta.292",
     "@xterm/addon-fit": "^0.12.0-beta.292",
     "@xterm/addon-image": "^0.10.0-beta.292",
     "@xterm/addon-search": "^0.17.0-beta.292",

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -492,6 +492,23 @@ function TerminalSection() {
             label={<Typography variant="body2">Copy on select</Typography>}
           />
           <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={prefs.allowOsc52ClipboardWrite}
+                onChange={(e) => prefs.set({ allowOsc52ClipboardWrite: e.target.checked })}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body2">Allow terminal clipboard writes (OSC 52)</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Lets terminal programs such as tmux and Zellij replace the system clipboard. Clipboard reads remain blocked.
+                </Typography>
+              </Box>
+            }
+          />
+          <FormControlLabel
             control={<Switch size="small" checked={prefs.pasteWarnMultiline} onChange={(e) => prefs.set({ pasteWarnMultiline: e.target.checked })} />}
             label={
               <Box>

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -308,13 +308,6 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     term.loadAddon(new Unicode11Addon());
     term.unicode.activeVersion = '11';
     term.loadAddon(new WebLinksAddon());
-    attachOsc52Clipboard(
-      term,
-      (text) => {
-        void copyToClipboard(text);
-      },
-      () => usePrefsStore.getState().allowOsc52ClipboardWrite,
-    );
     // xterm 6.1 streams Kitty APC payloads straight into ImageAddon's WASM
     // base64 decoder. This also handles Sixel and iTerm2 inline images.
     const image = new ImageAddon({
@@ -378,6 +371,17 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       }
       return true;
     };
+
+    attachOsc52Clipboard(
+      term,
+      (text) => {
+        void copyToClipboard(text);
+      },
+      () => usePrefsStore.getState().allowOsc52ClipboardWrite,
+      (data) => {
+        sendInput(data);
+      },
+    );
 
     const unregister = registerTerminal(tab.id, {
       focus: () => term.focus(),

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -46,6 +46,7 @@ import {
   themeWithFontColor,
 } from '../terminal/palette.js';
 import { attachCommandTracker } from '../terminal/shell-integration.js';
+import { attachOsc52Clipboard } from '../terminal/osc52-clipboard.js';
 import {
   attachKeywordHighlighter,
   resolveKeywordHighlights,
@@ -307,6 +308,13 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     term.loadAddon(new Unicode11Addon());
     term.unicode.activeVersion = '11';
     term.loadAddon(new WebLinksAddon());
+    attachOsc52Clipboard(
+      term,
+      (text) => {
+        void copyToClipboard(text);
+      },
+      () => usePrefsStore.getState().allowOsc52ClipboardWrite,
+    );
     // xterm 6.1 streams Kitty APC payloads straight into ImageAddon's WASM
     // base64 decoder. This also handles Sixel and iTerm2 inline images.
     const image = new ImageAddon({

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -43,6 +43,7 @@ const PREFERENCE_KEYS = [
   'cursorStyle',
   'localShell',
   'copyOnSelect',
+  'allowOsc52ClipboardWrite',
   'rightClickAction',
   'pasteWarnMultiline',
   'confirmCloseConnected',
@@ -591,6 +592,9 @@ export function sanitizePreferences(input: BackupPreferences): Partial<PrefsStat
     output.localShell = input.localShell;
   }
   if (typeof input.copyOnSelect === 'boolean') output.copyOnSelect = input.copyOnSelect;
+  if (typeof input.allowOsc52ClipboardWrite === 'boolean') {
+    output.allowOsc52ClipboardWrite = input.allowOsc52ClipboardWrite;
+  }
   if (['copy-paste', 'paste', 'menu'].includes(input.rightClickAction)) {
     output.rightClickAction = input.rightClickAction;
   }

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -57,6 +57,8 @@ export interface PrefsState {
   localShell: string;
   /** Copy the selection to the clipboard as soon as it is made. */
   copyOnSelect: boolean;
+  /** Let terminal applications replace the system clipboard via OSC 52. */
+  allowOsc52ClipboardWrite: boolean;
   /** Right-click: copy selection / paste (terminal convention), always paste, or context menu. */
   rightClickAction: RightClickAction;
   /** Preview multiline pastes before they can run several shell commands. */
@@ -169,6 +171,7 @@ export const usePrefsStore = create<PrefsState>()(
       cursorStyle: 'block',
       localShell: 'auto',
       copyOnSelect: false,
+      allowOsc52ClipboardWrite: true,
       rightClickAction: 'copy-paste',
       pasteWarnMultiline: true,
       confirmCloseConnected: true,

--- a/client/src/terminal/osc52-clipboard-provider.ts
+++ b/client/src/terminal/osc52-clipboard-provider.ts
@@ -1,0 +1,24 @@
+import type { IClipboardProvider } from '@xterm/addon-clipboard';
+
+export type ClipboardWriter = (text: string) => void;
+
+/**
+ * OSC 52 provider that permits clipboard writes without exposing clipboard
+ * contents to programs running in the terminal. Returning an empty string for
+ * read requests gives callers a valid response without leaking local data.
+ */
+export class WriteOnlyClipboardProvider implements IClipboardProvider {
+  constructor(
+    private readonly writer: ClipboardWriter,
+    private readonly allowWrite: () => boolean,
+  ) {}
+
+  readText(_selection: string): string {
+    return '';
+  }
+
+  writeText(_selection: string, text: string): void {
+    if (!this.allowWrite()) return;
+    this.writer(text);
+  }
+}

--- a/client/src/terminal/osc52-clipboard.ts
+++ b/client/src/terminal/osc52-clipboard.ts
@@ -2,22 +2,58 @@ import {
   Base64,
   ClipboardAddon,
 } from '@xterm/addon-clipboard';
-import type { Terminal } from '@xterm/xterm';
+import type { IDisposable, ITerminalAddon, Terminal } from '@xterm/xterm';
 import {
   WriteOnlyClipboardProvider,
   type ClipboardWriter,
 } from './osc52-clipboard-provider.js';
+
+export type TerminalReplyWriter = (data: string) => void;
+
+/**
+ * Keep OSC 52 read replies on the source transport. ClipboardAddon sends its
+ * replies through Terminal.input(), whose public onData event cannot preserve
+ * xterm's user-vs-protocol origin flag and would look like multi-exec input.
+ */
+class WriteOnlyOsc52Addon implements ITerminalAddon {
+  private readonly clipboard: ClipboardAddon;
+  private queryHandler?: IDisposable;
+
+  constructor(
+    writer: ClipboardWriter,
+    allowWrite: () => boolean,
+    private readonly reply: TerminalReplyWriter,
+  ) {
+    this.clipboard = new ClipboardAddon(
+      new Base64(),
+      new WriteOnlyClipboardProvider(writer, allowWrite),
+    );
+  }
+
+  activate(term: Terminal): void {
+    this.clipboard.activate(term);
+    // xterm calls the most recently registered OSC handler first. Consume
+    // queries here; return false for writes so ClipboardAddon decodes them.
+    this.queryHandler = term.parser.registerOscHandler(52, (data) => {
+      const separator = data.indexOf(';');
+      if (separator === -1 || data.slice(separator + 1) !== '?') return false;
+      this.reply(`\x1b]52;${data.slice(0, separator)};\x07`);
+      return true;
+    });
+  }
+
+  dispose(): void {
+    this.queryHandler?.dispose();
+    this.clipboard.dispose();
+  }
+}
 
 /** Attach OSC 52 clipboard handling; the terminal owns the addon's lifecycle. */
 export function attachOsc52Clipboard(
   term: Terminal,
   writer: ClipboardWriter,
   allowWrite: () => boolean,
+  reply: TerminalReplyWriter,
 ): void {
-  term.loadAddon(
-    new ClipboardAddon(
-      new Base64(),
-      new WriteOnlyClipboardProvider(writer, allowWrite),
-    ),
-  );
+  term.loadAddon(new WriteOnlyOsc52Addon(writer, allowWrite, reply));
 }

--- a/client/src/terminal/osc52-clipboard.ts
+++ b/client/src/terminal/osc52-clipboard.ts
@@ -1,0 +1,23 @@
+import {
+  Base64,
+  ClipboardAddon,
+} from '@xterm/addon-clipboard';
+import type { Terminal } from '@xterm/xterm';
+import {
+  WriteOnlyClipboardProvider,
+  type ClipboardWriter,
+} from './osc52-clipboard-provider.js';
+
+/** Attach OSC 52 clipboard handling; the terminal owns the addon's lifecycle. */
+export function attachOsc52Clipboard(
+  term: Terminal,
+  writer: ClipboardWriter,
+  allowWrite: () => boolean,
+): void {
+  term.loadAddon(
+    new ClipboardAddon(
+      new Base64(),
+      new WriteOnlyClipboardProvider(writer, allowWrite),
+    ),
+  );
+}

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -34,7 +34,9 @@ because storage policy should not change under a running recorder.
 - **Cursor**: block, underline or bar, blinking or not.
 - **Right-click**: copy-selection-otherwise-paste (the terminal convention), always paste,
   or a context menu.
-- **Copy on select** and the **multiline paste confirmation**.
+- **Copy on select**, **OSC 52 clipboard writes** from terminal programs such as tmux and
+  Zellij, and the **multiline paste confirmation**. OSC 52 reads remain blocked so a
+  terminal program cannot retrieve the local clipboard.
 - **Scrollback lines** kept per terminal.
 - **Local shell**: the shell a local terminal starts; `auto` uses the login shell.
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -129,6 +129,14 @@ Retention is bounded by a quota with a free-space reserve, and exhausted storage
 logging rather than filling the disk. See
 [session history](../guide/session-history.md).
 
+## Terminal clipboard access
+
+Terminal programs may replace the system clipboard through OSC 52 when **Allow terminal
+clipboard writes** is enabled in Terminal settings. It is enabled by default for tmux,
+Zellij and editor compatibility, and can be disabled at any time. OSC 52 clipboard reads
+are always blocked: a local or remote terminal program receives an empty value instead of
+the clipboard contents.
+
 ## Telnet and serial
 
 Telnet provides **no encryption and no server authentication**. All traffic, including what

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.2
         version: 5.101.4(react@19.2.8)
+      '@xterm/addon-clipboard':
+        specifier: ^0.3.0-beta.292
+        version: 0.3.0-beta.292(@xterm/xterm@6.1.0-beta.292)
       '@xterm/addon-fit':
         specifier: ^0.12.0-beta.292
         version: 0.12.0-beta.292(@xterm/xterm@6.1.0-beta.292)
@@ -1622,6 +1625,11 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+
+  '@xterm/addon-clipboard@0.3.0-beta.292':
+    resolution: {integrity: sha512-UNjPtLHO9do8lDoYcfuipBtQzjjex2iOudN7G+2ExqcvecVnex6v0UGxUttgg0xN+a6TTEZkdIaWIi/kZnjtoA==}
+    peerDependencies:
+      '@xterm/xterm': ^6.1.0-beta.292
 
   '@xterm/addon-fit@0.12.0-beta.292':
     resolution: {integrity: sha512-SIuWR0KM2IpmumVqL4L43aOUeTEUeN82ItyrUFHGFtfj3veoAIbPapxJPj7O0tYngfiiHZqqm1+XsZp/Fc8LLA==}
@@ -4548,6 +4556,10 @@ snapshots:
       tinyrainbow: 3.1.0
 
   '@xmldom/xmldom@0.8.13': {}
+
+  '@xterm/addon-clipboard@0.3.0-beta.292(@xterm/xterm@6.1.0-beta.292)':
+    dependencies:
+      '@xterm/xterm': 6.1.0-beta.292
 
   '@xterm/addon-fit@0.12.0-beta.292(@xterm/xterm@6.1.0-beta.292)':
     dependencies:

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -219,6 +219,19 @@ describe('restoring the font color preference', () => {
   });
 });
 
+describe('restoring the OSC 52 clipboard preference', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores only boolean clipboard-write choices', () => {
+    expect(sanitizePreferences(prefs({ allowOsc52ClipboardWrite: false })))
+      .toMatchObject({ allowOsc52ClipboardWrite: false });
+    expect(
+      sanitizePreferences(prefs({ allowOsc52ClipboardWrite: 'yes' }))
+        .allowOsc52ClipboardWrite,
+    ).toBeUndefined();
+  });
+});
+
 describe('restoring manual folder order', () => {
   const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
 

--- a/tests/unit/client/osc52-clipboard.test.ts
+++ b/tests/unit/client/osc52-clipboard.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WriteOnlyClipboardProvider } from '../../../client/src/terminal/osc52-clipboard-provider.js';
+
+describe('WriteOnlyClipboardProvider', () => {
+  it('writes decoded OSC 52 text when terminal clipboard writes are allowed', () => {
+    const writer = vi.fn();
+    const provider = new WriteOnlyClipboardProvider(writer, () => true);
+
+    provider.writeText('c', 'copied through zellij ✓');
+
+    expect(writer).toHaveBeenCalledWith('copied through zellij ✓');
+  });
+
+  it('checks the current preference for every write', () => {
+    const writer = vi.fn();
+    let allowed = false;
+    const provider = new WriteOnlyClipboardProvider(writer, () => allowed);
+
+    provider.writeText('c', 'blocked');
+    allowed = true;
+    provider.writeText('c', 'allowed');
+
+    expect(writer).toHaveBeenCalledTimes(1);
+    expect(writer).toHaveBeenCalledWith('allowed');
+  });
+
+  it('never exposes clipboard contents to OSC 52 read queries', () => {
+    const provider = new WriteOnlyClipboardProvider(vi.fn(), () => true);
+
+    expect(provider.readText('c')).toBe('');
+    expect(provider.readText('p')).toBe('');
+  });
+});
+
+describe('OSC 52 clipboard addon wiring', () => {
+  it('decodes a real UTF-8 OSC 52 write and blocks readback', async () => {
+    vi.stubGlobal('self', globalThis);
+    try {
+      const { attachOsc52Clipboard } = await import(
+        '../../../client/src/terminal/osc52-clipboard.js'
+      );
+      let handler: ((data: string) => boolean | Promise<boolean>) | undefined;
+      const input = vi.fn();
+      const term = {
+        parser: {
+          registerOscHandler(
+            id: number,
+            callback: (data: string) => boolean | Promise<boolean>,
+          ) {
+            expect(id).toBe(52);
+            handler = callback;
+            return { dispose: vi.fn() };
+          },
+        },
+        input,
+        loadAddon(addon: { activate(value: unknown): void }) {
+          addon.activate(this);
+        },
+      };
+      const writer = vi.fn();
+
+      attachOsc52Clipboard(
+        term as unknown as Parameters<typeof attachOsc52Clipboard>[0],
+        writer,
+        () => true,
+      );
+      expect(handler).toBeDefined();
+
+      const text = 'copied through zellij ✓';
+      const payload = Buffer.from(text, 'utf8').toString('base64');
+      await handler!(`c;${payload}`);
+      expect(writer).toHaveBeenCalledWith(text);
+
+      await handler!('c;?');
+      expect(input).toHaveBeenCalledWith('\x1b]52;c;\x07', false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/tests/unit/client/osc52-clipboard.test.ts
+++ b/tests/unit/client/osc52-clipboard.test.ts
@@ -33,13 +33,13 @@ describe('WriteOnlyClipboardProvider', () => {
 });
 
 describe('OSC 52 clipboard addon wiring', () => {
-  it('decodes a real UTF-8 OSC 52 write and blocks readback', async () => {
+  it('decodes writes and keeps read replies out of xterm user input', async () => {
     vi.stubGlobal('self', globalThis);
     try {
       const { attachOsc52Clipboard } = await import(
         '../../../client/src/terminal/osc52-clipboard.js'
       );
-      let handler: ((data: string) => boolean | Promise<boolean>) | undefined;
+      const handlers: Array<(data: string) => boolean | Promise<boolean>> = [];
       const input = vi.fn();
       const term = {
         parser: {
@@ -48,7 +48,7 @@ describe('OSC 52 clipboard addon wiring', () => {
             callback: (data: string) => boolean | Promise<boolean>,
           ) {
             expect(id).toBe(52);
-            handler = callback;
+            handlers.push(callback);
             return { dispose: vi.fn() };
           },
         },
@@ -58,21 +58,32 @@ describe('OSC 52 clipboard addon wiring', () => {
         },
       };
       const writer = vi.fn();
+      const reply = vi.fn();
 
       attachOsc52Clipboard(
         term as unknown as Parameters<typeof attachOsc52Clipboard>[0],
         writer,
         () => true,
+        reply,
       );
-      expect(handler).toBeDefined();
+      expect(handlers).toHaveLength(2);
+
+      const dispatch = async (data: string) => {
+        for (let i = handlers.length - 1; i >= 0; i--) {
+          if (await handlers[i]!(data)) return true;
+        }
+        return false;
+      };
 
       const text = 'copied through zellij ✓';
       const payload = Buffer.from(text, 'utf8').toString('base64');
-      await handler!(`c;${payload}`);
+      await dispatch(`c;${payload}`);
       expect(writer).toHaveBeenCalledWith(text);
+      expect(reply).not.toHaveBeenCalled();
 
-      await handler!('c;?');
-      expect(input).toHaveBeenCalledWith('\x1b]52;c;\x07', false);
+      await dispatch('c;?');
+      expect(reply).toHaveBeenCalledWith('\x1b]52;c;\x07');
+      expect(input).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
     }


### PR DESCRIPTION
## Summary

- handle OSC 52 clipboard writes through xterm's clipboard addon
- add a default-on terminal setting that applies immediately to live sessions
- keep OSC 52 reads blocked by returning an empty clipboard value
- preserve the preference in portable backups and document the security boundary
- cover UTF-8 OSC 52 payloads, live preference changes, blocked reads, and backup validation

## Why

Muxus did not register an OSC 52 handler, so clipboard copies emitted by remote terminal programs such as Zellij and tmux were ignored. This adds the expected terminal compatibility while preventing remote programs from reading the local clipboard.

Closes #35

## Validation

- `pnpm test` — 641 passed, 3 skipped
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:bundle`