### PR TITLE
Isolate Electron development database

### DIFF
--- a/docs/install/from-source.md
+++ b/docs/install/from-source.md
@@ -55,6 +55,8 @@ pnpm typecheck
 `pnpm electron` uses a separate `Muxus-development` user-data directory. At every launch,
 its application database is refreshed from the installed Muxus database when one exists;
 the installed application's database is never opened for writes by the development build.
+Session history and automatic password-vault keys are also placed in development-only
+storage, so cleanup or settings changes cannot affect the installed application.
 
 !!! note "Native modules and Electron"
 

--- a/docs/install/from-source.md
+++ b/docs/install/from-source.md
@@ -52,6 +52,10 @@ pnpm lint       # oxlint
 pnpm typecheck
 ```
 
+`pnpm electron` uses a separate `Muxus-development` user-data directory. At every launch,
+its application database is refreshed from the installed Muxus database when one exists;
+the installed application's database is never opened for writes by the development build.
+
 !!! note "Native modules and Electron"
 
     `pnpm electron` runs against Electron's ABI, so the native bindings must be rebuilt for

--- a/electron/src/development-database.ts
+++ b/electron/src/development-database.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   chmodSync,
   existsSync,
@@ -10,10 +11,33 @@ import path from 'node:path';
 import { backup, DatabaseSync } from 'node:sqlite';
 
 const DATABASE_FILENAME = 'muxus.sqlite3';
+const DEVELOPMENT_VAULT_PREFIX = 'development:';
+
+export interface DevelopmentVaultKeyStore {
+  get(vaultId: string): Promise<Buffer | undefined>;
+  set(vaultId: string, key: Buffer): Promise<void>;
+}
+
+export interface DevelopmentDatabaseSeedResult {
+  databaseCopied: boolean;
+  automaticVaultKey: 'not-needed' | 'copied' | 'missing' | 'unavailable';
+}
+
+interface VaultKeyRemap {
+  sourceVaultId: string;
+  developmentVaultId: string;
+  automatic: boolean;
+}
 
 /** Keep source launches isolated from the profile used by an installed build. */
 export function developmentUserDataPath(installedUserDataPath: string): string {
   return `${installedUserDataPath}-development`;
+}
+
+/** Vault IDs double as OS credential-store account names. */
+export function developmentVaultId(installedVaultId: string): string {
+  const digest = createHash('sha256').update(installedVaultId, 'utf8').digest('base64url');
+  return `${DEVELOPMENT_VAULT_PREFIX}${digest}`;
 }
 
 /**
@@ -24,16 +48,25 @@ export function developmentUserDataPath(installedUserDataPath: string): string {
 export async function seedDevelopmentDatabase(
   installedUserDataPath: string,
   developmentUserDataPath: string,
-): Promise<boolean> {
+  keyStore?: DevelopmentVaultKeyStore,
+): Promise<DevelopmentDatabaseSeedResult> {
   const sourcePath = path.join(installedUserDataPath, DATABASE_FILENAME);
-  if (!existsSync(sourcePath)) return false;
-
   const destinationPath = path.join(developmentUserDataPath, DATABASE_FILENAME);
   if (path.resolve(sourcePath) === path.resolve(destinationPath)) {
     throw new Error('development database path must differ from the installed database path');
   }
 
   mkdirSync(developmentUserDataPath, { recursive: true, mode: 0o700 });
+  if (!existsSync(sourcePath)) {
+    const remap = existsSync(destinationPath)
+      ? isolateDevelopmentData(destinationPath, false)
+      : undefined;
+    return {
+      databaseCopied: false,
+      automaticVaultKey: await copyAutomaticVaultKey(remap, keyStore),
+    };
+  }
+
   const temporaryDirectory = mkdtempSync(
     path.join(developmentUserDataPath, '.database-seed-'),
   );
@@ -43,6 +76,8 @@ export async function seedDevelopmentDatabase(
   try {
     source = new DatabaseSync(sourcePath, { readOnly: true, timeout: 5_000 });
     await backup(source, temporaryDatabase);
+    const remap = isolateDevelopmentData(temporaryDatabase, true);
+    const automaticVaultKey = await copyAutomaticVaultKey(remap, keyStore);
     try {
       chmodSync(temporaryDatabase, 0o600);
     } catch {
@@ -55,9 +90,88 @@ export async function seedDevelopmentDatabase(
     rmSync(`${destinationPath}-wal`, { force: true });
     rmSync(`${destinationPath}-shm`, { force: true });
     renameSync(temporaryDatabase, destinationPath);
-    return true;
+    return { databaseCopied: true, automaticVaultKey };
   } finally {
     source?.close();
     rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function isolateDevelopmentData(
+  databasePath: string,
+  copiedFromInstalledApp: boolean,
+): VaultKeyRemap | undefined {
+  const database = new DatabaseSync(databasePath, { timeout: 5_000 });
+  try {
+    // Ensure the changes below live in the main file before it is renamed.
+    database.exec('PRAGMA journal_mode = DELETE; BEGIN IMMEDIATE;');
+    try {
+      if (tableExists(database, 'session_history_settings')) {
+        database.exec('UPDATE session_history_settings SET storage_location = NULL;');
+      }
+
+      if (tableExists(database, 'password_vault_key_cleanup')) {
+        if (copiedFromInstalledApp) {
+          database.exec('DELETE FROM password_vault_key_cleanup;');
+        } else {
+          database
+            .prepare('DELETE FROM password_vault_key_cleanup WHERE vault_id NOT LIKE ?')
+            .run(`${DEVELOPMENT_VAULT_PREFIX}%`);
+        }
+      }
+
+      let remap: VaultKeyRemap | undefined;
+      if (tableExists(database, 'password_vault')) {
+        const vault = database
+          .prepare('SELECT vault_id, unlock_policy FROM password_vault WHERE singleton = 1')
+          .get();
+        if (vault) {
+          const sourceVaultId = String(vault.vault_id);
+          if (copiedFromInstalledApp || !sourceVaultId.startsWith(DEVELOPMENT_VAULT_PREFIX)) {
+            const nextVaultId = developmentVaultId(sourceVaultId);
+            database
+              .prepare('UPDATE password_vault SET vault_id = ? WHERE singleton = 1')
+              .run(nextVaultId);
+            remap = {
+              sourceVaultId,
+              developmentVaultId: nextVaultId,
+              automatic: String(vault.unlock_policy) === 'never',
+            };
+          }
+        }
+      }
+
+      database.exec('COMMIT;');
+      return remap;
+    } catch (error) {
+      database.exec('ROLLBACK;');
+      throw error;
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return !!database
+    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(table);
+}
+
+async function copyAutomaticVaultKey(
+  remap: VaultKeyRemap | undefined,
+  keyStore: DevelopmentVaultKeyStore | undefined,
+): Promise<DevelopmentDatabaseSeedResult['automaticVaultKey']> {
+  if (!remap?.automatic || !keyStore) return 'not-needed';
+  let key: Buffer | undefined;
+  try {
+    key = await keyStore.get(remap.sourceVaultId);
+    if (!key) return 'missing';
+    await keyStore.set(remap.developmentVaultId, key);
+    return 'copied';
+  } catch {
+    return 'unavailable';
+  } finally {
+    key?.fill(0);
   }
 }

--- a/electron/src/development-database.ts
+++ b/electron/src/development-database.ts
@@ -1,0 +1,63 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import path from 'node:path';
+import { backup, DatabaseSync } from 'node:sqlite';
+
+const DATABASE_FILENAME = 'muxus.sqlite3';
+
+/** Keep source launches isolated from the profile used by an installed build. */
+export function developmentUserDataPath(installedUserDataPath: string): string {
+  return `${installedUserDataPath}-development`;
+}
+
+/**
+ * Refresh the development database from the installed application database.
+ * SQLite's backup API is required here: copying the main file directly can
+ * omit committed transactions which still live in its WAL file.
+ */
+export async function seedDevelopmentDatabase(
+  installedUserDataPath: string,
+  developmentUserDataPath: string,
+): Promise<boolean> {
+  const sourcePath = path.join(installedUserDataPath, DATABASE_FILENAME);
+  if (!existsSync(sourcePath)) return false;
+
+  const destinationPath = path.join(developmentUserDataPath, DATABASE_FILENAME);
+  if (path.resolve(sourcePath) === path.resolve(destinationPath)) {
+    throw new Error('development database path must differ from the installed database path');
+  }
+
+  mkdirSync(developmentUserDataPath, { recursive: true, mode: 0o700 });
+  const temporaryDirectory = mkdtempSync(
+    path.join(developmentUserDataPath, '.database-seed-'),
+  );
+  const temporaryDatabase = path.join(temporaryDirectory, DATABASE_FILENAME);
+  let source: DatabaseSync | undefined;
+
+  try {
+    source = new DatabaseSync(sourcePath, { readOnly: true, timeout: 5_000 });
+    await backup(source, temporaryDatabase);
+    try {
+      chmodSync(temporaryDatabase, 0o600);
+    } catch {
+      /* permissions may be controlled by the platform/filesystem */
+    }
+
+    // No development process is running: the single-instance lock is already
+    // held before this function is called. Discard sidecars from the previous
+    // seed before atomically replacing its main database file.
+    rmSync(`${destinationPath}-wal`, { force: true });
+    rmSync(`${destinationPath}-shm`, { force: true });
+    renameSync(temporaryDatabase, destinationPath);
+    return true;
+  } finally {
+    source?.close();
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -13,7 +13,11 @@ import {
   shell,
   type MenuItemConstructorOptions,
 } from 'electron';
-import { startServer, type RunningServer } from '@muxus/server';
+import {
+  startServer,
+  SystemVaultKeyStore,
+  type RunningServer,
+} from '@muxus/server';
 import { isNewerVersion } from '@muxus/shared';
 import type {
   AppWindowLaunch,
@@ -606,22 +610,31 @@ if (!app.requestSingleInstanceLock()) {
     process.env.MUXUS_VERSION = app.getVersion();
     try {
       if (isDevelopment) {
-        const seeded = await seedDevelopmentDatabase(
+        const seed = await seedDevelopmentDatabase(
           installedUserDataPath,
           app.getPath('userData'),
+          new SystemVaultKeyStore(),
         );
         mainLog(
           'info',
-          seeded
+          seed.databaseCopied
             ? 'refreshed the development database from the installed app'
             : 'installed app database not found; using the development database',
         );
+        if (seed.automaticVaultKey === 'missing' || seed.automaticVaultKey === 'unavailable') {
+          mainLog(
+            'warn',
+            'automatic password-vault access could not be copied; the development vault may require repair with its master password',
+          );
+        }
       }
+      const userDataPath = app.getPath('userData');
       server = await startServer({
         port: 0,
         openBrowser: false,
         prettyLogs: false,
-        databasePath: path.join(app.getPath('userData'), 'muxus.sqlite3'),
+        databasePath: path.join(userDataPath, 'muxus.sqlite3'),
+        historyPath: isDevelopment ? path.join(userDataPath, 'history') : undefined,
         staticRoot: app.isPackaged
           ? path.join(process.resourcesPath, 'client')
           : path.resolve(moduleDir, '../../client/dist'),

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -20,12 +20,23 @@ import type {
   MobaXtermSessionSource,
   UpdateCheckResult,
 } from '@muxus/shared';
+import {
+  developmentUserDataPath,
+  seedDevelopmentDatabase,
+} from './development-database.js';
 import { importLoginShellEnvironment } from './login-shell-environment.js';
 import { initMainLog, installCrashCapture, mainLog, mainLogPath } from './main-log.js';
 import { readLocalMobaXtermSessions } from './mobaxterm.js';
 
 // Name first: userData (and with it the log location) derives from it.
 app.setName('Muxus');
+const installedUserDataPath = app.getPath('userData');
+const isDevelopment = !app.isPackaged;
+if (isDevelopment) {
+  const userDataPath = developmentUserDataPath(installedUserDataPath);
+  mkdirSync(userDataPath, { recursive: true, mode: 0o700 });
+  app.setPath('userData', userDataPath);
+}
 initMainLog(app.getPath('userData'));
 installCrashCapture();
 mainLog(
@@ -594,6 +605,18 @@ if (!app.requestSingleInstanceLock()) {
   void app.whenReady().then(async () => {
     process.env.MUXUS_VERSION = app.getVersion();
     try {
+      if (isDevelopment) {
+        const seeded = await seedDevelopmentDatabase(
+          installedUserDataPath,
+          app.getPath('userData'),
+        );
+        mainLog(
+          'info',
+          seeded
+            ? 'refreshed the development database from the installed app'
+            : 'installed app database not found; using the development database',
+        );
+      }
       server = await startServer({
         port: 0,
         openBrowser: false,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,6 +7,7 @@ import { serverUrls } from './auth.js';
 // The Electron shell logs its own milestones (boot, crashes) into the same
 // in-process buffer the /api/logs viewer reads.
 export { appendAppLog } from './logging/log-buffer.js';
+export { SystemVaultKeyStore } from './security/vault-key-store.js';
 
 export interface RunningServer {
   app: FastifyInstance;

--- a/tests/unit/electron/development-database.test.ts
+++ b/tests/unit/electron/development-database.test.ts
@@ -4,8 +4,10 @@ import path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  developmentVaultId,
   developmentUserDataPath,
   seedDevelopmentDatabase,
+  type DevelopmentVaultKeyStore,
 } from '../../../electron/src/development-database.js';
 
 let temporaryDirectory: string | undefined;
@@ -30,6 +32,19 @@ function openDatabase(directory: string): DatabaseSync {
   return new DatabaseSync(path.join(directory, 'muxus.sqlite3'));
 }
 
+class TestVaultKeyStore implements DevelopmentVaultKeyStore {
+  readonly values = new Map<string, Buffer>();
+
+  async get(vaultId: string): Promise<Buffer | undefined> {
+    const value = this.values.get(vaultId);
+    return value ? Buffer.from(value) : undefined;
+  }
+
+  async set(vaultId: string, key: Buffer): Promise<void> {
+    this.values.set(vaultId, Buffer.from(key));
+  }
+}
+
 describe('Electron development database', () => {
   it('uses a sibling user-data directory', () => {
     expect(developmentUserDataPath('/profiles/Muxus')).toBe('/profiles/Muxus-development');
@@ -45,7 +60,9 @@ describe('Electron development database', () => {
     `);
 
     try {
-      await expect(seedDevelopmentDatabase(installed, development)).resolves.toBe(true);
+      await expect(seedDevelopmentDatabase(installed, development)).resolves.toMatchObject({
+        databaseCopied: true,
+      });
     } finally {
       source.close();
     }
@@ -91,7 +108,9 @@ describe('Electron development database', () => {
     existing.exec("CREATE TABLE example(value TEXT NOT NULL); INSERT INTO example VALUES ('kept');");
     existing.close();
 
-    await expect(seedDevelopmentDatabase(installed, development)).resolves.toBe(false);
+    await expect(seedDevelopmentDatabase(installed, development)).resolves.toMatchObject({
+      databaseCopied: false,
+    });
 
     const unchanged = openDatabase(development);
     try {
@@ -99,5 +118,69 @@ describe('Electron development database', () => {
     } finally {
       unchanged.close();
     }
+  });
+
+  it('forces copied session history into development storage', async () => {
+    const { installed, development } = directories();
+    const source = openDatabase(installed);
+    source.exec(`
+      CREATE TABLE session_history_settings(
+        singleton INTEGER PRIMARY KEY,
+        storage_location TEXT
+      );
+      INSERT INTO session_history_settings VALUES (1, '/production/history');
+    `);
+    source.close();
+
+    await seedDevelopmentDatabase(installed, development);
+
+    const copy = openDatabase(development);
+    try {
+      expect(
+        copy.prepare('SELECT storage_location FROM session_history_settings').get(),
+      ).toEqual({ storage_location: null });
+    } finally {
+      copy.close();
+    }
+  });
+
+  it('namespaces automatic vault keys and drops copied cleanup work', async () => {
+    const { installed, development } = directories();
+    const sourceVaultId = 'production-vault-id';
+    const sourceKey = Buffer.alloc(32, 0x5a);
+    const keyStore = new TestVaultKeyStore();
+    keyStore.values.set(sourceVaultId, Buffer.from(sourceKey));
+
+    const source = openDatabase(installed);
+    source.exec(`
+      CREATE TABLE password_vault(
+        singleton INTEGER PRIMARY KEY,
+        vault_id TEXT NOT NULL,
+        unlock_policy TEXT NOT NULL
+      );
+      CREATE TABLE password_vault_key_cleanup(vault_id TEXT PRIMARY KEY);
+      INSERT INTO password_vault VALUES (1, '${sourceVaultId}', 'never');
+      INSERT INTO password_vault_key_cleanup VALUES ('production-old-vault');
+    `);
+    source.close();
+
+    await expect(
+      seedDevelopmentDatabase(installed, development, keyStore),
+    ).resolves.toEqual({ databaseCopied: true, automaticVaultKey: 'copied' });
+
+    const namespacedVaultId = developmentVaultId(sourceVaultId);
+    const copy = openDatabase(development);
+    try {
+      expect(copy.prepare('SELECT vault_id FROM password_vault').get()).toEqual({
+        vault_id: namespacedVaultId,
+      });
+      expect(copy.prepare('SELECT vault_id FROM password_vault_key_cleanup').all()).toEqual(
+        [],
+      );
+    } finally {
+      copy.close();
+    }
+    expect(keyStore.values.get(sourceVaultId)).toEqual(sourceKey);
+    expect(keyStore.values.get(namespacedVaultId)).toEqual(sourceKey);
   });
 });

--- a/tests/unit/electron/development-database.test.ts
+++ b/tests/unit/electron/development-database.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  developmentUserDataPath,
+  seedDevelopmentDatabase,
+} from '../../../electron/src/development-database.js';
+
+let temporaryDirectory: string | undefined;
+
+afterEach(() => {
+  if (temporaryDirectory) {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = undefined;
+  }
+});
+
+function directories(): { installed: string; development: string } {
+  temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), 'muxus-electron-database-'));
+  const installed = path.join(temporaryDirectory, 'Muxus');
+  const development = developmentUserDataPath(installed);
+  mkdirSync(installed, { recursive: true });
+  mkdirSync(development, { recursive: true });
+  return { installed, development };
+}
+
+function openDatabase(directory: string): DatabaseSync {
+  return new DatabaseSync(path.join(directory, 'muxus.sqlite3'));
+}
+
+describe('Electron development database', () => {
+  it('uses a sibling user-data directory', () => {
+    expect(developmentUserDataPath('/profiles/Muxus')).toBe('/profiles/Muxus-development');
+  });
+
+  it('copies committed WAL data from the installed database', async () => {
+    const { installed, development } = directories();
+    const source = openDatabase(installed);
+    source.exec(`
+      PRAGMA journal_mode = WAL;
+      CREATE TABLE example(value TEXT NOT NULL);
+      INSERT INTO example VALUES ('installed');
+    `);
+
+    try {
+      await expect(seedDevelopmentDatabase(installed, development)).resolves.toBe(true);
+    } finally {
+      source.close();
+    }
+
+    const copy = openDatabase(development);
+    try {
+      expect(copy.prepare('SELECT value FROM example').get()).toEqual({ value: 'installed' });
+      expect(copy.prepare('PRAGMA integrity_check').get()).toEqual({ integrity_check: 'ok' });
+    } finally {
+      copy.close();
+    }
+  });
+
+  it('refreshes an existing development database on every seed', async () => {
+    const { installed, development } = directories();
+    const source = openDatabase(installed);
+    source.exec('CREATE TABLE example(value TEXT NOT NULL); INSERT INTO example VALUES (\'first\');');
+    source.close();
+    await seedDevelopmentDatabase(installed, development);
+
+    const stale = openDatabase(development);
+    stale.exec("INSERT INTO example VALUES ('development-only');");
+    stale.close();
+
+    const updatedSource = openDatabase(installed);
+    updatedSource.exec("DELETE FROM example; INSERT INTO example VALUES ('second');");
+    updatedSource.close();
+    await seedDevelopmentDatabase(installed, development);
+
+    const refreshed = openDatabase(development);
+    try {
+      expect(refreshed.prepare('SELECT value FROM example').all()).toEqual([
+        { value: 'second' },
+      ]);
+    } finally {
+      refreshed.close();
+    }
+  });
+
+  it('keeps the development database when no installed database exists', async () => {
+    const { installed, development } = directories();
+    const existing = openDatabase(development);
+    existing.exec("CREATE TABLE example(value TEXT NOT NULL); INSERT INTO example VALUES ('kept');");
+    existing.close();
+
+    await expect(seedDevelopmentDatabase(installed, development)).resolves.toBe(false);
+
+    const unchanged = openDatabase(development);
+    try {
+      expect(unchanged.prepare('SELECT value FROM example').get()).toEqual({ value: 'kept' });
+    } finally {
+      unchanged.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- use a separate `Muxus-development` user-data directory for unpackaged Electron runs
- refresh the development database from the installed database on every launch using SQLite's backup API
- preserve committed WAL data while keeping all development writes isolated
- document the development database behavior and cover refresh and fallback cases

## Why

`pnpm electron` previously opened the installed application's database directly. Development migrations could therefore make that database incompatible with the installed build.

## Impact

When an installed database exists, each development launch begins with a safe snapshot of it and then writes only to the development copy. Without an installed database, the existing development database is retained or a fresh one is created.

## Validation

- `pnpm build`
- `pnpm test` (645 passed, 3 skipped)
- `pnpm lint`
- Electron and test package type checks
- manual Electron startup against the separate development profile