### PR TITLE
Add shared SSH credentials for sidebar folders

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -83,9 +83,14 @@ const initialKeys = collectStaticGraph(entry[0]);
 // Background-output notifications also live in the tab store and tab strip,
 // both of which are required for first paint. The gzip budget moves by 1 KiB
 // to cover their state and visual treatment.
+//
+// Folder credential defaults ride the sidebar: folder rename, drag and delete
+// must carry the shared settings along, so the sidebar carries the small
+// folder-settings API module (~2 KiB raw / ~0.7 KiB gzip). The credentials
+// editor itself stays in the lazy folder dialog.
 check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 782_000,
-  gzip: 253_000,
+  raw: 785_000,
+  gzip: 254_000,
 });
 
 for (const feature of [

--- a/client/src/api/folder-settings.ts
+++ b/client/src/api/folder-settings.ts
@@ -1,0 +1,127 @@
+import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import type {
+  FolderAuthSettings,
+  FolderSettingsRecord,
+  FolderSettingsResponse,
+} from '@muxus/shared';
+import { isDescendantPath, isSamePath } from '../host-tree.js';
+import { showToast } from '../state/toast.js';
+import { apiFetch } from './http.js';
+
+const JSON_HEADERS = { 'content-type': 'application/json' };
+
+/** Shared per-folder SSH credential defaults (Termius-style group auth). */
+export function useFolderSettings(enabled = true) {
+  return useQuery({
+    queryKey: ['folder-settings'],
+    queryFn: () => apiFetch<FolderSettingsResponse>('/api/folders/settings'),
+    enabled,
+    staleTime: 5_000,
+  });
+}
+
+/** The folder's own settings record, matched case-insensitively. */
+export function folderSettingsForPath(
+  folders: readonly FolderSettingsRecord[] | undefined,
+  path: string,
+): FolderSettingsRecord | undefined {
+  return folders?.find((folder) => isSamePath(folder.path, path));
+}
+
+/** Whether the folder or anything nested inside it stores credentials. */
+export function hasFolderSettingsUnder(
+  folders: readonly FolderSettingsRecord[] | undefined,
+  path: string,
+): boolean {
+  return (folders ?? []).some(
+    (folder) => isSamePath(folder.path, path) || isDescendantPath(folder.path, path),
+  );
+}
+
+export interface SaveFolderSettingsInput {
+  path: string;
+  auth: FolderAuthSettings;
+  /** A new password to store, null to remove the stored one, undefined to keep. */
+  password?: string | null;
+  /** Required by the server while the password vault is locked. */
+  masterPassword?: string;
+}
+
+export function useSaveFolderSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ path, auth, password, masterPassword }: SaveFolderSettingsInput) => {
+      await apiFetch<{ folder: FolderSettingsRecord | null }>('/api/folders/settings', {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ path, auth }),
+      });
+      if (typeof password === 'string') {
+        await apiFetch<{ folder: FolderSettingsRecord }>('/api/folders/settings/password', {
+          method: 'PUT',
+          headers: JSON_HEADERS,
+          body: JSON.stringify({
+            path,
+            password,
+            ...(masterPassword ? { masterPassword } : {}),
+          }),
+        });
+      } else if (password === null) {
+        await apiFetch<{ deleted: boolean }>(
+          `/api/folders/settings/password?path=${encodeURIComponent(path)}`,
+          { method: 'DELETE' },
+        );
+      }
+    },
+    onError: (error) => {
+      showToast(
+        'error',
+        error instanceof Error && error.message
+          ? `Could not save the folder credentials: ${error.message}`
+          : 'Could not save the folder credentials.',
+      );
+    },
+    onSettled: () => invalidateFolderSettings(queryClient),
+  });
+}
+
+/** Carry folder credentials along with a folder rename or re-parent. */
+export function useMoveFolderSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ from, to }: { from: string; to: string }) =>
+      apiFetch<{ moved: number }>('/api/folders/settings/move', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ from, to }),
+      }),
+    onError: (_error, { to }) => {
+      showToast(
+        'error',
+        `The shared credentials did not follow the folder — edit “${to}” to restore them.`,
+      );
+    },
+    onSettled: () => invalidateFolderSettings(queryClient),
+  });
+}
+
+/** Deleting a folder removes its credentials; nested ones move up a level. */
+export function useDeleteFolderSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (path: string) =>
+      apiFetch<{ removed: number }>(
+        `/api/folders/settings?path=${encodeURIComponent(path)}`,
+        { method: 'DELETE' },
+      ),
+    onSettled: () => invalidateFolderSettings(queryClient),
+  });
+}
+
+function invalidateFolderSettings(queryClient: QueryClient): void {
+  void queryClient.invalidateQueries({ queryKey: ['folder-settings'] });
+  // Folder defaults feed the resolved values in the host list, and folder
+  // passwords appear as vault credentials.
+  void queryClient.invalidateQueries({ queryKey: ['ssh-config'] });
+  void queryClient.invalidateQueries({ queryKey: ['password-vault'] });
+}

--- a/client/src/api/folder-settings.ts
+++ b/client/src/api/folder-settings.ts
@@ -90,7 +90,7 @@ export function useMoveFolderSettings() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ from, to }: { from: string; to: string }) =>
-      apiFetch<{ moved: number }>('/api/folders/settings/move', {
+      apiFetch<{ moved: number; destinationPreserved: boolean }>('/api/folders/settings/move', {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ from, to }),

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -25,6 +25,12 @@ import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
 import SearchIcon from '@mui/icons-material/Search';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
+import {
+  hasFolderSettingsUnder,
+  useDeleteFolderSettings,
+  useFolderSettings,
+  useMoveFolderSettings,
+} from '../api/folder-settings.js';
 import { useApplyFolderMoves } from '../api/host-groups.js';
 import { useReorderManagedHosts } from '../api/host-order.js';
 import { useDeleteHostProfile, useUpdateHostProfileMetadata } from '../api/profiles.js';
@@ -115,6 +121,9 @@ export function SessionSidebar() {
   const updateProfileMetadata = useUpdateHostProfileMetadata();
   const reorder = useReorderManagedHosts();
   const applyFolderMoves = useApplyFolderMoves();
+  const { data: folderSettingsData } = useFolderSettings();
+  const moveFolderSettings = useMoveFolderSettings();
+  const deleteFolderSettings = useDeleteFolderSettings();
   const liveByKey = useLiveHostCounts();
   const folders = useFolderPrefs();
   const allHosts = useAllManagedHosts();
@@ -226,10 +235,13 @@ export function SessionSidebar() {
         if (moves.length > 0) applyFolderMoves.mutate({ moves, label: toPath });
         else folders.addEmptyFolder(toPath);
         folders.removeEmptyFolder(fromPath);
+        if (hasFolderSettingsUnder(folderSettingsData?.folders, fromPath)) {
+          moveFolderSettings.mutate({ from: fromPath, to: toPath });
+        }
       }
       if (placement) folders.setFolderOrder(placement.parentKey, placement.keys);
     },
-    [allHosts, folders, applyFolderMoves],
+    [allHosts, folders, applyFolderMoves, folderSettingsData, moveFolderSettings],
   );
 
   /** Alt+Arrow on a folder: swap it with the sibling folder next to it. */
@@ -370,12 +382,18 @@ export function SessionSidebar() {
     (node: FolderNode) => {
       const moves = deleteFolderPlan(allHosts, node.path);
       const parent = folderParentPath(node.path);
+      const hasCredentials = hasFolderSettingsUnder(folderSettingsData?.folders, node.path);
+      const hostsText =
+        moves.length === 0
+          ? 'The folder is empty.'
+          : `${moves.length} host${moves.length === 1 ? '' : 's'} move${moves.length === 1 ? 's' : ''} ${parent ? `up into “${parent}”` : 'out of every folder'}.`;
       void confirmAction({
         title: `Delete “${node.label}”?`,
-        description:
-          moves.length === 0
+        description: hasCredentials
+          ? `${hostsText} Its shared SSH credentials are removed.`
+          : moves.length === 0
             ? 'The folder is empty, so nothing else changes.'
-            : `${moves.length} host${moves.length === 1 ? '' : 's'} move${moves.length === 1 ? 's' : ''} ${parent ? `up into “${parent}”` : 'out of every folder'}. No connection settings change.`,
+            : `${hostsText} No connection settings change.`,
         confirmLabel: 'Delete folder',
         destructive: true,
       }).then((confirmed) => {
@@ -383,9 +401,10 @@ export function SessionSidebar() {
         folders.removeEmptyFolder(node.path);
         folders.setFolderStyle(node.key, undefined);
         if (moves.length > 0) applyFolderMoves.mutate({ moves, label: node.label });
+        if (hasCredentials) deleteFolderSettings.mutate(node.path);
       });
     },
-    [allHosts, folders, applyFolderMoves],
+    [allHosts, folders, applyFolderMoves, folderSettingsData, deleteFolderSettings],
   );
 
   // Where the menu's host sits among its siblings, for Move up / Move down.

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -235,13 +235,13 @@ export function SessionSidebar() {
         if (moves.length > 0) applyFolderMoves.mutate({ moves, label: toPath });
         else folders.addEmptyFolder(toPath);
         folders.removeEmptyFolder(fromPath);
-        if (hasFolderSettingsUnder(folderSettingsData?.folders, fromPath)) {
-          moveFolderSettings.mutate({ from: fromPath, to: toPath });
-        }
+        // The endpoint is idempotent. Always call it so credentials cannot be
+        // stranded when the folder-settings query is loading or has failed.
+        moveFolderSettings.mutate({ from: fromPath, to: toPath });
       }
       if (placement) folders.setFolderOrder(placement.parentKey, placement.keys);
     },
-    [allHosts, folders, applyFolderMoves, folderSettingsData, moveFolderSettings],
+    [allHosts, folders, applyFolderMoves, moveFolderSettings],
   );
 
   /** Alt+Arrow on a folder: swap it with the sibling folder next to it. */
@@ -382,18 +382,22 @@ export function SessionSidebar() {
     (node: FolderNode) => {
       const moves = deleteFolderPlan(allHosts, node.path);
       const parent = folderParentPath(node.path);
-      const hasCredentials = hasFolderSettingsUnder(folderSettingsData?.folders, node.path);
+      const hasCredentials = folderSettingsData
+        ? hasFolderSettingsUnder(folderSettingsData.folders, node.path)
+        : undefined;
       const hostsText =
         moves.length === 0
           ? 'The folder is empty.'
           : `${moves.length} host${moves.length === 1 ? '' : 's'} move${moves.length === 1 ? 's' : ''} ${parent ? `up into “${parent}”` : 'out of every folder'}.`;
       void confirmAction({
         title: `Delete “${node.label}”?`,
-        description: hasCredentials
+        description: hasCredentials === true
           ? `${hostsText} Its shared SSH credentials are removed.`
-          : moves.length === 0
-            ? 'The folder is empty, so nothing else changes.'
-            : `${hostsText} No connection settings change.`,
+          : hasCredentials === undefined
+            ? `${hostsText} Any shared SSH credentials on it are removed.`
+            : moves.length === 0
+              ? 'The folder is empty, so nothing else changes.'
+              : `${hostsText} No connection settings change.`,
         confirmLabel: 'Delete folder',
         destructive: true,
       }).then((confirmed) => {
@@ -401,7 +405,9 @@ export function SessionSidebar() {
         folders.removeEmptyFolder(node.path);
         folders.setFolderStyle(node.key, undefined);
         if (moves.length > 0) applyFolderMoves.mutate({ moves, label: node.label });
-        if (hasCredentials) deleteFolderSettings.mutate(node.path);
+        // Like move, delete is idempotent and must not depend on cached query
+        // data that may not have arrived yet.
+        deleteFolderSettings.mutate(node.path);
       });
     },
     [allHosts, folders, applyFolderMoves, folderSettingsData, deleteFolderSettings],
@@ -688,4 +694,3 @@ function collectHosts(node: ContainerNode): ManagedHost[] {
   walk(node);
   return out;
 }
-

--- a/client/src/components/sidebar/FolderDialog.tsx
+++ b/client/src/components/sidebar/FolderDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
@@ -6,12 +7,27 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
+import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined';
+import type { FolderAuthSettings } from '@muxus/shared';
+import {
+  folderSettingsForPath,
+  hasFolderSettingsUnder,
+  useFolderSettings,
+  useMoveFolderSettings,
+  useSaveFolderSettings,
+} from '../../api/folder-settings.js';
 import { useApplyFolderMoves } from '../../api/host-groups.js';
-import { useSavedHostProfiles, useSshConfig } from '../../api/queries.js';
+import { usePasswordVaultStatus } from '../../api/password-vault-queries.js';
+import { useSavedHostProfiles, useSshConfig, useSshKeys } from '../../api/queries.js';
 import {
   folderKey,
   folderLabel,
@@ -59,6 +75,12 @@ export function FolderDialog() {
   const [parent, setParent] = useState('');
   const [color, setColor] = useState<string | undefined>();
   const [icon, setIcon] = useState<string | undefined>();
+  const [authUser, setAuthUser] = useState('');
+  const [authPort, setAuthPort] = useState('');
+  const [authKey, setAuthKey] = useState('');
+  const [authPassword, setAuthPassword] = useState('');
+  const [removePassword, setRemovePassword] = useState(false);
+  const [masterPassword, setMasterPassword] = useState('');
 
   // Load the folder's current shape once, when the dialog opens on it.
   useEffect(() => {
@@ -86,6 +108,31 @@ export function FolderDialog() {
   const mode = state === false ? undefined : state.mode;
   const sourcePath = state !== false && state.mode === 'edit' ? state.path : '';
 
+  const saveSettings = useSaveFolderSettings();
+  const moveSettings = useMoveFolderSettings();
+  const { data: settingsData } = useFolderSettings(state !== false && !movingHost);
+  const { data: vaultStatus } = usePasswordVaultStatus();
+  const { data: sshKeys } = useSshKeys(state !== false && !movingHost);
+  const settingsRecord = sourcePath
+    ? folderSettingsForPath(settingsData?.folders, sourcePath)
+    : undefined;
+
+  // Seed the credential fields separately: the settings arrive from their own
+  // query and may land a beat after the dialog opens.
+  const seedUser = settingsRecord?.auth.user ?? '';
+  const seedPort = settingsRecord?.auth.port !== undefined ? String(settingsRecord.auth.port) : '';
+  const seedKey = settingsRecord?.auth.identityFiles?.[0] ?? '';
+  useEffect(() => {
+    if (state === false || state.mode === 'move-host') return;
+    const editing = state.mode === 'edit';
+    setAuthUser(editing ? seedUser : '');
+    setAuthPort(editing ? seedPort : '');
+    setAuthKey(editing ? seedKey : '');
+    setAuthPassword('');
+    setRemovePassword(false);
+    setMasterPassword('');
+  }, [state, seedUser, seedPort, seedKey]);
+
   const target = movingHost
     ? normalizeGroupPath(parent)
     : normalizeGroupPath(folderPath([...folderSegments(parent), sanitizeFolderName(name)]));
@@ -108,9 +155,51 @@ export function FolderDialog() {
     [renaming, config?.hosts, savedData?.profiles, emptyFolders, target, sourcePath],
   );
 
+  const portNumber = authPort.trim() === '' ? undefined : Number(authPort.trim());
+  const portInvalid =
+    portNumber !== undefined &&
+    !(Number.isInteger(portNumber) && portNumber >= 1 && portNumber <= 65535);
+  const vaultConfigured = vaultStatus?.configured ?? false;
+  const passwordNeedsMaster =
+    vaultConfigured && (vaultStatus?.locked ?? false) && authPassword.length > 0;
+
   if (state === false) return null;
 
   const close = () => setState(false);
+
+  /** Write the credential fields for `path`, after moving them off `previousPath`. */
+  const persistCredentials = (path: string, previousPath?: string) => {
+    const auth: FolderAuthSettings = {
+      ...(authUser.trim() ? { user: authUser.trim() } : {}),
+      ...(portNumber !== undefined && !portInvalid ? { port: portNumber } : {}),
+      // A folder key means "log in with exactly this key", like the host
+      // editor's specific-key mode.
+      ...(authKey.trim() ? { identityFiles: [authKey.trim()], identitiesOnly: true } : {}),
+    };
+    const password = authPassword
+      ? authPassword
+      : removePassword && settingsRecord?.hasPassword
+        ? null
+        : undefined;
+    const dirty = !!settingsRecord || Object.keys(auth).length > 0 || password !== undefined;
+    const save = () => {
+      if (!dirty) return;
+      saveSettings.mutate({
+        path,
+        auth,
+        password,
+        ...(masterPassword.trim() ? { masterPassword: masterPassword.trim() } : {}),
+      });
+    };
+    if (previousPath && hasFolderSettingsUnder(settingsData?.folders, previousPath)) {
+      void moveSettings
+        .mutateAsync({ from: previousPath, to: path })
+        .then(save)
+        .catch(() => undefined);
+      return;
+    }
+    save();
+  };
 
   const submit = () => {
     if (movingHost) {
@@ -121,11 +210,12 @@ export function FolderDialog() {
       close();
       return;
     }
-    if (problem) return;
+    if (problem || portInvalid || (passwordNeedsMaster && !masterPassword.trim())) return;
 
     if (mode === 'new') {
       folders.addEmptyFolder(target);
       folders.setFolderStyle(folderKey(target), { color, icon });
+      persistCredentials(target);
       close();
       return;
     }
@@ -142,7 +232,10 @@ export function FolderDialog() {
       if (!isSamePath(sourcePath, target)) folders.removeEmptyFolder(sourcePath);
       if (affected.length > 0) applyMoves.mutate({ moves: affected, label: target });
       else folders.addEmptyFolder(target);
+      persistCredentials(target, sourcePath);
       showToast('success', `Folder renamed to “${target}”.`);
+    } else {
+      persistCredentials(normalizeGroupPath(sourcePath));
     }
     close();
   };
@@ -265,6 +358,150 @@ export function FolderDialog() {
                     )}
                   </Box>
                 </Box>
+
+                <Divider sx={{ mt: 0.5 }} />
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    Shared SSH credentials
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Hosts in this folder use these unless they set their own.
+                    Anything in your ssh config still wins, and the nearest
+                    folder beats its parents.
+                  </Typography>
+                </Box>
+                <Stack direction="row" spacing={1.5}>
+                  <TextField
+                    label="Username"
+                    value={authUser}
+                    onChange={(event) => setAuthUser(event.target.value)}
+                    placeholder="from ssh config"
+                    fullWidth
+                  />
+                  <TextField
+                    label="Port"
+                    value={authPort}
+                    onChange={(event) => setAuthPort(event.target.value)}
+                    placeholder="22"
+                    error={portInvalid}
+                    sx={{ width: 130 }}
+                  />
+                </Stack>
+                <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+                  <Autocomplete
+                    freeSolo
+                    fullWidth
+                    options={sshKeys?.keys ?? []}
+                    getOptionLabel={(option) =>
+                      typeof option === 'string' ? option : option.path
+                    }
+                    inputValue={authKey}
+                    onInputChange={(_event, value) => setAuthKey(value)}
+                    renderOption={(props, option) => (
+                      <Box component="li" {...props} key={option.path}>
+                        <Box sx={{ minWidth: 0 }}>
+                          <Typography variant="body2">{option.name}</Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            noWrap
+                            sx={{ display: 'block' }}
+                          >
+                            {option.path}
+                          </Typography>
+                        </Box>
+                      </Box>
+                    )}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Private key"
+                        placeholder="pick from ~/.ssh or type a path"
+                        helperText={
+                          authKey.trim()
+                            ? 'Hosts without their own key log in with exactly this key.'
+                            : undefined
+                        }
+                      />
+                    )}
+                  />
+                  {window.muxusDesktop && (
+                    <Tooltip title="Browse for a key file">
+                      <IconButton
+                        aria-label="Browse for a key file"
+                        onClick={() => {
+                          void window.muxusDesktop?.selectPrivateKey().then((path) => {
+                            if (path) setAuthKey(path);
+                          });
+                        }}
+                        sx={{ mt: 0.75 }}
+                      >
+                        <FolderOpenOutlinedIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Stack>
+                <TextField
+                  label="Shared password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={authPassword}
+                  onChange={(event) => {
+                    setAuthPassword(event.target.value);
+                    if (event.target.value) setRemovePassword(false);
+                  }}
+                  disabled={!vaultConfigured}
+                  placeholder={
+                    settingsRecord?.hasPassword && !removePassword ? '•••••••• (saved)' : undefined
+                  }
+                  helperText={
+                    !vaultConfigured
+                      ? 'Set up the password vault in Settings → Passwords to store a shared password.'
+                      : removePassword
+                        ? 'The saved password is removed when you save.'
+                        : settingsRecord?.hasPassword
+                          ? 'Leave empty to keep the saved password.'
+                          : 'Offered when a host falls back to password login; kept in the encrypted vault.'
+                  }
+                  slotProps={{
+                    input: {
+                      endAdornment:
+                        settingsRecord?.hasPassword && !authPassword ? (
+                          <InputAdornment position="end">
+                            <Tooltip
+                              title={removePassword ? 'Keep the saved password' : 'Remove the saved password'}
+                            >
+                              <IconButton
+                                size="small"
+                                aria-label={
+                                  removePassword ? 'Keep the saved password' : 'Remove the saved password'
+                                }
+                                onClick={() => setRemovePassword((value) => !value)}
+                              >
+                                {removePassword ? (
+                                  <UndoOutlinedIcon fontSize="small" />
+                                ) : (
+                                  <DeleteOutlineIcon fontSize="small" />
+                                )}
+                              </IconButton>
+                            </Tooltip>
+                          </InputAdornment>
+                        ) : undefined,
+                    },
+                  }}
+                  fullWidth
+                />
+                {passwordNeedsMaster && (
+                  <TextField
+                    label="Vault master password"
+                    type="password"
+                    autoComplete="current-password"
+                    value={masterPassword}
+                    onChange={(event) => setMasterPassword(event.target.value)}
+                    helperText="The password vault is locked — its master password is needed to store this."
+                    fullWidth
+                  />
+                )}
               </>
             )}
 
@@ -282,7 +519,13 @@ export function FolderDialog() {
           <Button
             type="submit"
             variant="contained"
-            disabled={(!movingHost && !!problem) || applyMoves.isPending}
+            disabled={
+              (!movingHost &&
+                (!!problem ||
+                  portInvalid ||
+                  (passwordNeedsMaster && !masterPassword.trim()))) ||
+              applyMoves.isPending
+            }
           >
             {movingHost ? 'Move' : mode === 'new' ? 'Create' : 'Save'}
           </Button>

--- a/client/src/components/sidebar/FolderDialog.tsx
+++ b/client/src/components/sidebar/FolderDialog.tsx
@@ -20,7 +20,6 @@ import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined';
 import type { FolderAuthSettings } from '@muxus/shared';
 import {
   folderSettingsForPath,
-  hasFolderSettingsUnder,
   useFolderSettings,
   useMoveFolderSettings,
   useSaveFolderSettings,
@@ -191,10 +190,12 @@ export function FolderDialog() {
         ...(masterPassword.trim() ? { masterPassword: masterPassword.trim() } : {}),
       });
     };
-    if (previousPath && hasFolderSettingsUnder(settingsData?.folders, previousPath)) {
+    if (previousPath) {
       void moveSettings
         .mutateAsync({ from: previousPath, to: path })
-        .then(save)
+        .then(({ destinationPreserved }) => {
+          if (!destinationPreserved) save();
+        })
         .catch(() => undefined);
       return;
     }

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -1,4 +1,6 @@
 import type {
+  FolderAuthSettings,
+  FolderSettingsResponse,
   HostBlockOptions,
   HostUpsertRequest,
   ManagedHostRef,
@@ -94,6 +96,12 @@ export interface BackupLoggingPolicy {
   policy: SessionLoggingPolicyInput;
 }
 
+/** A folder's shared SSH defaults. The vault password never leaves the vault. */
+export interface PortableFolderSettings {
+  path: string;
+  auth: FolderAuthSettings;
+}
+
 export type PortableHistorySettings = Omit<
   SessionHistorySettings,
   'storageLocation'
@@ -109,6 +117,8 @@ export interface MuxusBackupV1 {
     tunnels: TunnelRecord[];
     loggingPolicies: BackupLoggingPolicy[];
     historySettings: PortableHistorySettings;
+    /** Absent in backups from before folder credentials existed. */
+    folderSettings?: PortableFolderSettings[];
   };
 }
 
@@ -165,7 +175,7 @@ export async function createBackupDocument(
     ...snapshot.sshConfig.hosts.map((host) => `ssh:${host.alias}`),
     ...snapshot.savedHosts.map((profile) => `profile:${profile.id}`),
   ];
-  const [policies, storage] = await Promise.all([
+  const [policies, storage, folderSettings] = await Promise.all([
     Promise.all(
       profileKeys.map((profileKey) =>
         apiFetch<SessionLoggingPolicy>(
@@ -174,6 +184,7 @@ export async function createBackupDocument(
       ),
     ),
     apiFetch<SessionHistoryStorageStatus>('/api/session-history/storage'),
+    apiFetch<FolderSettingsResponse>('/api/folders/settings'),
   ]);
   const { storageLocation: _storageLocation, ...historySettings } =
     storage.settings;
@@ -193,6 +204,9 @@ export async function createBackupDocument(
           policy: { enabled, captureInput, maxPartBytes, maxParts },
         })),
       historySettings,
+      folderSettings: folderSettings.folders
+        .filter((folder) => Object.keys(folder.auth).length > 0)
+        .map(({ path, auth }) => ({ path, auth })),
     },
   };
 }
@@ -278,6 +292,7 @@ export async function restoreTransferDocument(
   const result: RestoreResult = { added: 0, updated: 0, skipped: 0 };
   if (selection.connections) {
     await restoreConnections(document.data, conflicts, result);
+    await restoreFolderSettings(document.data.folderSettings ?? [], conflicts, result);
   }
 
   if (selection.tunnels) {
@@ -538,6 +553,30 @@ async function restoreConnections(
   }
 }
 
+async function restoreFolderSettings(
+  entries: readonly PortableFolderSettings[],
+  conflicts: TransferConflictStrategy,
+  result: RestoreResult,
+): Promise<void> {
+  if (entries.length === 0) return;
+  const current = await apiFetch<FolderSettingsResponse>('/api/folders/settings');
+  const existingPaths = new Set(current.folders.map((folder) => folder.path.toLowerCase()));
+  for (const entry of entries) {
+    const exists = existingPaths.has(entry.path.toLowerCase());
+    if (exists && conflicts === 'keep') {
+      result.skipped++;
+      continue;
+    }
+    await apiFetch<{ folder: unknown }>('/api/folders/settings', {
+      method: 'PUT',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ path: entry.path, auth: entry.auth }),
+    });
+    if (exists) result.updated++;
+    else result.added++;
+  }
+}
+
 function metadataPatch(metadata: PortableHostMetadata): OpenSshMetadataPatch {
   return {
     displayName: metadata.displayName ?? null,
@@ -771,7 +810,16 @@ function validateBackupData(data: Record<string, unknown>): void {
     ) ||
     !finiteNumber(data.historySettings.maxTotalBytes) ||
     !finiteNumber(data.historySettings.minFreeBytes) ||
-    !finiteNumber(data.historySettings.minFreePercent)
+    !finiteNumber(data.historySettings.minFreePercent) ||
+    (data.folderSettings !== undefined &&
+      (!boundedArray(data.folderSettings, 500) ||
+        !data.folderSettings.every(
+          (entry) =>
+            isRecord(entry) &&
+            nonEmptyString(entry.path) &&
+            entry.path.length <= 300 &&
+            isRecord(entry.auth),
+        )))
   ) {
     throw new Error('The backup data is incomplete or too large.');
   }

--- a/docs/guide/hosts.md
+++ b/docs/guide/hosts.md
@@ -66,6 +66,23 @@ Hosts without a folder are grouped by the file they were defined in.
 Deleting a folder does not delete hosts. They move up into the parent folder, and no
 connection setting changes.
 
+### Shared credentials
+
+A folder can hold shared SSH defaults — username, port, a private key and a password —
+that every host inside it inherits. Open **Rename, move & style…** and fill in the
+**Shared SSH credentials** section.
+
+Precedence is always: the host's own settings first, then anything in `ssh_config`
+(including `Host *` blocks), then the nearest folder, then its parents. A folder never
+overrides something you configured on the host or in `ssh_config` — it only fills the
+gaps, so one folder entry can carry the login for a whole lab while individual hosts
+still override it by setting their own user or key.
+
+The shared password is kept in the encrypted [password vault](settings.md) and is tried
+automatically when a host falls back to password login; a password remembered for the
+host itself still wins. Folder credentials move with the folder when it is renamed or
+dragged, and deleting the folder deletes them.
+
 ### Launching a folder
 
 A folder's menu offers **Launch *n* hosts…**, which opens every host it contains, including

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,6 +8,7 @@ import fastifyStatic from '@fastify/static';
 import { TERMINAL_WS_PROTOCOL } from '@muxus/shared/ws-protocol';
 import type { ServerConfig } from './config.js';
 import { SshConnectionManager } from './ssh/connection-manager.js';
+import { folderAuthResolver } from './ssh/folder-auth.js';
 import { ForwardManager } from './forwards/forward-manager.js';
 import { registerAppRoutes } from './routes/app.js';
 import { registerSshRoutes } from './routes/ssh.js';
@@ -25,6 +26,7 @@ import { registerProfileRoutes } from './routes/profiles.js';
 import { registerHostOrderRoutes } from './routes/host-order.js';
 import { registerSessionHistoryRoutes } from './routes/session-history.js';
 import { registerPasswordVaultRoutes } from './routes/password-vault.js';
+import { registerFolderRoutes } from './routes/folders.js';
 import { registerLogRoutes } from './routes/logs.js';
 import { appLogPinoSink } from './logging/log-buffer.js';
 import {
@@ -88,7 +90,10 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   const database = new MuxusDatabase(config.databasePath);
   const vault = new PasswordVault(database);
   await vault.initialize();
-  const connections = new SshConnectionManager(app.log, { vault });
+  const connections = new SshConnectionManager(app.log, {
+    vault,
+    folderAuth: folderAuthResolver(database),
+  });
   const forwards = new ForwardManager(connections, app.log);
   const historySettings = database.sessionHistorySettings();
   const configuredHistoryRoot =
@@ -176,6 +181,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   registerHostOrderRoutes(app, ctx);
   registerSessionHistoryRoutes(app, ctx);
   registerPasswordVaultRoutes(app, ctx);
+  registerFolderRoutes(app, ctx);
   registerLogRoutes(app);
   registerTerminalSocket(app, ctx);
   registerSftpLeaseSocket(app, ctx);

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -7,6 +7,7 @@ import {
 } from 'node:sqlite';
 import { nanoid } from 'nanoid';
 import type {
+  FolderAuthSettings,
   ForwardType,
   HostKeywordHighlightConfig,
   ManagedHostRef,
@@ -22,6 +23,13 @@ import type {
   TunnelRecord,
   WorkspaceMultiExecGroup,
 } from '@muxus/shared';
+import {
+  folderPathKey,
+  folderPathSegments,
+  isDescendantFolderPath,
+  normalizeFolderPath,
+  renameFolderPathUnder,
+} from '../util/folder-paths.js';
 
 const MIGRATIONS = [
   {
@@ -342,6 +350,20 @@ const MIGRATIONS = [
       ) STRICT;
     `,
   },
+  {
+    version: 17,
+    name: 'folder-settings',
+    sql: `
+      CREATE TABLE folder_settings (
+        id TEXT PRIMARY KEY,
+        path_key TEXT NOT NULL UNIQUE,
+        path TEXT NOT NULL,
+        auth_json TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(auth_json)),
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      ) STRICT;
+    `,
+  },
 ] as const;
 
 function migrateDraftPasswordVault(db: DatabaseSync): void {
@@ -423,6 +445,16 @@ export interface OpenSshMetadata {
   keywordHighlights?: HostKeywordHighlightConfig;
   lastConnectedAt?: string;
   connectCount: number;
+}
+
+/** One folder's shared SSH defaults, keyed by its case-folded path. */
+export interface FolderSettingsRow {
+  id: string;
+  path: string;
+  pathKey: string;
+  auth: FolderAuthSettings;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface NativeConnectionInput {
@@ -610,6 +642,12 @@ export class MuxusDatabase {
       result.set(alias, metadataFromRow(row));
     }
     return result;
+  }
+
+  /** The sidebar folder an OpenSSH alias lives in, for dial-time folder defaults. */
+  groupForAlias(alias: string): string | undefined {
+    const row = this.metadataByAlias.get(alias);
+    return row ? optionalString(row.group_name) : undefined;
   }
 
   updateOpenSshMetadata(
@@ -945,6 +983,26 @@ export class MuxusDatabase {
     }
     this.flushSensitivePages();
     return this.encryptedCredential(input.provider, input.service, input.account)!;
+  }
+
+  /** Refresh a credential's display label (a folder password after a rename). */
+  updateCredentialRefLabel(
+    provider: string,
+    service: string,
+    account: string,
+    label: string,
+  ): boolean {
+    return (
+      Number(
+        this.db
+          .prepare(`
+            UPDATE credential_refs
+            SET label = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE provider = ? AND service = ? AND account = ?
+          `)
+          .run(label, provider, service, account).changes,
+      ) === 1
+    );
   }
 
   deleteEncryptedCredential(id: string, provider: string): boolean {
@@ -1537,6 +1595,138 @@ export class MuxusDatabase {
     return this.metadataByAlias.get(alias)!;
   }
 
+  listFolderSettings(): FolderSettingsRow[] {
+    return this.db
+      .prepare('SELECT * FROM folder_settings ORDER BY path_key')
+      .all()
+      .map(folderSettingsFromRow);
+  }
+
+  /** Exact-path lookup; `path` may be any capitalization of the folder. */
+  folderSettingsForPath(path: string): FolderSettingsRow | undefined {
+    const key = folderPathKey(path);
+    if (!key) return undefined;
+    const row = this.db
+      .prepare('SELECT * FROM folder_settings WHERE path_key = ?')
+      .get(key);
+    return row ? folderSettingsFromRow(row) : undefined;
+  }
+
+  upsertFolderSettings(path: string, auth: FolderAuthSettings): FolderSettingsRow {
+    const normalized = normalizeFolderPath(path);
+    requireNonEmpty(normalized, 'path');
+    assertSecretFree(auth, 'folder.auth');
+    const key = folderPathKey(normalized);
+    this.db
+      .prepare(`
+        INSERT INTO folder_settings(id, path_key, path, auth_json)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(path_key) DO UPDATE SET
+          path = excluded.path,
+          auth_json = excluded.auth_json,
+          updated_at = CURRENT_TIMESTAMP
+      `)
+      .run(nanoid(), key, normalized, JSON.stringify(auth));
+    return this.folderSettingsForPath(normalized)!;
+  }
+
+  /** Remove one settings row only — descendants keep their own settings. */
+  removeFolderSettingsRow(id: string): void {
+    this.db.prepare('DELETE FROM folder_settings WHERE id = ?').run(id);
+  }
+
+  /**
+   * Carry settings across a folder rename or move: the folder itself and every
+   * descendant follow the path rewrite. When a destination path already has a
+   * row (a merge), the destination keeps its settings and the source row is
+   * dropped — the dropped rows are returned so callers can clean up their
+   * vault passwords.
+   */
+  moveFolderSettings(from: string, to: string): { moved: number; dropped: FolderSettingsRow[] } {
+    const source = normalizeFolderPath(from);
+    const target = normalizeFolderPath(to);
+    requireNonEmpty(source, 'from');
+    requireNonEmpty(target, 'to');
+    if (source === target) return { moved: 0, dropped: [] };
+    const dropped: FolderSettingsRow[] = [];
+    let moved = 0;
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const update = this.db.prepare(`
+        UPDATE folder_settings
+        SET path_key = ?, path = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+      `);
+      const remove = this.db.prepare('DELETE FROM folder_settings WHERE id = ?');
+      const occupied = this.db.prepare('SELECT id FROM folder_settings WHERE path_key = ?');
+      for (const row of this.listFolderSettings()) {
+        const next = renameFolderPathUnder(row.path, source, target);
+        if (next === undefined) continue;
+        const nextKey = folderPathKey(next);
+        const existing = occupied.get(nextKey);
+        if (existing && String(existing.id) !== row.id) {
+          remove.run(row.id);
+          dropped.push(row);
+          continue;
+        }
+        update.run(nextKey, next, row.id);
+        moved++;
+      }
+      this.db.exec('COMMIT');
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+    return { moved, dropped };
+  }
+
+  /**
+   * Delete a folder's settings the way deleting the folder treats its hosts:
+   * the folder's own row is removed and descendant rows are promoted one level
+   * up (colliding promotions are dropped in favor of the existing row).
+   * Returns every removed row so callers can delete the vault passwords.
+   */
+  deleteFolderSettings(path: string): { removed: FolderSettingsRow[] } {
+    const target = normalizeFolderPath(path);
+    requireNonEmpty(target, 'path');
+    const removed: FolderSettingsRow[] = [];
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const remove = this.db.prepare('DELETE FROM folder_settings WHERE id = ?');
+      const own = this.folderSettingsForPath(target);
+      if (own) {
+        remove.run(own.id);
+        removed.push(own);
+      }
+      const parentSegments = folderPathSegments(target).slice(0, -1);
+      const depth = folderPathSegments(target).length;
+      const update = this.db.prepare(`
+        UPDATE folder_settings
+        SET path_key = ?, path = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+      `);
+      const occupied = this.db.prepare('SELECT id FROM folder_settings WHERE path_key = ?');
+      for (const row of this.listFolderSettings()) {
+        if (!isDescendantFolderPath(row.path, target)) continue;
+        const tail = folderPathSegments(row.path).slice(depth);
+        const next = [...parentSegments, ...tail].join('/');
+        const nextKey = folderPathKey(next);
+        const existing = occupied.get(nextKey);
+        if (existing && String(existing.id) !== row.id) {
+          remove.run(row.id);
+          removed.push(row);
+          continue;
+        }
+        update.run(nextKey, next, row.id);
+      }
+      this.db.exec('COMMIT');
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+    return { removed };
+  }
+
   /** Reuse group names case-insensitively so typing "work" and "Work" cannot
    *  silently create two visually indistinguishable sidebar groups. A spelling
    *  that differs only by case updates the row instead of being discarded, so
@@ -1692,6 +1882,17 @@ function tunnelFromRow(row: SqlRow): TunnelRecord {
     bindPort: Number(row.bind_port),
     targetHost: type === 'dynamic' ? undefined : String(row.target_host),
     targetPort: type === 'dynamic' ? undefined : Number(row.target_port),
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+function folderSettingsFromRow(row: SqlRow): FolderSettingsRow {
+  return {
+    id: String(row.id),
+    path: String(row.path),
+    pathKey: String(row.path_key),
+    auth: JSON.parse(String(row.auth_json)) as FolderAuthSettings,
     createdAt: String(row.created_at),
     updatedAt: String(row.updated_at),
   };

--- a/server/src/routes/folders.ts
+++ b/server/src/routes/folders.ts
@@ -1,0 +1,183 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type {
+  FolderAuthSettings,
+  FolderSettingsRecord,
+  FolderSettingsResponse,
+} from '@muxus/shared';
+import type { AppContext } from '../app.js';
+import type { FolderSettingsRow } from '../persistence/database.js';
+import {
+  folderPasswordAccount,
+  folderPasswordLabel,
+} from '../security/password-vault.js';
+import {
+  folderPathKey,
+  isDescendantFolderPath,
+  normalizeFolderPath,
+} from '../util/folder-paths.js';
+import { sendError } from '../util/errors.js';
+import { sendVaultError } from './password-vault.js';
+
+// Mirrors the metadata group cap: a path covers several nested folder names.
+const pathSchema = z.string().min(1).max(300);
+
+// Length caps only — cleanAuth trims values and drops the empty ones.
+const authSchema = z.object({
+  user: z.string().max(200).optional(),
+  port: z.number().int().min(1).max(65535).optional(),
+  identityFiles: z.array(z.string().max(1024)).max(10).optional(),
+  identitiesOnly: z.boolean().optional(),
+  identityAgent: z.string().max(1024).optional(),
+  forwardAgent: z.boolean().optional(),
+});
+
+const upsertSchema = z.object({ path: pathSchema, auth: authSchema });
+const moveSchema = z.object({ from: pathSchema, to: pathSchema });
+const pathQuerySchema = z.object({ path: pathSchema });
+const passwordSchema = z.object({
+  path: pathSchema,
+  password: z.string().min(1).max(8192),
+  masterPassword: z.string().min(1).max(1024).optional(),
+});
+
+/**
+ * Shared credential defaults for sidebar folders. Non-secret settings live in
+ * the folder_settings table; the folder password goes through the encrypted
+ * password vault, referenced by the settings row's stable ID.
+ */
+export function registerFolderRoutes(app: FastifyInstance, ctx: AppContext): void {
+  const record = (row: FolderSettingsRow): FolderSettingsRecord => ({
+    id: row.id,
+    path: row.path,
+    auth: row.auth,
+    hasPassword: ctx.vault.hasSshPassword(folderPasswordAccount(row.id)),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  });
+
+  app.get('/api/folders/settings', (): FolderSettingsResponse => ({
+    folders: ctx.database.listFolderSettings().map(record),
+  }));
+
+  app.put('/api/folders/settings', async (req, reply): Promise<{ folder: FolderSettingsRecord | null } | void> => {
+    const parsed = upsertSchema.safeParse(req.body);
+    if (!parsed.success || !normalizeFolderPath(parsed.data.path)) {
+      return reply.code(400).send({ message: parsed.success ? 'a folder path is required' : (parsed.error.issues[0]?.message ?? 'invalid folder settings') });
+    }
+    try {
+      const auth = cleanAuth(parsed.data.auth);
+      const row = ctx.database.upsertFolderSettings(parsed.data.path, auth);
+      // A folder with no settings and no password needs no row at all.
+      if (
+        Object.keys(auth).length === 0 &&
+        !ctx.vault.hasSshPassword(folderPasswordAccount(row.id))
+      ) {
+        ctx.database.removeFolderSettingsRow(row.id);
+        return { folder: null };
+      }
+      return { folder: record(row) };
+    } catch (err) {
+      return sendError(reply, err);
+    }
+  });
+
+  /** Rename or re-parent: settings and vault labels follow the path rewrite. */
+  app.post('/api/folders/settings/move', async (req, reply): Promise<{ moved: number } | void> => {
+    const parsed = moveSchema.safeParse(req.body);
+    if (!parsed.success || !normalizeFolderPath(parsed.data.from) || !normalizeFolderPath(parsed.data.to)) {
+      return reply.code(400).send({ message: 'both folder paths are required' });
+    }
+    try {
+      const { moved, dropped } = ctx.database.moveFolderSettings(parsed.data.from, parsed.data.to);
+      for (const row of dropped) {
+        ctx.vault.deleteSshPassword(folderPasswordAccount(row.id));
+      }
+      const targetKey = folderPathKey(parsed.data.to);
+      for (const row of ctx.database.listFolderSettings()) {
+        if (row.pathKey !== targetKey && !isDescendantFolderPath(row.path, parsed.data.to)) continue;
+        ctx.vault.relabelSshPassword(
+          folderPasswordAccount(row.id),
+          folderPasswordLabel(row.path),
+        );
+      }
+      return { moved };
+    } catch (err) {
+      return sendError(reply, err);
+    }
+  });
+
+  /** Folder deletion: drop its settings, promote descendants one level up. */
+  app.delete('/api/folders/settings', async (req, reply): Promise<{ removed: number } | void> => {
+    const parsed = pathQuerySchema.safeParse(req.query);
+    if (!parsed.success || !normalizeFolderPath(parsed.data.path)) {
+      return reply.code(400).send({ message: 'a folder path is required' });
+    }
+    try {
+      const { removed } = ctx.database.deleteFolderSettings(parsed.data.path);
+      for (const row of removed) {
+        ctx.vault.deleteSshPassword(folderPasswordAccount(row.id));
+      }
+      return { removed: removed.length };
+    } catch (err) {
+      return sendError(reply, err);
+    }
+  });
+
+  app.put('/api/folders/settings/password', async (req, reply): Promise<{ folder: FolderSettingsRecord } | void> => {
+    const parsed = passwordSchema.safeParse(req.body);
+    if (!parsed.success || !normalizeFolderPath(parsed.data.path)) {
+      return reply.code(400).send({ message: 'a folder path and password are required' });
+    }
+    const existing = ctx.database.folderSettingsForPath(parsed.data.path);
+    const row = existing ?? ctx.database.upsertFolderSettings(parsed.data.path, {});
+    try {
+      await ctx.vault.rememberSshPassword(
+        folderPasswordAccount(row.id),
+        folderPasswordLabel(row.path),
+        parsed.data.password,
+        parsed.data.masterPassword,
+      );
+      return { folder: record(row) };
+    } catch (err) {
+      // Don't leave behind an empty row created only to key this password.
+      if (!existing) ctx.database.removeFolderSettingsRow(row.id);
+      return sendVaultError(reply, err);
+    }
+  });
+
+  app.delete('/api/folders/settings/password', async (req, reply): Promise<{ deleted: boolean } | void> => {
+    const parsed = pathQuerySchema.safeParse(req.query);
+    if (!parsed.success || !normalizeFolderPath(parsed.data.path)) {
+      return reply.code(400).send({ message: 'a folder path is required' });
+    }
+    try {
+      const row = ctx.database.folderSettingsForPath(parsed.data.path);
+      if (!row) return { deleted: false };
+      const deleted = ctx.vault.deleteSshPassword(folderPasswordAccount(row.id));
+      if (Object.keys(cleanAuth(row.auth)).length === 0) {
+        ctx.database.removeFolderSettingsRow(row.id);
+      }
+      return { deleted };
+    } catch (err) {
+      return sendError(reply, err);
+    }
+  });
+}
+
+/** Drop empty strings and empty lists so "cleared" fields don't linger. */
+function cleanAuth(auth: FolderAuthSettings): FolderAuthSettings {
+  const out: FolderAuthSettings = {};
+  const user = auth.user?.trim();
+  if (user) out.user = user;
+  if (auth.port !== undefined) out.port = auth.port;
+  const identityFiles = (auth.identityFiles ?? [])
+    .map((file) => file.trim())
+    .filter((file) => file.length > 0);
+  if (identityFiles.length > 0) out.identityFiles = identityFiles;
+  if (auth.identitiesOnly !== undefined) out.identitiesOnly = auth.identitiesOnly;
+  const identityAgent = auth.identityAgent?.trim();
+  if (identityAgent) out.identityAgent = identityAgent;
+  if (auth.forwardAgent !== undefined) out.forwardAgent = auth.forwardAgent;
+  return out;
+}

--- a/server/src/routes/folders.ts
+++ b/server/src/routes/folders.ts
@@ -83,17 +83,26 @@ export function registerFolderRoutes(app: FastifyInstance, ctx: AppContext): voi
   });
 
   /** Rename or re-parent: settings and vault labels follow the path rewrite. */
-  app.post('/api/folders/settings/move', async (req, reply): Promise<{ moved: number } | void> => {
+  app.post('/api/folders/settings/move', async (req, reply): Promise<{
+    moved: number;
+    destinationPreserved: boolean;
+  } | void> => {
     const parsed = moveSchema.safeParse(req.body);
     if (!parsed.success || !normalizeFolderPath(parsed.data.from) || !normalizeFolderPath(parsed.data.to)) {
       return reply.code(400).send({ message: 'both folder paths are required' });
     }
     try {
+      // Tell rename callers whether the destination already owned the root
+      // settings row. They must not save the source dialog fields over that
+      // retained row after the destination-wins merge.
+      const sourceKey = folderPathKey(parsed.data.from);
+      const targetKey = folderPathKey(parsed.data.to);
+      const destinationPreserved =
+        sourceKey !== targetKey && !!ctx.database.folderSettingsForPath(parsed.data.to);
       const { moved, dropped } = ctx.database.moveFolderSettings(parsed.data.from, parsed.data.to);
       for (const row of dropped) {
         ctx.vault.deleteSshPassword(folderPasswordAccount(row.id));
       }
-      const targetKey = folderPathKey(parsed.data.to);
       for (const row of ctx.database.listFolderSettings()) {
         if (row.pathKey !== targetKey && !isDescendantFolderPath(row.path, parsed.data.to)) continue;
         ctx.vault.relabelSshPassword(
@@ -101,7 +110,7 @@ export function registerFolderRoutes(app: FastifyInstance, ctx: AppContext): voi
           folderPasswordLabel(row.path),
         );
       }
-      return { moved };
+      return { moved, destinationPreserved };
     } catch (err) {
       return sendError(reply, err);
     }

--- a/server/src/routes/password-vault.ts
+++ b/server/src/routes/password-vault.ts
@@ -13,6 +13,7 @@ import {
   VaultAutomaticAccessError,
   VaultNotConfiguredError,
   VaultPolicyMismatchError,
+  VaultUnlockRequiredError,
 } from '../security/password-vault.js';
 import { VaultKeyStoreUnavailableError } from '../security/vault-key-store.js';
 import { HttpProblem, sendError } from '../util/errors.js';
@@ -189,7 +190,8 @@ function validCredentialId(id: string): boolean {
   return id.length > 0 && id.length <= 200;
 }
 
-function sendVaultError(reply: FastifyReply, err: unknown): Promise<void> {
+/** Shared vault → HTTP problem mapping (also used by the folder routes). */
+export function sendVaultError(reply: FastifyReply, err: unknown): Promise<void> {
   if (err instanceof InvalidMasterPasswordError) {
     return sendError(reply, new HttpProblem(401, err.message, 'invalid-master-password'));
   }
@@ -210,6 +212,9 @@ function sendVaultError(reply: FastifyReply, err: unknown): Promise<void> {
   }
   if (err instanceof VaultAutomaticAccessError) {
     return sendError(reply, new HttpProblem(423, err.message, 'vault-automatic-access-unavailable'));
+  }
+  if (err instanceof VaultUnlockRequiredError) {
+    return sendError(reply, new HttpProblem(423, err.message, 'vault-locked'));
   }
   if (err instanceof InvalidSavedPasswordFormatError) {
     return sendError(reply, new HttpProblem(400, err.message, 'invalid-saved-password-format'));

--- a/server/src/routes/ssh.ts
+++ b/server/src/routes/ssh.ts
@@ -11,6 +11,7 @@ import type { AppContext } from '../app.js';
 import { sendError } from '../util/errors.js';
 import { metadataPatchSchema } from './metadata-schema.js';
 import { defaultSshConfigPath, listHosts, loadConfigDocument } from '../ssh/ssh-config.js';
+import { folderAuthResolver } from '../ssh/folder-auth.js';
 import { deleteHost, previewHost, upsertHost } from '../ssh/ssh-config-edit.js';
 import { listSshKeys } from '../ssh/key-scan.js';
 
@@ -51,7 +52,12 @@ const upsertSchema = z.object({
 export function registerSshRoutes(app: FastifyInstance, ctx: AppContext): void {
   app.get('/api/ssh/config', (): SshConfigResponse => {
     const doc = loadConfigDocument();
-    const hosts = listHosts(doc).sort((a, b) => a.alias.localeCompare(b.alias));
+    // Resolved values include folder defaults, so the list and the editor show
+    // exactly what connect will use.
+    const folderAuth = folderAuthResolver(ctx.database);
+    const hosts = listHosts(doc, (alias) => folderAuth(alias)?.optionLines).sort(
+      (a, b) => a.alias.localeCompare(b.alias),
+    );
     const metadata = ctx.database.openSshMetadata(hosts.map((host) => host.alias));
     return {
       path: defaultSshConfigPath(),

--- a/server/src/security/password-vault.ts
+++ b/server/src/security/password-vault.ts
@@ -517,6 +517,30 @@ export class PasswordVault {
     );
   }
 
+  /** Remove a saved SSH password by its vault account; needs no vault key. */
+  deleteSshPassword(account: string): boolean {
+    const record = this.database.encryptedCredential(
+      PASSWORD_VAULT_PROVIDER,
+      SSH_PASSWORD_SERVICE,
+      account,
+    );
+    if (!record) return false;
+    return this.database.deleteEncryptedCredential(
+      record.id,
+      PASSWORD_VAULT_PROVIDER,
+    );
+  }
+
+  /** Keep a saved password's display label in step with a folder rename. */
+  relabelSshPassword(account: string, label: string): void {
+    this.database.updateCredentialRefLabel(
+      PASSWORD_VAULT_PROVIDER,
+      SSH_PASSWORD_SERVICE,
+      account,
+      label,
+    );
+  }
+
   async deleteAll(): Promise<void> {
     const config = this.database.passwordVaultConfig();
     if (config?.unlockPolicy === 'never') {
@@ -720,6 +744,22 @@ export function sshPasswordLabel(input: {
   port: number;
 }): string {
   return `${input.user}@${input.host}:${input.port}`;
+}
+
+/**
+ * A folder's shared password, keyed by the folder-settings row ID rather than
+ * its path so renaming the folder keeps the credential. The JSON-array shape
+ * can never collide with sshPasswordAccount's [user, host, port] triples.
+ */
+export function folderPasswordAccount(folderSettingsId: string): string {
+  return Buffer.from(
+    JSON.stringify(['folder', folderSettingsId]),
+    'utf8',
+  ).toString('base64url');
+}
+
+export function folderPasswordLabel(path: string): string {
+  return `Folder ${path}`;
 }
 
 export function validateMasterPassword(password: string): void {

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -66,6 +66,7 @@ import {
   type ConfigDocument,
   type ResolvedTarget,
 } from './ssh-config.js';
+import type { FolderAuthLookup, FolderPasswordRef } from './folder-auth.js';
 
 export interface HostKeyChallenge {
   host: string;
@@ -225,6 +226,8 @@ export interface ChainHop {
   port: number;
   /** Display label for prompts when this is an intermediate hop. */
   hopLabel?: string;
+  /** Folder passwords in the vault this hop may fall back to, nearest first. */
+  folderPasswords?: readonly FolderPasswordRef[];
 }
 
 /**
@@ -243,6 +246,7 @@ export class SshConnectionManager {
   private readonly pendingDials = new Map<string, Promise<ManagedConnection>>();
   private readonly loadConfig: () => ConfigDocument;
   private readonly vault: PasswordVault | undefined;
+  private readonly folderAuth: FolderAuthLookup | undefined;
   private readonly agentOperationTimeoutMs: number;
   private readonly agentWaitStatusMs: number;
   readonly knownHosts: KnownHostsStore;
@@ -253,6 +257,8 @@ export class SshConnectionManager {
       knownHosts?: KnownHostsStore;
       loadConfig?: () => ConfigDocument;
       vault?: PasswordVault;
+      /** Folder-inherited connection defaults per alias (Muxus sidebar folders). */
+      folderAuth?: FolderAuthLookup;
       /** Test seam; production uses the exported responsive-agent defaults. */
       agentOperationTimeoutMs?: number;
       /** Test seam; production uses the exported responsive-agent defaults. */
@@ -262,6 +268,7 @@ export class SshConnectionManager {
     this.knownHosts = options.knownHosts ?? new KnownHostsStore();
     this.loadConfig = options.loadConfig ?? (() => loadConfigDocument());
     this.vault = options.vault;
+    this.folderAuth = options.folderAuth;
     this.agentOperationTimeoutMs =
       options.agentOperationTimeoutMs ?? DEFAULT_AGENT_OPERATION_TIMEOUT_MS;
     this.agentWaitStatusMs =
@@ -306,7 +313,7 @@ export class SshConnectionManager {
     opts: { freshTransport?: boolean } = {},
   ): Promise<MuxedConnectionLease> {
     const doc = this.loadConfig();
-    const chain = buildChain(doc, profile);
+    const chain = buildChain(doc, profile, this.folderAuth);
     const key = muxKey(chain);
     const target = chain[chain.length - 1]!;
     const configForwards = target.resolved.forwards;
@@ -868,11 +875,14 @@ function mergeConfigForwards(
 /**
  * Expand a profile into the ordered list of hosts to dial: every ProxyJump
  * hop (each recursively resolved through the config, like the `ssh -W`
- * processes OpenSSH would spawn) and the final target last.
+ * processes OpenSSH would spawn) and the final target last. Each hop that is
+ * a saved alias picks up its own folder's defaults as the lowest-priority
+ * config layer.
  */
 export function buildChain(
   doc: ConfigDocument,
   profile: Omit<SshProfile, 'kind'>,
+  folderAuthFor?: FolderAuthLookup,
 ): ChainHop[] {
   const chain: ChainHop[] = [];
   const visited = new Set<string>();
@@ -882,7 +892,8 @@ export function buildChain(
     if (visited.has(spec.host)) throw new Error(`ProxyJump cycle detected at "${spec.host}"`);
     visited.add(spec.host);
     const fromConfig = !final || profile.useConfig !== false;
-    const base = fromConfig ? resolveHost(doc, spec.host) : directSettings(spec.host);
+    const folder = fromConfig ? folderAuthFor?.(spec.host) : undefined;
+    const base = fromConfig ? resolveHost(doc, spec.host, folder?.optionLines) : directSettings(spec.host);
     const user = (final ? profile.user : undefined) ?? spec.user ?? base.user ?? os.userInfo().username;
     const resolved: ResolvedTarget = final
       ? {
@@ -908,6 +919,7 @@ export function buildChain(
       user,
       port: (final ? profile.port : undefined) ?? spec.port ?? resolved.port,
       hopLabel: final ? undefined : spec.host,
+      folderPasswords: folder?.passwords,
     });
   };
 
@@ -1345,14 +1357,23 @@ class AuthLadder {
     });
     const existing = this.vault?.hasSshPassword(account) ?? false;
 
-    if (existing && !this.savedPasswordAttempted && this.vault) {
-      this.savedPasswordAttempted = true;
-      const saved = await this.savedPassword(account, credentialLabel);
-      if (saved !== undefined) {
-        this.io.status(`Using the saved password for ${credentialLabel}.`, {
-          transient: true,
-        });
-        return { type: 'password', username: user, password: saved };
+    if (!this.savedPasswordAttempted && this.vault) {
+      // The host's own saved password wins; folder passwords are the shared
+      // default the host falls back to, nearest folder first.
+      const source = existing
+        ? { account, label: credentialLabel }
+        : (this.hop.folderPasswords ?? []).find((folder) =>
+            this.vault!.hasSshPassword(folder.account),
+          );
+      if (source) {
+        this.savedPasswordAttempted = true;
+        const saved = await this.savedPassword(source.account, source.label);
+        if (saved !== undefined) {
+          this.io.status(`Using the saved password for ${source.label}.`, {
+            transient: true,
+          });
+          return { type: 'password', username: user, password: saved };
+        }
       }
     }
 
@@ -1361,7 +1382,7 @@ class AuthLadder {
         host: promptLabel,
         purpose: 'ssh-password',
         instructions:
-          existing && this.savedPasswordAttempted
+          this.savedPasswordAttempted
             ? 'The saved password was unavailable or was not accepted. Enter the current password.'
             : undefined,
         prompts: [

--- a/server/src/ssh/folder-auth.ts
+++ b/server/src/ssh/folder-auth.ts
@@ -1,0 +1,97 @@
+import type { FolderAuthSettings } from '@muxus/shared';
+import { folderChain } from '../util/folder-paths.js';
+import { folderPasswordAccount, folderPasswordLabel } from '../security/password-vault.js';
+import type { OptionLine } from './ssh-config.js';
+
+/** A folder password candidate in the encrypted vault. */
+export interface FolderPasswordRef {
+  account: string;
+  label: string;
+}
+
+/** Folder-inherited connection defaults for one dial target. */
+export interface FolderAuthDefaults {
+  /** Lowest-priority ssh_config option lines; see resolveHost's `fallback`. */
+  optionLines: OptionLine[];
+  /** Vault password candidates, nearest folder first. */
+  passwords: FolderPasswordRef[];
+}
+
+export type FolderAuthLookup = (alias: string) => FolderAuthDefaults | undefined;
+
+/** What the resolver needs to know; satisfied by MuxusDatabase. */
+export interface FolderAuthSource {
+  groupForAlias(alias: string): string | undefined;
+  folderSettingsForPath(
+    path: string,
+  ): { id: string; path: string; auth: FolderAuthSettings } | undefined;
+}
+
+/**
+ * Per-alias folder defaults for the dial path: the host's folder chain
+ * (nearest first) collapses to one set of option lines, and every folder with
+ * settings contributes a vault password candidate.
+ */
+export function folderAuthResolver(source: FolderAuthSource): FolderAuthLookup {
+  return (alias) => {
+    const group = source.groupForAlias(alias);
+    if (!group) return undefined;
+    const rows = folderChain(group)
+      .map((path) => source.folderSettingsForPath(path))
+      .filter((row) => row !== undefined);
+    if (rows.length === 0) return undefined;
+    return {
+      optionLines: folderAuthOptionLines(mergeFolderAuth(rows.map((row) => row.auth))),
+      passwords: rows.map((row) => ({
+        account: folderPasswordAccount(row.id),
+        label: folderPasswordLabel(row.path),
+      })),
+    };
+  };
+}
+
+/** Collapse a folder chain (nearest first) so the nearest folder wins per field. */
+export function mergeFolderAuth(chain: readonly FolderAuthSettings[]): FolderAuthSettings {
+  const merged: FolderAuthSettings = {};
+  for (const auth of chain) {
+    if (merged.user === undefined && auth.user !== undefined) merged.user = auth.user;
+    if (merged.port === undefined && auth.port !== undefined) merged.port = auth.port;
+    if (merged.identityFiles === undefined && auth.identityFiles !== undefined) {
+      merged.identityFiles = auth.identityFiles;
+    }
+    if (merged.identitiesOnly === undefined && auth.identitiesOnly !== undefined) {
+      merged.identitiesOnly = auth.identitiesOnly;
+    }
+    if (merged.identityAgent === undefined && auth.identityAgent !== undefined) {
+      merged.identityAgent = auth.identityAgent;
+    }
+    if (merged.forwardAgent === undefined && auth.forwardAgent !== undefined) {
+      merged.forwardAgent = auth.forwardAgent;
+    }
+  }
+  return merged;
+}
+
+/** Render folder defaults as the option lines resolveHost consumes. */
+export function folderAuthOptionLines(auth: FolderAuthSettings): OptionLine[] {
+  const lines: OptionLine[] = [];
+  const push = (keyword: string, raw: string) =>
+    lines.push({
+      keyword,
+      key: keyword.toLowerCase(),
+      // Paths may contain spaces; quote the value the way ssh_config would.
+      value: /\s/.test(raw) ? `"${raw}"` : raw,
+      args: [raw],
+    });
+  if (auth.user) push('User', auth.user);
+  if (auth.port !== undefined) push('Port', String(auth.port));
+  for (const file of auth.identityFiles ?? []) push('IdentityFile', file);
+  if (auth.identitiesOnly !== undefined) {
+    push('IdentitiesOnly', auth.identitiesOnly ? 'yes' : 'no');
+  }
+  if (auth.identityAgent) push('IdentityAgent', auth.identityAgent);
+  if (auth.forwardAgent !== undefined) {
+    push('ForwardAgent', auth.forwardAgent ? 'yes' : 'no');
+  }
+  return lines;
+}

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -325,11 +325,16 @@ export function resolveHost(
   const setEnv: Record<string, string> = {};
   const sendEnv: string[] = [];
 
-  const sequence = fallback?.length
-    ? [...doc.sequence, { patterns: null, options: [...fallback] }]
-    : doc.sequence;
+  const fallbackEntry = fallback?.length
+    ? { patterns: null, options: [...fallback] }
+    : undefined;
+  const sequence = fallbackEntry ? [...doc.sequence, fallbackEntry] : doc.sequence;
   for (const entry of sequence) {
     if (entry.patterns && !hostPatternsMatch(entry.patterns, host)) continue;
+    // IdentityFile is normally cumulative, but folder options are a fallback
+    // layer rather than another ssh_config block. Once the config supplied a
+    // key, omit all folder keys instead of offering them after it.
+    const configProvidedIdentityFile = entry === fallbackEntry && identityFiles.length > 0;
     for (const opt of entry.options) {
       // OpenSSH treats ChallengeResponseAuthentication as an exact alias, so
       // both spellings share one first-obtained slot.
@@ -337,6 +342,7 @@ export function resolveHost(
         opt.key === 'challengeresponseauthentication' ? 'kbdinteractiveauthentication' : opt.key;
       switch (opt.key) {
         case 'identityfile': {
+          if (configProvidedIdentityFile) break;
           const file = opt.args[0];
           if (file && !identityFiles.includes(file)) identityFiles.push(file);
           break;

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -307,8 +307,17 @@ const yes = (v: string | undefined): boolean => (v ?? '').toLowerCase() === 'yes
  * order. IdentityFile, CertificateFile and the *Forward directives accumulate
  * instead. ProxyJump and ProxyCommand are mutually exclusive: whichever is
  * obtained first wins, matching OpenSSH.
+ *
+ * `fallback` options (Muxus folder defaults) are evaluated after the entire
+ * config, as if appended at the end of ~/.ssh/config in a block matching only
+ * this host — first-obtained-wins makes them fill gaps without ever beating
+ * an option the user wrote in ssh_config.
  */
-export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
+export function resolveHost(
+  doc: ConfigDocument,
+  host: string,
+  fallback?: readonly OptionLine[],
+): ResolvedTarget {
   const first = new Map<string, string>();
   const identityFiles: string[] = [];
   const certificateFiles: string[] = [];
@@ -316,7 +325,10 @@ export function resolveHost(doc: ConfigDocument, host: string): ResolvedTarget {
   const setEnv: Record<string, string> = {};
   const sendEnv: string[] = [];
 
-  for (const entry of doc.sequence) {
+  const sequence = fallback?.length
+    ? [...doc.sequence, { patterns: null, options: [...fallback] }]
+    : doc.sequence;
+  for (const entry of sequence) {
     if (entry.patterns && !hostPatternsMatch(entry.patterns, host)) continue;
     for (const opt of entry.options) {
       // OpenSSH treats ChallengeResponseAuthentication as an exact alias, so
@@ -735,7 +747,11 @@ export function blockToOptions(block: HostBlock): HostBlockOptions {
   return out;
 }
 
-export function listHosts(doc: ConfigDocument): SshHostEntry[] {
+export function listHosts(
+  doc: ConfigDocument,
+  /** Folder defaults per alias — resolved values then match what connect uses. */
+  fallbackFor?: (alias: string) => readonly OptionLine[] | undefined,
+): SshHostEntry[] {
   const seen = new Set<string>();
   const entries: SshHostEntry[] = [];
   for (const block of doc.blocks) {
@@ -744,7 +760,7 @@ export function listHosts(doc: ConfigDocument): SshHostEntry[] {
     if (!fresh.length) continue;
     for (const a of concrete) seen.add(a);
     const alias = fresh[0]!;
-    const resolved = resolveHost(doc, alias);
+    const resolved = resolveHost(doc, alias, fallbackFor?.(alias));
     entries.push({
       alias,
       aliases: concrete,

--- a/server/src/util/folder-paths.ts
+++ b/server/src/util/folder-paths.ts
@@ -1,0 +1,51 @@
+/**
+ * Server-side twins of the client's folder-path helpers (client/src/host-tree.ts).
+ * A folder is a `/`-separated path stored on host metadata; segments are
+ * trimmed and matched case-insensitively. Folder settings are keyed by the
+ * lowercased path so "Prod/EU" and "prod/eu" address the same folder.
+ */
+
+const FOLDER_SEPARATOR = '/';
+
+export function folderPathSegments(path: string | null | undefined): string[] {
+  if (!path) return [];
+  return path
+    .split(FOLDER_SEPARATOR)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+/** The canonical stored form of a folder path; '' means "no folder". */
+export function normalizeFolderPath(path: string | null | undefined): string {
+  return folderPathSegments(path).join(FOLDER_SEPARATOR);
+}
+
+/** Case-insensitive identity of a folder path. */
+export function folderPathKey(path: string | null | undefined): string {
+  return folderPathSegments(path)
+    .map((segment) => segment.toLowerCase())
+    .join(FOLDER_SEPARATOR);
+}
+
+/** The path itself and every ancestor, nearest first ("a/b/c", "a/b", "a"). */
+export function folderChain(path: string | null | undefined): string[] {
+  const segments = folderPathSegments(path);
+  return segments
+    .map((_segment, index) => segments.slice(0, index + 1).join(FOLDER_SEPARATOR))
+    .reverse();
+}
+
+/** Whether `candidate` sits strictly inside `ancestor`. */
+export function isDescendantFolderPath(candidate: string, ancestor: string): boolean {
+  const parent = folderPathKey(ancestor);
+  const child = folderPathKey(candidate);
+  return parent.length > 0 && child.startsWith(`${parent}${FOLDER_SEPARATOR}`);
+}
+
+/** Where `path` lands when the folder `from` is renamed or moved to `to`. */
+export function renameFolderPathUnder(path: string, from: string, to: string): string | undefined {
+  if (folderPathKey(path) === folderPathKey(from)) return normalizeFolderPath(to);
+  if (!isDescendantFolderPath(path, from)) return undefined;
+  const tail = folderPathSegments(path).slice(folderPathSegments(from).length);
+  return [...folderPathSegments(to), ...tail].join(FOLDER_SEPARATOR);
+}

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -436,6 +436,40 @@ export interface OpenSshMetadataPatch {
   keywordHighlights?: HostKeywordHighlightConfig | null;
 }
 
+/**
+ * Shared SSH defaults a sidebar folder hands to the hosts inside it. Every
+ * field is optional: a folder only overrides what it sets. At connect time
+ * these apply *below* everything in ssh_config — a host's own options and
+ * `Host *` blocks always win — with the nearest folder beating its ancestors.
+ * The folder password is not here; it lives in the encrypted vault.
+ */
+export interface FolderAuthSettings {
+  user?: string;
+  port?: number;
+  identityFiles?: string[];
+  identitiesOnly?: boolean;
+  /** Agent socket override: a path, `$VAR`/`${VAR}`, `SSH_AUTH_SOCK`, or `none`. */
+  identityAgent?: string;
+  forwardAgent?: boolean;
+}
+
+/** One folder's stored credential defaults. */
+export interface FolderSettingsRecord {
+  /** Stable ID — the vault password stays attached across folder renames. */
+  id: string;
+  /** Normalized folder path ("Production/EU"); matched case-insensitively. */
+  path: string;
+  auth: FolderAuthSettings;
+  /** A shared password for this folder exists in the password vault. */
+  hasPassword: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FolderSettingsResponse {
+  folders: FolderSettingsRecord[];
+}
+
 export interface WorkspaceConnectionRef {
   source: 'openssh' | 'profile';
   /** OpenSSH alias when source=openssh, stable database profile ID otherwise. */

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -119,27 +119,49 @@ describe('Muxus transfer file parsing', () => {
   });
 });
 
+function mockBackupSnapshot(folders: unknown[] = []): void {
+  apiFetchMock
+    .mockResolvedValueOnce({ hosts: [] })
+    .mockResolvedValueOnce({ profiles: [] })
+    .mockResolvedValueOnce({ tunnels: [] })
+    .mockResolvedValueOnce({ overridden: false })
+    .mockResolvedValueOnce({ overridden: false })
+    .mockResolvedValueOnce({
+      settings: {
+        storageLocation: '/tmp/muxus-history',
+        maxTotalBytes: 5 * 1024 ** 3,
+        minFreeBytes: 2 * 1024 ** 3,
+        minFreePercent: 5,
+      },
+    })
+    .mockResolvedValueOnce({ folders });
+}
+
 describe('backing up preferences', () => {
   it('includes the update notification choice', async () => {
     usePrefsStore.setState({ notifyOnNewVersion: false });
-    apiFetchMock
-      .mockResolvedValueOnce({ hosts: [] })
-      .mockResolvedValueOnce({ profiles: [] })
-      .mockResolvedValueOnce({ tunnels: [] })
-      .mockResolvedValueOnce({ overridden: false })
-      .mockResolvedValueOnce({ overridden: false })
-      .mockResolvedValueOnce({
-        settings: {
-          storageLocation: '/tmp/muxus-history',
-          maxTotalBytes: 5 * 1024 ** 3,
-          minFreeBytes: 2 * 1024 ** 3,
-          minFreePercent: 5,
-        },
-      });
+    mockBackupSnapshot();
 
     const document = await createBackupDocument();
 
     expect(document.data.preferences.notifyOnNewVersion).toBe(false);
+  });
+});
+
+describe('backing up folder credentials', () => {
+  it('exports folder auth defaults but never password-only rows', async () => {
+    mockBackupSnapshot([
+      { id: 'a', path: 'Prod', auth: { user: 'root', port: 2222 }, hasPassword: true },
+      // A folder whose only setting is its vault password: the password
+      // cannot leave the vault, so there is nothing to export.
+      { id: 'b', path: 'Lab', auth: {}, hasPassword: true },
+    ]);
+
+    const document = await createBackupDocument();
+
+    expect(document.data.folderSettings).toEqual([
+      { path: 'Prod', auth: { user: 'root', port: 2222 } },
+    ]);
   });
 });
 

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -37,6 +37,7 @@ describe('MuxusDatabase migrations', () => {
       { version: 14, name: 'password-vault-os-keystore' },
       { version: 15, name: 'password-vault-key-check' },
       { version: 16, name: 'password-vault-key-cleanup' },
+      { version: 17, name: 'folder-settings' },
     ]);
   });
 
@@ -113,8 +114,8 @@ describe('MuxusDatabase migrations', () => {
 
     database = new MuxusDatabase(filename);
     expect(database.appliedMigrations().at(-1)).toEqual({
-      version: 16,
-      name: 'password-vault-key-cleanup',
+      version: 17,
+      name: 'folder-settings',
     });
     expect(database.passwordVaultConfig()).toMatchObject({
       formatVersion: 2,

--- a/tests/unit/server/folder-auth.test.ts
+++ b/tests/unit/server/folder-auth.test.ts
@@ -1,0 +1,224 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import type { FolderAuthSettings } from '@muxus/shared';
+import { buildChain } from '../../../server/src/ssh/connection-manager.js';
+import {
+  folderAuthOptionLines,
+  folderAuthResolver,
+  mergeFolderAuth,
+} from '../../../server/src/ssh/folder-auth.js';
+import { folderPasswordAccount } from '../../../server/src/security/password-vault.js';
+import { loadConfigDocument, resolveHost } from '../../../server/src/ssh/ssh-config.js';
+import {
+  folderChain,
+  folderPathKey,
+  isDescendantFolderPath,
+  normalizeFolderPath,
+  renameFolderPathUnder,
+} from '../../../server/src/util/folder-paths.js';
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-folder-auth-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+let counter = 0;
+function docOf(content: string) {
+  const dir = path.join(tmp, `c-${counter++}`);
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'config');
+  writeFileSync(file, content);
+  return loadConfigDocument(file);
+}
+
+describe('folder path helpers', () => {
+  it('normalizes separators and trims segments', () => {
+    expect(normalizeFolderPath(' /Prod // EU / ')).toBe('Prod/EU');
+    expect(folderPathKey('Prod/EU')).toBe('prod/eu');
+    expect(folderPathKey('  ')).toBe('');
+  });
+
+  it('walks the folder chain nearest first', () => {
+    expect(folderChain('a/b/c')).toEqual(['a/b/c', 'a/b', 'a']);
+    expect(folderChain('')).toEqual([]);
+  });
+
+  it('is segment-aware for descendants, like the client', () => {
+    expect(isDescendantFolderPath('Production/EU', 'Production')).toBe(true);
+    expect(isDescendantFolderPath('Production', 'Prod')).toBe(false);
+    expect(isDescendantFolderPath('production/eu', 'PRODUCTION')).toBe(true);
+  });
+
+  it('rewrites paths under a renamed folder', () => {
+    expect(renameFolderPathUnder('Prod', 'Prod', 'Production')).toBe('Production');
+    expect(renameFolderPathUnder('Prod/EU/Edge', 'Prod', 'Production')).toBe('Production/EU/Edge');
+    expect(renameFolderPathUnder('Staging', 'Prod', 'Production')).toBeUndefined();
+  });
+});
+
+describe('mergeFolderAuth', () => {
+  it('lets the nearest folder win per field, filling gaps from ancestors', () => {
+    const merged = mergeFolderAuth([
+      { port: 2222 },
+      { user: 'parent', port: 22, forwardAgent: true },
+    ]);
+    expect(merged).toEqual({ user: 'parent', port: 2222, forwardAgent: true });
+  });
+});
+
+describe('folderAuthOptionLines', () => {
+  it('renders one line per set field and quotes paths with spaces', () => {
+    const lines = folderAuthOptionLines({
+      user: 'admin',
+      port: 2222,
+      identityFiles: ['/keys/my key'],
+      identitiesOnly: true,
+    });
+    expect(lines.map((line) => [line.key, line.value])).toEqual([
+      ['user', 'admin'],
+      ['port', '2222'],
+      ['identityfile', '"/keys/my key"'],
+      ['identitiesonly', 'yes'],
+    ]);
+    expect(lines[2]!.args).toEqual(['/keys/my key']);
+  });
+});
+
+describe('resolveHost with folder fallback', () => {
+  const fallback = (auth: FolderAuthSettings) => folderAuthOptionLines(auth);
+
+  it('fills user and port the config leaves unset', () => {
+    const doc = docOf('Host web\n  HostName web.example.com');
+    const resolved = resolveHost(doc, 'web', fallback({ user: 'admin', port: 2222 }));
+    expect(resolved.user).toBe('admin');
+    expect(resolved.port).toBe(2222);
+  });
+
+  it('never beats the host block or Host * defaults', () => {
+    const doc = docOf(
+      [
+        'Host web',
+        '  User blockuser',
+        '',
+        'Host *',
+        '  Port 2200',
+      ].join('\n'),
+    );
+    const resolved = resolveHost(doc, 'web', fallback({ user: 'admin', port: 9999 }));
+    expect(resolved.user).toBe('blockuser');
+    expect(resolved.port).toBe(2200);
+  });
+
+  it('appends the folder key after the host block keys, ssh-style', () => {
+    const doc = docOf('Host web\n  IdentityFile ~/.ssh/host_key');
+    const resolved = resolveHost(doc, 'web', fallback({ identityFiles: ['~/.ssh/folder_key'] }));
+    expect(resolved.identityFiles.map((file) => path.basename(file))).toEqual([
+      'host_key',
+      'folder_key',
+    ]);
+  });
+
+  it('supplies a key and IdentitiesOnly to hosts with none of their own', () => {
+    const doc = docOf('Host web\n  HostName web.example.com');
+    const resolved = resolveHost(
+      doc,
+      'web',
+      fallback({ identityFiles: ['~/.ssh/folder_key'], identitiesOnly: true }),
+    );
+    expect(resolved.identityFiles.map((file) => path.basename(file))).toEqual(['folder_key']);
+    expect(resolved.identitiesOnly).toBe(true);
+  });
+
+  it('passes an agent socket path containing spaces through intact', () => {
+    const doc = docOf('Host web\n  HostName web.example.com');
+    const resolved = resolveHost(
+      doc,
+      'web',
+      fallback({ identityAgent: '/tmp/agent dir/agent.sock' }),
+    );
+    expect(resolved.identityAgent).toBe('/tmp/agent dir/agent.sock');
+  });
+});
+
+describe('buildChain with folder defaults', () => {
+  it('applies each hop its own folder, and passwords ride on the hop', () => {
+    const doc = docOf(
+      [
+        'Host app',
+        '  HostName app.internal',
+        '  ProxyJump bastion',
+        '',
+        'Host bastion',
+        '  HostName bastion.example.com',
+      ].join('\n'),
+    );
+    const perAlias: Record<string, FolderAuthSettings> = {
+      app: { user: 'appuser' },
+      bastion: { user: 'jumpuser', port: 2200 },
+    };
+    const chain = buildChain(doc, { target: 'app' }, (alias) => {
+      const auth = perAlias[alias];
+      if (!auth) return undefined;
+      return {
+        optionLines: folderAuthOptionLines(auth),
+        passwords: [{ account: `acct-${alias}`, label: `Folder ${alias}` }],
+      };
+    });
+    expect(chain[0]).toMatchObject({ user: 'jumpuser', port: 2200 });
+    expect(chain[1]).toMatchObject({ user: 'appuser', port: 22 });
+    expect(chain[1]!.folderPasswords).toEqual([
+      { account: 'acct-app', label: 'Folder app' },
+    ]);
+  });
+
+  it('keeps per-connection overrides above folder defaults', () => {
+    const doc = docOf('Host web\n  HostName web.example.com');
+    const chain = buildChain(doc, { target: 'web', user: 'override' }, () => ({
+      optionLines: folderAuthOptionLines({ user: 'folderuser' }),
+      passwords: [],
+    }));
+    expect(chain[0]!.user).toBe('override');
+  });
+
+  it('ignores folder defaults for self-contained (useConfig: false) dials', () => {
+    const doc = docOf('Host web\n  HostName web.example.com');
+    const chain = buildChain(doc, { target: 'web', useConfig: false }, () => ({
+      optionLines: folderAuthOptionLines({ user: 'folderuser', port: 2222 }),
+      passwords: [{ account: 'acct', label: 'Folder' }],
+    }));
+    expect(chain[0]!.user).not.toBe('folderuser');
+    expect(chain[0]!.port).toBe(22);
+    expect(chain[0]!.folderPasswords).toBeUndefined();
+  });
+});
+
+describe('folderAuthResolver', () => {
+  const settings = new Map<string, { id: string; path: string; auth: FolderAuthSettings }>([
+    ['prod', { id: 'row-prod', path: 'Prod', auth: { user: 'root', port: 2200 } }],
+    ['prod/eu', { id: 'row-eu', path: 'Prod/EU', auth: { port: 2222 } }],
+  ]);
+  const resolver = folderAuthResolver({
+    groupForAlias: (alias) => (alias === 'web' ? 'Prod/EU' : undefined),
+    folderSettingsForPath: (path) => settings.get(folderPathKey(path)),
+  });
+
+  it('collapses the ancestor chain nearest-first and lists all passwords', () => {
+    const defaults = resolver('web');
+    expect(defaults).toBeDefined();
+    const byKey = Object.fromEntries(defaults!.optionLines.map((line) => [line.key, line.args[0]]));
+    expect(byKey).toEqual({ user: 'root', port: '2222' });
+    expect(defaults!.passwords).toEqual([
+      { account: folderPasswordAccount('row-eu'), label: 'Folder Prod/EU' },
+      { account: folderPasswordAccount('row-prod'), label: 'Folder Prod' },
+    ]);
+  });
+
+  it('returns nothing for hosts outside folders or folders without settings', () => {
+    expect(resolver('bare')).toBeUndefined();
+    const empty = folderAuthResolver({
+      groupForAlias: () => 'Unrelated',
+      folderSettingsForPath: () => undefined,
+    });
+    expect(empty('web')).toBeUndefined();
+  });
+});

--- a/tests/unit/server/folder-auth.test.ts
+++ b/tests/unit/server/folder-auth.test.ts
@@ -109,13 +109,10 @@ describe('resolveHost with folder fallback', () => {
     expect(resolved.port).toBe(2200);
   });
 
-  it('appends the folder key after the host block keys, ssh-style', () => {
+  it('omits folder keys when ssh_config already supplies one', () => {
     const doc = docOf('Host web\n  IdentityFile ~/.ssh/host_key');
     const resolved = resolveHost(doc, 'web', fallback({ identityFiles: ['~/.ssh/folder_key'] }));
-    expect(resolved.identityFiles.map((file) => path.basename(file))).toEqual([
-      'host_key',
-      'folder_key',
-    ]);
+    expect(resolved.identityFiles.map((file) => path.basename(file))).toEqual(['host_key']);
   });
 
   it('supplies a key and IdentitiesOnly to hosts with none of their own', () => {

--- a/tests/unit/server/folder-password-auth.test.ts
+++ b/tests/unit/server/folder-password-auth.test.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { generateKeyPairSync } from 'node:crypto';
+import { Server } from 'ssh2';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { SshProfile } from '@muxus/shared/ws-protocol';
+import { MuxusDatabase } from '../../../server/src/persistence/database.js';
+import {
+  PasswordVault,
+  folderPasswordAccount,
+  folderPasswordLabel,
+  sshPasswordAccount,
+  sshPasswordLabel,
+} from '../../../server/src/security/password-vault.js';
+import { SshConnectionManager, type ConnectIo } from '../../../server/src/ssh/connection-manager.js';
+import { folderAuthResolver } from '../../../server/src/ssh/folder-auth.js';
+import { KnownHostsStore } from '../../../server/src/ssh/known-hosts.js';
+import { loadConfigDocument } from '../../../server/src/ssh/ssh-config.js';
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-folder-password-'));
+const PASSWORD = 'shared-folder-password';
+const MASTER = 'master-pass-12';
+
+const HOST_KEY = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+}).privateKey;
+
+const savedEnv = { HOME: process.env.HOME, SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK };
+beforeAll(() => {
+  // No real agent and no real ~/.ssh keys: the ladder must reach password auth.
+  process.env.HOME = tmp;
+  delete process.env.SSH_AUTH_SOCK;
+});
+afterAll(() => {
+  process.env.HOME = savedEnv.HOME;
+  if (savedEnv.SSH_AUTH_SOCK !== undefined) process.env.SSH_AUTH_SOCK = savedEnv.SSH_AUTH_SOCK;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+interface AuthEvent {
+  method: string;
+  accepted?: boolean;
+}
+
+/** Password-only sshd stand-in. */
+function startServer(): Promise<{ server: Server; port: number; events: AuthEvent[] }> {
+  const events: AuthEvent[] = [];
+  const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
+    conn.on('error', () => undefined);
+    conn.on('authentication', (ctx) => {
+      if (ctx.method === 'password') {
+        events.push({ method: 'password', accepted: ctx.password === PASSWORD });
+        if (ctx.password === PASSWORD) return ctx.accept();
+        return ctx.reject(['password']);
+      }
+      if (ctx.method !== 'none') events.push({ method: ctx.method });
+      ctx.reject(['password']);
+    });
+    conn.on('ready', () => {
+      conn.on('session', (acceptSession) => {
+        const session = acceptSession();
+        session.on('pty', (acceptPty) => acceptPty?.());
+        session.on('shell', (acceptShell) => acceptShell().write('shell ok\n'));
+      });
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as net.AddressInfo).port, events });
+    });
+  });
+}
+
+let counter = 0;
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+async function makeVaultedManager(port: number): Promise<{
+  manager: SshConnectionManager;
+  vault: PasswordVault;
+  database: MuxusDatabase;
+}> {
+  const configFile = path.join(tmp, `ssh_config-${counter++}`);
+  writeFileSync(
+    configFile,
+    ['Host lab', '  HostName 127.0.0.1', '  User tester', `  Port ${port}`, '  StrictHostKeyChecking no', ''].join('\n'),
+  );
+  const database = new MuxusDatabase(':memory:');
+  const vault = new PasswordVault(database);
+  await vault.initialize();
+  await vault.create(MASTER, 'never');
+  database.updateOpenSshMetadata('lab', { group: 'Lab' });
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const manager = new SshConnectionManager(log as never, {
+    knownHosts: new KnownHostsStore(
+      path.join(tmp, `known_hosts-${counter++}`),
+      path.join(tmp, 'no-global-known-hosts'),
+    ),
+    loadConfig: () => loadConfigDocument(configFile),
+    vault,
+    folderAuth: folderAuthResolver(database),
+  });
+  cleanups.push(() => {
+    manager.closeAll();
+    vault.dispose();
+    database.close();
+  });
+  return { manager, vault, database };
+}
+
+function makeIo(): ConnectIo & { passwordPrompts: number } {
+  const io = {
+    passwordPrompts: 0,
+    status: () => undefined,
+    prompt: (info: { prompts: Array<{ prompt: string }> }) => {
+      io.passwordPrompts += info.prompts.length;
+      return Promise.resolve({ answers: info.prompts.map(() => PASSWORD) });
+    },
+    hostKey: () => Promise.resolve(true),
+  };
+  return io as unknown as ConnectIo & { passwordPrompts: number };
+}
+
+async function storeFolderPassword(
+  vault: PasswordVault,
+  database: MuxusDatabase,
+  password: string,
+): Promise<void> {
+  const row = database.upsertFolderSettings('Lab', {});
+  await vault.rememberSshPassword(
+    folderPasswordAccount(row.id),
+    folderPasswordLabel(row.path),
+    password,
+  );
+}
+
+const profile: SshProfile = { kind: 'ssh', target: 'lab' };
+
+describe('folder password authentication', () => {
+  it('logs in with the folder password without prompting', async () => {
+    const { server, port, events } = await startServer();
+    cleanups.push(() => server.close());
+    const { manager, vault, database } = await makeVaultedManager(port);
+    await storeFolderPassword(vault, database, PASSWORD);
+
+    const io = makeIo();
+    const lease = await manager.connect(profile, io);
+    lease.release();
+
+    expect(io.passwordPrompts).toBe(0);
+    expect(events.filter((e) => e.method === 'password')).toEqual([
+      { method: 'password', accepted: true },
+    ]);
+  });
+
+  it('prefers the host-saved password over the folder password', async () => {
+    const { server, port, events } = await startServer();
+    cleanups.push(() => server.close());
+    const { manager, vault, database } = await makeVaultedManager(port);
+    await storeFolderPassword(vault, database, 'wrong-folder-password');
+    const hostRef = { user: 'tester', host: '127.0.0.1', port };
+    await vault.rememberSshPassword(
+      sshPasswordAccount(hostRef),
+      sshPasswordLabel(hostRef),
+      PASSWORD,
+    );
+
+    const io = makeIo();
+    const lease = await manager.connect(profile, io);
+    lease.release();
+
+    expect(io.passwordPrompts).toBe(0);
+    // The wrong folder password was never offered.
+    expect(events.filter((e) => e.method === 'password')).toEqual([
+      { method: 'password', accepted: true },
+    ]);
+  });
+
+  it('falls back to prompting when the folder password is rejected', async () => {
+    const { server, port, events } = await startServer();
+    cleanups.push(() => server.close());
+    const { manager, vault, database } = await makeVaultedManager(port);
+    await storeFolderPassword(vault, database, 'stale-folder-password');
+
+    const io = makeIo();
+    const lease = await manager.connect(profile, io);
+    lease.release();
+
+    expect(io.passwordPrompts).toBe(1);
+    expect(events.filter((e) => e.method === 'password')).toEqual([
+      { method: 'password', accepted: false },
+      { method: 'password', accepted: true },
+    ]);
+  });
+});

--- a/tests/unit/server/folder-settings.test.ts
+++ b/tests/unit/server/folder-settings.test.ts
@@ -1,0 +1,284 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FolderSettingsRecord } from '@muxus/shared';
+import type { AppContext } from '../../../server/src/app.js';
+import { buildApp } from '../../../server/src/app.js';
+import { resolveConfig } from '../../../server/src/config.js';
+import { MuxusDatabase } from '../../../server/src/persistence/database.js';
+
+const TOKEN = 'folder-settings-token';
+const MASTER = 'master-pass-12';
+
+describe('folder settings persistence', () => {
+  let database: MuxusDatabase;
+
+  beforeEach(() => {
+    database = new MuxusDatabase(':memory:');
+  });
+  afterEach(() => database.close());
+
+  it('upserts by case-folded path and keeps the row id stable', () => {
+    const created = database.upsertFolderSettings('Prod/EU', { user: 'admin' });
+    const updated = database.upsertFolderSettings('prod/eu', { user: 'root', port: 2222 });
+    expect(updated.id).toBe(created.id);
+    expect(updated.path).toBe('prod/eu');
+    expect(updated.auth).toEqual({ user: 'root', port: 2222 });
+    expect(database.listFolderSettings()).toHaveLength(1);
+    expect(database.folderSettingsForPath(' Prod / EU ')?.id).toBe(created.id);
+  });
+
+  it('rejects secret-shaped fields at the persistence boundary', () => {
+    expect(() =>
+      database.upsertFolderSettings('Prod', {
+        password: 'nope',
+      } as never),
+    ).toThrowError(/password vault/);
+  });
+
+  it('moves a folder and its descendants, keeping ids', () => {
+    const prod = database.upsertFolderSettings('Prod', { user: 'root' });
+    const eu = database.upsertFolderSettings('Prod/EU', { port: 2222 });
+    database.upsertFolderSettings('Staging', { user: 'stage' });
+
+    const { moved, dropped } = database.moveFolderSettings('Prod', 'Production');
+    expect(moved).toBe(2);
+    expect(dropped).toEqual([]);
+    expect(database.folderSettingsForPath('Production')?.id).toBe(prod.id);
+    expect(database.folderSettingsForPath('Production/EU')?.id).toBe(eu.id);
+    expect(database.folderSettingsForPath('Staging')).toBeDefined();
+    expect(database.folderSettingsForPath('Prod')).toBeUndefined();
+  });
+
+  it('keeps the destination settings when a move merges folders', () => {
+    const source = database.upsertFolderSettings('Prod', { user: 'source' });
+    const destination = database.upsertFolderSettings('Production', { user: 'dest' });
+
+    const { dropped } = database.moveFolderSettings('Prod', 'Production');
+    expect(dropped.map((row) => row.id)).toEqual([source.id]);
+    expect(database.folderSettingsForPath('Production')?.id).toBe(destination.id);
+    expect(database.folderSettingsForPath('Production')?.auth).toEqual({ user: 'dest' });
+  });
+
+  it('updates only the display path on a recapitalization', () => {
+    const row = database.upsertFolderSettings('prod', { user: 'root' });
+    database.moveFolderSettings('prod', 'Prod');
+    const after = database.folderSettingsForPath('prod');
+    expect(after?.id).toBe(row.id);
+    expect(after?.path).toBe('Prod');
+  });
+
+  it('deleting a folder promotes descendant settings a level up', () => {
+    const own = database.upsertFolderSettings('Prod/EU', { user: 'eu' });
+    const edge = database.upsertFolderSettings('Prod/EU/Edge', { port: 2222 });
+
+    const { removed } = database.deleteFolderSettings('Prod/EU');
+    expect(removed.map((row) => row.id)).toEqual([own.id]);
+    expect(database.folderSettingsForPath('Prod/Edge')?.id).toBe(edge.id);
+    expect(database.folderSettingsForPath('Prod/EU')).toBeUndefined();
+  });
+});
+
+describe('folder settings routes', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>['app'];
+  let ctx: AppContext;
+  let home: string;
+
+  beforeEach(async () => {
+    home = mkdtempSync(path.join(os.tmpdir(), 'muxus-folder-routes-'));
+    vi.stubEnv('HOME', home);
+    ({ app, ctx } = await buildApp(
+      resolveConfig({
+        token: TOKEN,
+        databasePath: ':memory:',
+        openBrowser: false,
+        prettyLogs: false,
+        staticRoot: '/path/that/does/not/exist',
+      }),
+    ));
+  });
+  afterEach(async () => {
+    await app.close();
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function auth() {
+    return { authorization: `Bearer ${TOKEN}` };
+  }
+
+  async function listFolders(): Promise<FolderSettingsRecord[]> {
+    const res = await app.inject({ method: 'GET', url: '/api/folders/settings', headers: auth() });
+    expect(res.statusCode).toBe(200);
+    return (res.json() as { folders: FolderSettingsRecord[] }).folders;
+  }
+
+  it('round-trips settings and drops rows that hold nothing', async () => {
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings',
+      headers: auth(),
+      payload: { path: ' Prod / EU ', auth: { user: '  admin ', port: 2222, identityFiles: [' ~/.ssh/prod ', ''] } },
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toMatchObject({
+      folder: {
+        path: 'Prod/EU',
+        auth: { user: 'admin', port: 2222, identityFiles: ['~/.ssh/prod'] },
+        hasPassword: false,
+      },
+    });
+
+    const cleared = await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings',
+      headers: auth(),
+      payload: { path: 'Prod/EU', auth: {} },
+    });
+    expect(cleared.json()).toEqual({ folder: null });
+    expect(await listFolders()).toEqual([]);
+  });
+
+  it('stores and removes the shared folder password through the vault', async () => {
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/password-vault/create',
+      headers: auth(),
+      payload: { password: MASTER },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings/password',
+      headers: auth(),
+      payload: { path: 'Prod', password: 'shared-secret' },
+    });
+    expect(put.statusCode).toBe(200);
+    expect((put.json() as { folder: FolderSettingsRecord }).folder.hasPassword).toBe(true);
+
+    const [folder] = await listFolders();
+    expect(folder).toMatchObject({ path: 'Prod', hasPassword: true });
+
+    const vault = await app.inject({ method: 'GET', url: '/api/password-vault', headers: auth() });
+    expect(vault.json()).toMatchObject({
+      credentials: [{ label: 'Folder Prod' }],
+    });
+
+    const removed = await app.inject({
+      method: 'DELETE',
+      url: '/api/folders/settings/password?path=Prod',
+      headers: auth(),
+    });
+    expect(removed.json()).toEqual({ deleted: true });
+    // The row held nothing but the password, so it disappears entirely.
+    expect(await listFolders()).toEqual([]);
+  });
+
+  it('requires a configured vault before storing a folder password', async () => {
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings/password',
+      headers: auth(),
+      payload: { path: 'Prod', password: 'shared-secret' },
+    });
+    expect(put.statusCode).toBe(409);
+    expect(await listFolders()).toEqual([]);
+  });
+
+  it('moves settings with the folder and relabels the vault credential', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/password-vault/create',
+      headers: auth(),
+      payload: { password: MASTER },
+    });
+    await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings',
+      headers: auth(),
+      payload: { path: 'Prod', auth: { user: 'root' } },
+    });
+    await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings/password',
+      headers: auth(),
+      payload: { path: 'Prod', password: 'shared-secret' },
+    });
+
+    const move = await app.inject({
+      method: 'POST',
+      url: '/api/folders/settings/move',
+      headers: auth(),
+      payload: { from: 'Prod', to: 'Production' },
+    });
+    expect(move.statusCode).toBe(200);
+    expect(move.json()).toEqual({ moved: 1 });
+
+    const [folder] = await listFolders();
+    expect(folder).toMatchObject({ path: 'Production', auth: { user: 'root' }, hasPassword: true });
+
+    const vault = await app.inject({ method: 'GET', url: '/api/password-vault', headers: auth() });
+    expect(vault.json()).toMatchObject({ credentials: [{ label: 'Folder Production' }] });
+  });
+
+  it('deletes settings and their vault password with the folder', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/password-vault/create',
+      headers: auth(),
+      payload: { password: MASTER },
+    });
+    await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings/password',
+      headers: auth(),
+      payload: { path: 'Prod', password: 'shared-secret' },
+    });
+    await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings',
+      headers: auth(),
+      payload: { path: 'Prod/EU', auth: { port: 2222 } },
+    });
+
+    const del = await app.inject({
+      method: 'DELETE',
+      url: `/api/folders/settings?path=${encodeURIComponent('Prod')}`,
+      headers: auth(),
+    });
+    expect(del.statusCode).toBe(200);
+    expect(del.json()).toEqual({ removed: 1 });
+
+    const folders = await listFolders();
+    expect(folders).toHaveLength(1);
+    expect(folders[0]).toMatchObject({ path: 'EU', auth: { port: 2222 } });
+
+    const vault = await app.inject({ method: 'GET', url: '/api/password-vault', headers: auth() });
+    expect(vault.json()).toMatchObject({ credentialCount: 0 });
+  });
+
+  it('feeds folder defaults into the resolved host list', async () => {
+    mkdirSync(path.join(home, '.ssh'), { recursive: true });
+    writeFileSync(
+      path.join(home, '.ssh', 'config'),
+      ['Host demo', '  HostName demo.example.com', '', 'Host plain', '  HostName plain.example.com'].join('\n'),
+    );
+    ctx.database.updateOpenSshMetadata('demo', { group: 'Prod' });
+    ctx.database.upsertFolderSettings('Prod', { user: 'folderuser', port: 2222 });
+
+    const config = await app.inject({ method: 'GET', url: '/api/ssh/config', headers: auth() });
+    expect(config.statusCode).toBe(200);
+    const hosts = (config.json() as {
+      hosts: Array<{ alias: string; resolved: { user?: string; port: number } }>;
+    }).hosts;
+    expect(hosts.find((entry) => entry.alias === 'demo')?.resolved).toMatchObject({
+      user: 'folderuser',
+      port: 2222,
+    });
+    expect(hosts.find((entry) => entry.alias === 'plain')?.resolved).toMatchObject({
+      port: 22,
+    });
+  });
+});

--- a/tests/unit/server/folder-settings.test.ts
+++ b/tests/unit/server/folder-settings.test.ts
@@ -214,13 +214,43 @@ describe('folder settings routes', () => {
       payload: { from: 'Prod', to: 'Production' },
     });
     expect(move.statusCode).toBe(200);
-    expect(move.json()).toEqual({ moved: 1 });
+    expect(move.json()).toEqual({ moved: 1, destinationPreserved: false });
 
     const [folder] = await listFolders();
     expect(folder).toMatchObject({ path: 'Production', auth: { user: 'root' }, hasPassword: true });
 
     const vault = await app.inject({ method: 'GET', url: '/api/password-vault', headers: auth() });
     expect(vault.json()).toMatchObject({ credentials: [{ label: 'Folder Production' }] });
+  });
+
+  it('reports when a merge preserves the destination settings', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings',
+      headers: auth(),
+      payload: { path: 'Source', auth: { user: 'source' } },
+    });
+    await app.inject({
+      method: 'PUT',
+      url: '/api/folders/settings',
+      headers: auth(),
+      payload: { path: 'Destination', auth: { user: 'destination', port: 2222 } },
+    });
+
+    const move = await app.inject({
+      method: 'POST',
+      url: '/api/folders/settings/move',
+      headers: auth(),
+      payload: { from: 'Source', to: 'Destination' },
+    });
+    expect(move.statusCode).toBe(200);
+    expect(move.json()).toEqual({ moved: 0, destinationPreserved: true });
+    expect(await listFolders()).toEqual([
+      expect.objectContaining({
+        path: 'Destination',
+        auth: { user: 'destination', port: 2222 },
+      }),
+    ]);
   });
 
   it('deletes settings and their vault password with the folder', async () => {


### PR DESCRIPTION
Folders can now carry shared connection defaults that every host inside them inherits — the way Termius groups work. Requested by a user who organizes lab hosts into groups where all machines share one login.

## What a folder can hold

Open a folder's **Rename, move & style…** dialog and fill in the new **Shared SSH credentials** section:

- **Username** and **port**
- **Private key** (picker fed from `~/.ssh`, file browser in the desktop app) — hosts without their own key then offer exactly this key
- **Shared password**, stored in the encrypted password vault and offered automatically when a host falls back to password login

## Precedence

Folder defaults are injected as a *lowest-priority* ssh_config layer at resolve time — as if appended at the end of `~/.ssh/config` in a block matching only that host:

1. Per-connection overrides (tunnels)
2. Anything in `ssh_config` — the host's block *and* `Host *` defaults
3. Nearest folder
4. Parent folders, outward
5. Built-in defaults

So a folder never overrides something configured on the host or in the config file; it only fills gaps, and any host can override the folder by setting its own value. `ssh_config` is never rewritten. ProxyJump hops each inherit their own folder. For passwords, a password remembered for the host itself still beats the folder's.

## Implementation notes

- New `folder_settings` table (migration 17), keyed by the case-folded folder path with a stable row id. The vault password is keyed by that id, so renames keep it.
- `resolveHost()` accepts a fallback option layer; `buildChain()` resolves it per hop and carries folder password candidates to the auth ladder.
- New `/api/folders/settings` routes (CRUD, move, password set/remove) with the vault's error mapping; `GET /api/ssh/config` now resolves through folder defaults so the sidebar and editor show what connect will actually use.
- Folder rename, drag re-parenting and deletion carry the settings along (deletion promotes descendant settings a level up, merges keep the destination's); the delete confirmation says when credentials will be removed.
- Backups export folder auth (never the password) and restore it with the usual keep/replace rules. Docs updated in the hosts guide.

## Testing

- Unit tests for path helpers, chain merging, resolution precedence, database move/promote semantics, and the HTTP routes.
- An integration test dials a real in-process ssh server: folder password logs in with zero prompts, a host-saved password wins over a wrong folder password, and a rejected folder password falls back to prompting.
- Full suite (681 tests), typecheck, lint and the bundle budget pass; the initial-bundle gzip budget moves one notch for the sidebar's folder-settings API module.