### PR TITLE
Add tab pinning and drag-and-drop management

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -88,9 +88,15 @@ const initialKeys = collectStaticGraph(entry[0]);
 // must carry the shared settings along, so the sidebar carries the small
 // folder-settings API module (~2 KiB raw / ~0.7 KiB gzip). The credentials
 // editor itself stays in the lazy folder dialog.
+//
+// Cross-pane tab dragging has a synchronous HTML drag-token path and an exact
+// pane-move state transition on first paint (~1.1 KiB raw / ~1 KiB gzip). The
+// cross-window coordinator, snapshot flush, and adoption path remain lazy.
+// Browser-style drag feedback (live same-strip resorting, insertion lines,
+// FLIP slides) lives in the tab strip itself (~2.5 KiB raw / ~0.7 KiB gzip).
 check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 785_000,
-  gzip: 254_000,
+  raw: 790_000,
+  gzip: 256_500,
 });
 
 for (const feature of [

--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type DragEvent } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
@@ -13,6 +13,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
+import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -44,12 +45,27 @@ import {
   requestCloseTabs,
   splitActivePane,
 } from '../session-actions.js';
-import { useTabsStore, type PaneDirection, type TabStatus, type TerminalTab } from '../state/tabs.js';
+import {
+  useTabsStore,
+  type PaneDirection,
+  type TabStatus,
+  type TerminalTab,
+} from '../state/tabs.js';
 import { findPane } from '../state/workspace-layout.js';
 import { layout, statusTextColor } from '../theme.js';
 import { useMultiExecStore } from '../state/multi-exec.js';
 import { terminalHandle } from '../terminal/terminal-registry.js';
 import { hostKindIcon } from './host-kind-icon.js';
+import {
+  activeTabTransfer,
+  beginTabDrag,
+  endTabDrag,
+  hasTabTransfer,
+  readTabTransfer,
+  writeTabTransfer,
+} from '../tab-drag.js';
+
+const loadTabTransfer = () => import('../tab-transfer.js');
 
 const statusDot: Record<TabStatus, 'warning' | 'success' | 'error'> = {
   connecting: 'warning',
@@ -60,6 +76,20 @@ const statusDot: Record<TabStatus, 'warning' | 'success' | 'error'> = {
 
 /** Color flags a tab can be marked with (context menu). */
 const TAB_FLAG_COLORS = ['#ef5350', '#ffa726', '#ffee58', '#66bb6a', '#26c6da', '#42a5f5', '#ab47bc', '#ec407a'];
+
+/** Which side of the hovered tab a drop at this pointer position lands on. */
+function dropEdge(event: DragEvent<HTMLElement>): 'before' | 'after' {
+  const bounds = event.currentTarget.getBoundingClientRect();
+  return event.clientX < bounds.left + bounds.width / 2 ? 'before' : 'after';
+}
+
+function PinIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M9 2h6v8l4 3v2h-6v7h-2v-7H5v-2l4-3z" />
+    </SvgIcon>
+  );
+}
 
 /** Browser-style terminal tab strip scoped to one split pane. */
 export function TabStrip({
@@ -81,10 +111,22 @@ export function TabStrip({
   const toggleZoom = useTabsStore((s) => s.toggleZoom);
   const equalizePanes = useTabsStore((s) => s.equalizePanes);
   const update = useTabsStore((s) => s.update);
+  const setPinned = useTabsStore((s) => s.setPinned);
   const reconnect = useTabsStore((s) => s.reconnect);
   const multiExecTargets = useMultiExecStore((s) => s.selectedIds);
   const multiExecSelected = new Set(multiExecTargets);
   const toggleMultiExecTarget = useMultiExecStore((s) => s.toggleTarget);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  /** Insertion line for drops arriving from another pane or window; null targetId = end of strip. */
+  const [dropIndicator, setDropIndicator] = useState<
+    { targetId: string | null; edge: 'before' | 'after' } | null
+  >(null);
+  const tabElements = useRef(new Map<string, HTMLElement>());
+  const flipLefts = useRef(new Map<string, number>());
+  /** Hovered midpoints are unreliable while tabs are sliding; pause live resorting until then. */
+  const settleUntil = useRef(0);
+  const orderKey = tabs.map((tab) => tab.id).join('\n');
+  const previousOrderKey = useRef(orderKey);
   const [menu, setMenu] = useState<{ position: { top: number; left: number }; tab: TerminalTab } | null>(null);
   const [paneMenu, setPaneMenu] = useState<{ top: number; left: number } | null>(null);
   const [renaming, setRenaming] = useState<TerminalTab | null>(null);
@@ -108,12 +150,54 @@ export function TabStrip({
     requestAnimationFrame(() => renameInputRef.current?.select());
   }, [renaming]);
 
+  // FLIP: when this pane's tab order changes (live drag resorting, reorder
+  // chords, drops), slide each tab from its previous slot instead of teleporting.
+  useLayoutEffect(() => {
+    const moved = previousOrderKey.current !== orderKey;
+    previousOrderKey.current = orderKey;
+    const lefts = flipLefts.current;
+    for (const id of lefts.keys()) {
+      if (!tabElements.current.has(id)) lefts.delete(id);
+    }
+    for (const [id, element] of tabElements.current) {
+      // offsetLeft is the layout slot: unaffected by strip scroll and by a
+      // still-running slide, so back-to-back reorders start from the truth.
+      const left = element.offsetLeft;
+      const from = lefts.get(id);
+      if (moved && from !== undefined && from !== left && typeof element.animate === 'function') {
+        element.animate(
+          [{ transform: `translateX(${from - left}px)` }, { transform: 'none' }],
+          { duration: 160, easing: 'cubic-bezier(0.2, 0, 0, 1)' },
+        );
+        settleUntil.current = performance.now() + 170;
+      }
+      lefts.set(id, left);
+    }
+  });
+
   const openMenu = (tab: TerminalTab, position: { top: number; left: number }) => setMenu({ position, tab });
   const menuTab = menu ? allTabs.find((t) => t.id === menu.tab.id) : undefined;
 
   const commitRename = () => {
     if (renaming && renameValue.trim()) update(renaming.id, { title: renameValue.trim() });
     setRenaming(null);
+  };
+
+  const dropTab = (
+    transferId: string,
+    targetId?: string,
+    edge: 'before' | 'after' = 'after',
+  ) => {
+    const local = activeTabTransfer();
+    if (local?.transferId === transferId) {
+      useTabsStore.getState().moveTabToPane(local.tabId, paneId, targetId, edge);
+      endTabDrag(transferId);
+      void loadTabTransfer().then((module) => module.finishLocalTabTransfer(transferId));
+      return;
+    }
+    void loadTabTransfer().then((module) =>
+      module.receiveTabTransfer(transferId, paneId, targetId, edge),
+    );
   };
 
   return (
@@ -138,6 +222,41 @@ export function TabStrip({
           borderBottomColor: (theme) => alpha(theme.palette.text.primary, 0.18),
         }),
       }}
+      onDragOver={(event) => {
+        if (!hasTabTransfer(event.dataTransfer)) return;
+        if ((event.target as HTMLElement).closest('[data-muxus-tab]')) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+        const local = activeTabTransfer();
+        const dragged = local
+          ? allTabs.find((candidate) => candidate.id === local.tabId)
+          : undefined;
+        if (dragged?.paneId === paneId) {
+          // Hovering past the last tab sends a same-strip drag to the end of
+          // its group live; the moving tab is its own indicator.
+          setDropIndicator(null);
+          if (performance.now() >= settleUntil.current) {
+            useTabsStore.getState().moveTabToPane(dragged.id, paneId);
+          }
+          return;
+        }
+        setDropIndicator((current) =>
+          current?.targetId === null ? current : { targetId: null, edge: 'after' },
+        );
+      }}
+      onDragLeave={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setDropIndicator(null);
+        }
+      }}
+      onDrop={(event) => {
+        setDropIndicator(null);
+        if ((event.target as HTMLElement).closest('[data-muxus-tab]')) return;
+        const transferId = readTabTransfer(event.dataTransfer);
+        if (!transferId) return;
+        event.preventDefault();
+        dropTab(transferId);
+      }}
       onPointerDown={() => focusPane(paneId)}
       onContextMenu={(e) => {
         // Tabs handle their own menu first; this one belongs to the pane.
@@ -159,11 +278,76 @@ export function TabStrip({
         return (
           <Stack
             key={tab.id}
+            data-muxus-tab={tab.id}
             direction="row"
             role="tab"
             aria-selected={active}
-            aria-label={hasUnreadOutput ? `${tab.title}, new terminal output` : tab.title}
+            aria-label={[
+              tab.title,
+              tab.pinned ? 'pinned' : '',
+              hasUnreadOutput ? 'new terminal output' : '',
+            ].filter(Boolean).join(', ')}
             tabIndex={0}
+            draggable
+            ref={(element: HTMLElement | null) => {
+              if (element) tabElements.current.set(tab.id, element);
+              else tabElements.current.delete(tab.id);
+            }}
+            onDragStart={(event) => {
+              const transferId = beginTabDrag(tab.id);
+              void loadTabTransfer().then((module) =>
+                module.registerTabTransferSource(transferId, tab.id),
+              );
+              event.dataTransfer.effectAllowed = 'move';
+              writeTabTransfer(event.dataTransfer, transferId);
+              // After the browser snapshots the drag image, dim the strip copy.
+              requestAnimationFrame(() => setDraggingId(tab.id));
+            }}
+            onDragOver={(event) => {
+              if (!hasTabTransfer(event.dataTransfer)) return;
+              const local = activeTabTransfer();
+              const dragged = local
+                ? allTabs.find((candidate) => candidate.id === local.tabId)
+                : undefined;
+              if (
+                dragged?.paneId === paneId &&
+                !!dragged.pinned !== !!tab.pinned
+              ) {
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              event.dataTransfer.dropEffect = 'move';
+              if (dragged?.paneId === paneId) {
+                // Same-strip drags resort live, browser style; the moving tab
+                // is its own indicator.
+                setDropIndicator(null);
+                if (dragged.id !== tab.id && performance.now() >= settleUntil.current) {
+                  useTabsStore.getState().reorderTab(dragged.id, tab.id, dropEdge(event));
+                }
+                return;
+              }
+              const edge = dropEdge(event);
+              setDropIndicator((current) =>
+                current?.targetId === tab.id && current.edge === edge
+                  ? current
+                  : { targetId: tab.id, edge },
+              );
+            }}
+            onDrop={(event) => {
+              const transferId = readTabTransfer(event.dataTransfer);
+              if (!transferId) return;
+              event.preventDefault();
+              event.stopPropagation();
+              setDropIndicator(null);
+              dropTab(transferId, tab.id, dropEdge(event));
+            }}
+            onDragEnd={() => {
+              setDraggingId(null);
+              setDropIndicator(null);
+              const current = activeTabTransfer();
+              if (current?.tabId === tab.id) endTabDrag(current.transferId);
+            }}
             onClick={() => activate(tab.id)}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') activate(tab.id);
@@ -187,7 +371,7 @@ export function TabStrip({
               minWidth: 0,
               maxWidth: 220,
               position: 'relative',
-              cursor: 'pointer',
+              cursor: 'grab',
               userSelect: 'none',
               borderRight: 1,
               borderColor: 'divider',
@@ -204,8 +388,26 @@ export function TabStrip({
                 : hasUnreadOutput
                   ? `linear-gradient(180deg, ${alpha(theme.palette.info.main, 0.12)}, transparent 80%)`
                   : 'none',
-              transition: theme.transitions.create(['background-color', 'color'], {
+              // The strip copy stays in place at low opacity while its drag
+              // image follows the pointer, the way browser tabs behave.
+              opacity: draggingId === tab.id ? 0.4 : 1,
+              transition: theme.transitions.create(['background-color', 'color', 'opacity'], {
                 duration: theme.transitions.duration.shortest,
+              }),
+              ...(dropIndicator?.targetId === tab.id && {
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  [dropIndicator.edge === 'before' ? 'left' : 'right']: -1,
+                  top: 7,
+                  bottom: 7,
+                  width: 2,
+                  borderRadius: '1px',
+                  bgcolor: 'primary.main',
+                  boxShadow: `0 0 8px ${alpha(theme.palette.primary.main, 0.55)}`,
+                  zIndex: 2,
+                  pointerEvents: 'none',
+                },
               }),
               '&::after': {
                 content: '""',
@@ -278,6 +480,12 @@ export function TabStrip({
             >
               {tab.title}
             </Typography>
+            {tab.pinned ? (
+              <PinIcon
+                aria-label="Pinned"
+                sx={{ fontSize: 13, flexShrink: 0, color: 'text.secondary' }}
+              />
+            ) : null}
             {multiExecSelected.has(tab.id) && (
               <Tooltip
                 title={
@@ -347,6 +555,22 @@ export function TabStrip({
           </Stack>
         );
       })}
+      {dropIndicator?.targetId === null ? (
+        <Box
+          data-muxus-drop-indicator="end"
+          sx={(theme) => ({
+            width: 2,
+            flexShrink: 0,
+            alignSelf: 'stretch',
+            my: '7px',
+            ml: '-1px',
+            borderRadius: '1px',
+            bgcolor: 'primary.main',
+            boxShadow: `0 0 8px ${alpha(theme.palette.primary.main, 0.55)}`,
+            pointerEvents: 'none',
+          })}
+        />
+      ) : null}
       <Tooltip title={withChord('New tab', newTabChord)}>
         <IconButton
           size="small"
@@ -531,6 +755,20 @@ export function TabStrip({
           <ListItemText>Rename tab</ListItemText>
         </MenuItem>
         <MenuItem
+          onClick={() => {
+            if (menuTab) setPinned(menuTab.id, !menuTab.pinned);
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <PinIcon
+              fontSize="small"
+              sx={{ transform: menuTab?.pinned ? 'rotate(45deg)' : undefined }}
+            />
+          </ListItemIcon>
+          <ListItemText>{menuTab?.pinned ? 'Unpin tab' : 'Pin tab'}</ListItemText>
+        </MenuItem>
+        <MenuItem
           disabled={!menuTab?.profile}
           onClick={() => {
             if (menuTab) duplicateTab(menuTab.id);
@@ -697,9 +935,13 @@ export function TabStrip({
           <ListItemText>Close tab</ListItemText>
         </MenuItem>
         <MenuItem
-          disabled={tabs.length < 2}
+          disabled={!tabs.some((tab) => tab.id !== menuTab?.id && !tab.pinned)}
           onClick={() => {
-            if (menuTab) void requestCloseTabs(tabs.filter((t) => t.id !== menuTab.id).map((t) => t.id));
+            if (menuTab) {
+              void requestCloseTabs(
+                tabs.filter((tab) => tab.id !== menuTab.id && !tab.pinned).map((tab) => tab.id),
+              );
+            }
             setMenu(null);
           }}
         >

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -84,6 +84,7 @@ import {
   TERMINAL_SNAPSHOT_QUIET_MS,
 } from '../terminal/scrollback-snapshots.js';
 import { registerUnloadKeepalive } from '../unload-keepalive.js';
+import { completeTabTransfer } from '../tab-transfer.js';
 
 const SEARCH_DECORATIONS: ISearchOptions['decorations'] = {
   matchBackground: '#594b24',
@@ -392,6 +393,11 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       getSelection: () => term.getSelection(),
       bufferText: () => bufferText(term),
       bufferHtml: () => serialize.serializeAsHTML({ includeGlobalBackground: true }),
+      persistSnapshot: async () => {
+        if (!usePrefsStore.getState().restoreScrollback) return;
+        const data = serializeScrollback(serialize);
+        if (data !== undefined) await putTerminalSnapshot(tab.id, data);
+      },
       zoomIn: () => applyZoom('in'),
       zoomOut: () => applyZoom('out'),
       zoomReset: () => applyZoom('reset'),
@@ -538,13 +544,22 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         // it was not when the terminal mounted. Measure now so the remote PTY
         // starts at the size on screen instead of being resized a beat later.
         if (!fitted) fitted = fitTerminal();
-        ws?.send(JSON.stringify({
-          op: 'connect',
-          profile: tab.profile,
-          title: tab.title,
-          cols: term.cols,
-          rows: term.rows,
-        }));
+        ws?.send(JSON.stringify(
+          tab.transferId && tab.terminalId
+            ? {
+                op: 'attach',
+                terminalId: tab.terminalId,
+                cols: term.cols,
+                rows: term.rows,
+              }
+            : {
+                op: 'connect',
+                profile: tab.profile,
+                title: tab.title,
+                cols: term.cols,
+                rows: term.rows,
+              },
+        ));
       };
       ws.onmessage = (ev) => {
         if (ev.data instanceof ArrayBuffer) {
@@ -576,6 +591,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
           return;
         }
         switch (ctl.op) {
+          case 'session':
+            updateTab(tab.id, { terminalId: ctl.terminalId });
+            break;
           case 'status': {
             if (!ready && !transportSuspect) {
               updateTab(tab.id, {
@@ -633,10 +651,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             ready = true;
             readyAt = Date.now();
             clearTransientStatus();
-            waitingForTerminalOutput = shouldWaitForTerminalOutput(
-              tab.profile.kind,
-              receivedTerminalOutput,
-            );
+            waitingForTerminalOutput = tab.transferId
+              ? false
+              : shouldWaitForTerminalOutput(tab.profile.kind, receivedTerminalOutput);
             updateTab(tab.id, {
               status: transportSuspect
                 ? 'interrupted'
@@ -647,7 +664,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               disconnectReason: undefined,
               // Only SSH transport IDs are valid SFTP/forwarding lease keys.
               connId: tab.profile.kind === 'ssh' ? ctl.connId : undefined,
+              transferId: undefined,
             });
+            if (tab.transferId) completeTabTransfer(tab.transferId);
             const current = useTabsStore
               .getState()
               .tabs.find((candidate) => candidate.id === tab.id);
@@ -731,6 +750,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
           updateTab(tab.id, {
             status: 'closed',
             connId: undefined,
+            terminalId: undefined,
             failureReason: reason,
             disconnectReason: reasonKind,
           });
@@ -744,6 +764,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         updateTab(tab.id, {
           status: 'interrupted',
           connId: undefined,
+          terminalId: undefined,
           failureReason: reason,
           disconnectReason: reasonKind,
         });

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -101,6 +101,7 @@ const ACTIVE_IMAGE_STORAGE_MB = 64;
 const BACKGROUND_IMAGE_STORAGE_MB = 16;
 /** Quiet period a container size has to hold before the terminal refits. */
 const RESIZE_SETTLE_MS = 90;
+const TRANSFER_PREPARE_TIMEOUT_MS = 5_000;
 
 /** Plain-text contents of scrollback + screen, trailing blank rows trimmed. */
 function bufferText(term: Terminal): string {
@@ -384,6 +385,18 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       },
     );
 
+    let transferPreparation: {
+      resolve: (prepared: boolean) => void;
+      timer: ReturnType<typeof setTimeout>;
+    } | undefined;
+    const settleTransferPreparation = (prepared: boolean) => {
+      const pending = transferPreparation;
+      if (!pending) return;
+      transferPreparation = undefined;
+      clearTimeout(pending.timer);
+      pending.resolve(prepared);
+    };
+
     const unregister = registerTerminal(tab.id, {
       focus: () => term.focus(),
       sendInput,
@@ -397,6 +410,35 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         if (!usePrefsStore.getState().restoreScrollback) return;
         const data = serializeScrollback(serialize);
         if (data !== undefined) await putTerminalSnapshot(tab.id, data);
+      },
+      prepareTransfer: () => {
+        const socket = wsRef.current;
+        if (
+          transferPreparation ||
+          !socket ||
+          socket.readyState !== WebSocket.OPEN
+        ) {
+          return Promise.resolve(false);
+        }
+        return new Promise((resolve) => {
+          const timer = setTimeout(() => {
+            if (transferPreparation?.resolve !== resolve) return;
+            transferPreparation = undefined;
+            if (socket.readyState === WebSocket.OPEN) {
+              socket.send(JSON.stringify({ op: 'cancel-transfer' }));
+            }
+            resolve(false);
+          }, TRANSFER_PREPARE_TIMEOUT_MS);
+          transferPreparation = { resolve, timer };
+          socket.send(JSON.stringify({ op: 'prepare-transfer' }));
+        });
+      },
+      cancelTransfer: () => {
+        settleTransferPreparation(false);
+        const socket = wsRef.current;
+        if (socket?.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify({ op: 'cancel-transfer' }));
+        }
       },
       zoomIn: () => applyZoom('in'),
       zoomOut: () => applyZoom('out'),
@@ -594,6 +636,17 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
           case 'session':
             updateTab(tab.id, { terminalId: ctl.terminalId });
             break;
+          case 'transfer-ready': {
+            const pending = transferPreparation;
+            if (pending) {
+              // WebSocket frames are ordered, but xterm applies writes
+              // asynchronously. Drain all pre-freeze output before snapshotting.
+              term.write('', () => {
+                if (transferPreparation === pending) settleTransferPreparation(true);
+              });
+            }
+            break;
+          }
           case 'status': {
             if (!ready && !transportSuspect) {
               updateTab(tab.id, {
@@ -862,6 +915,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
 
     return () => {
       disposed = true;
+      settleTransferPreparation(false);
       clearInterval(snapshotTimer);
       if (quietSnapshotTimer !== undefined) clearTimeout(quietSnapshotTimer);
       unregisterUnloadFlush();

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -28,12 +28,18 @@ interface TabBase {
   title: string;
   /** Live SSH connection id from `ready`; absent for local, Telnet, and serial tabs. */
   connId?: string;
+  /** Stable server-side terminal identity, including while a connection is still opening. */
+  terminalId?: string;
+  /** Cross-window transfer awaiting acknowledgement from the source window. */
+  transferId?: string;
   /** SFTP file panel visible for this tab. */
   sftpOpen: boolean;
   /** Monotonic UI signal consumed by the mounted terminal search bar. */
   searchRequest: number;
   /** User-set color flag marking the tab. */
   color?: string;
+  /** Pinned tabs stay grouped at the start of their pane. */
+  pinned?: boolean;
   /** Remote files open in the Monaco workspace attached to this session. */
   editorPaths: string[];
   activeEditorPath?: string;
@@ -68,11 +74,14 @@ export interface EmptyTab extends TabBase {
 }
 
 export type TerminalTab = SessionTab | EmptyTab;
+export type TransferableTab = Omit<SessionTab, 'paneId'> | Omit<EmptyTab, 'paneId'>;
 
 type TabUpdate = Partial<{
   title: string;
   status: TabStatus;
   connId: string | undefined;
+  terminalId: string | undefined;
+  transferId: string | undefined;
   sftpOpen: boolean;
   color: string | undefined;
   loggingEnabled: boolean | undefined;
@@ -119,6 +128,17 @@ interface TabsState {
   activateTabIndex: (index: number | 'last') => boolean;
   /** Reorder the active tab inside its own pane. */
   moveTabWithinPane: (offset: -1 | 1) => boolean;
+  /** Place one tab before or after another tab in the same pane and pin group. */
+  reorderTab: (id: string, targetId: string, edge: 'before' | 'after') => boolean;
+  /** Move a tab to an exact position in another split pane. */
+  moveTabToPane: (
+    id: string,
+    paneId: string,
+    targetId?: string,
+    edge?: 'before' | 'after',
+  ) => boolean;
+  /** Pin or unpin a tab and move it to the corresponding strip boundary. */
+  setPinned: (id: string, pinned: boolean) => boolean;
   split: (paneId: string, direction: PaneDirection) => string | undefined;
   closePane: (paneId: string) => void;
   /** Focus the pane that borders the active one in a direction. */
@@ -224,6 +244,46 @@ function clearOutput(unreadOutputIds: Set<string>, id: string): Set<string> {
   if (!unreadOutputIds.has(id)) return unreadOutputIds;
   const next = new Set(unreadOutputIds);
   next.delete(id);
+  return next;
+}
+
+/** Replace one pane's ordered tabs without disturbing the other panes' slots. */
+function replacePaneTabs(
+  tabs: readonly TerminalTab[],
+  paneId: string,
+  paneTabs: readonly TerminalTab[],
+): TerminalTab[] {
+  let index = 0;
+  return tabs.map((tab) => tab.paneId === paneId ? paneTabs[index++]! : tab);
+}
+
+/** Insert a tab at an exact target, while keeping each pane's pinned group first. */
+export function insertIntoPane(
+  tabs: readonly TerminalTab[],
+  tab: TerminalTab,
+  paneId: string,
+  targetId?: string,
+  edge: 'before' | 'after' = 'after',
+): TerminalTab[] {
+  const next = [...tabs];
+  const paneTabs = next.filter((candidate) => candidate.paneId === paneId);
+  const targetIndex = paneTabs.findIndex(
+    (candidate) => candidate.id === targetId && !!candidate.pinned === !!tab.pinned,
+  );
+  const firstUnpinned = paneTabs.findIndex((candidate) => !candidate.pinned);
+  const paneIndex = targetIndex >= 0
+    ? targetIndex + (edge === 'after' ? 1 : 0)
+    : tab.pinned
+      ? firstUnpinned < 0 ? paneTabs.length : firstUnpinned
+      : paneTabs.length;
+  const anchor = paneTabs[paneIndex];
+  const previous = paneTabs[paneIndex - 1];
+  const index = anchor
+    ? next.findIndex((candidate) => candidate.id === anchor.id)
+    : previous
+      ? next.findIndex((candidate) => candidate.id === previous.id) + 1
+      : next.length;
+  next.splice(index, 0, { ...tab, paneId });
   return next;
 }
 
@@ -415,12 +475,91 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     const paneTabs = state.tabs.filter((tab) => tab.paneId === state.activePaneId);
     const position = paneTabs.findIndex((tab) => tab.id === state.activeId);
     const swapWith = paneTabs[position + offset];
-    if (position < 0 || !swapWith) return false;
-    const tabs = [...state.tabs];
-    const from = tabs.findIndex((tab) => tab.id === paneTabs[position]!.id);
-    const to = tabs.findIndex((tab) => tab.id === swapWith.id);
-    [tabs[from], tabs[to]] = [tabs[to]!, tabs[from]!];
-    set({ tabs });
+    if (position < 0 || !swapWith || !!swapWith.pinned !== !!paneTabs[position]!.pinned) {
+      return false;
+    }
+    return state.reorderTab(
+      paneTabs[position]!.id,
+      swapWith.id,
+      offset < 0 ? 'before' : 'after',
+    );
+  },
+  reorderTab: (id, targetId, edge) => {
+    const state = get();
+    const tab = state.tabs.find((candidate) => candidate.id === id);
+    const target = state.tabs.find((candidate) => candidate.id === targetId);
+    if (
+      !tab ||
+      !target ||
+      tab.id === target.id ||
+      tab.paneId !== target.paneId ||
+      !!tab.pinned !== !!target.pinned
+    ) {
+      return false;
+    }
+    return state.moveTabToPane(id, target.paneId, targetId, edge);
+  },
+  moveTabToPane: (id, paneId, targetId, edge = 'after') => {
+    const state = get();
+    const tab = state.tabs.find((candidate) => candidate.id === id);
+    if (!tab || !findPane(state.root, paneId) || targetId === id) return false;
+    if (targetId && !state.tabs.some((candidate) => candidate.id === targetId && candidate.paneId === paneId)) {
+      return false;
+    }
+    const sourceId = tab.paneId;
+    const sourceTabs = state.tabs.filter((candidate) => candidate.paneId === sourceId);
+    const others = state.tabs.filter((candidate) => candidate.id !== id);
+    const tabs = insertIntoPane(others, tab, paneId, targetId, edge);
+    if (
+      state.tabs.every(
+        (candidate, index) =>
+          candidate.id === tabs[index]?.id && candidate.paneId === tabs[index]?.paneId,
+      )
+    ) {
+      return false;
+    }
+    if (sourceId === paneId) {
+      set({ tabs });
+      return true;
+    }
+
+    const sourceIndex = sourceTabs.findIndex((candidate) => candidate.id === id);
+    const remaining = tabs.filter((candidate) => candidate.paneId === sourceId);
+    const previousSourceActiveId = findPane(state.root, sourceId)?.activeTabId;
+    const sourceActiveId = previousSourceActiveId === id
+      ? remaining[Math.min(sourceIndex, remaining.length - 1)]?.id ?? null
+      : previousSourceActiveId ?? null;
+    let root = updatePane(state.root, sourceId, (pane) => ({ ...pane, activeTabId: sourceActiveId }));
+    root = updatePane(root, paneId, (pane) => ({ ...pane, activeTabId: id }));
+    let zoomedPaneId = state.zoomedPaneId;
+    if (remaining.length === 0) {
+      const collapsed = collapsePane(root, sourceId);
+      if (collapsed) {
+        root = collapsed.root;
+        if (zoomedPaneId === sourceId) zoomedPaneId = null;
+      }
+    }
+    const nextZoomedPaneId = zoomedPaneId === paneId ? zoomedPaneId : null;
+    set({
+      tabs,
+      root,
+      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, tabs, root, nextZoomedPaneId),
+      activePaneId: paneId,
+      activeId: id,
+      zoomedPaneId: nextZoomedPaneId,
+    });
+    return true;
+  },
+  setPinned: (id, pinned) => {
+    const state = get();
+    const tab = state.tabs.find((candidate) => candidate.id === id);
+    if (!tab || !!tab.pinned === pinned) return false;
+    const paneTabs = state.tabs.filter((candidate) => candidate.paneId === tab.paneId);
+    const reordered = paneTabs.filter((candidate) => candidate.id !== id);
+    const boundary = reordered.findIndex((candidate) => !candidate.pinned);
+    const index = boundary < 0 ? reordered.length : boundary;
+    reordered.splice(index, 0, { ...tab, pinned: pinned || undefined });
+    set({ tabs: replacePaneTabs(state.tabs, tab.paneId, reordered) });
     return true;
   },
   split: (paneId, direction) => {
@@ -486,47 +625,8 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     const neighbor = neighborPaneId(state.root, sourceId, direction);
     // Splitting off the only tab of a pane would just move the pane around.
     if (!neighbor && sourceTabs.length < 2) return false;
-
-    let root = state.root;
-    let targetId = neighbor;
-    if (!targetId) {
-      const inserted = insertSplit(root, sourceId, direction);
-      root = inserted.root;
-      targetId = inserted.pane.id;
-    }
-
-    const others = state.tabs.filter((candidate) => candidate.id !== tab.id);
-    const lastOfTarget = others.reduce(
-      (found, candidate, index) => (candidate.paneId === targetId ? index : found),
-      -1,
-    );
-    const tabs = [...others];
-    tabs.splice(lastOfTarget >= 0 ? lastOfTarget + 1 : tabs.length, 0, { ...tab, paneId: targetId });
-
-    const remaining = tabs.filter((candidate) => candidate.paneId === sourceId);
-    const sourceIndex = sourceTabs.findIndex((candidate) => candidate.id === tab.id);
-    const sourceActiveId = remaining[Math.min(sourceIndex, remaining.length - 1)]?.id ?? null;
-    root = updatePane(root, targetId, (pane) => ({ ...pane, activeTabId: tab.id }));
-    root = updatePane(root, sourceId, (pane) => ({ ...pane, activeTabId: sourceActiveId }));
-
-    let zoomedPaneId = state.zoomedPaneId;
-    if (remaining.length === 0) {
-      const collapsed = collapsePane(root, sourceId);
-      if (collapsed) {
-        root = collapsed.root;
-        if (zoomedPaneId === sourceId) zoomedPaneId = null;
-      }
-    }
-    const nextZoomedPaneId = zoomedPaneId === targetId ? zoomedPaneId : null;
-    set({
-      tabs,
-      root,
-      unreadOutputIds: clearVisibleOutput(state.unreadOutputIds, tabs, root, nextZoomedPaneId),
-      activePaneId: targetId,
-      activeId: tab.id,
-      zoomedPaneId: nextZoomedPaneId,
-    });
-    return true;
+    const targetId = neighbor ?? state.split(sourceId, direction);
+    return targetId ? get().moveTabToPane(tab.id, targetId) : false;
   },
   toggleZoom: (paneId) => {
     const state = get();
@@ -699,6 +799,8 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
               ...tab,
               status: 'connecting' as const,
               connectOnMount: true,
+              terminalId: undefined,
+              transferId: undefined,
               reconnectRequest: tab.reconnectRequest + 1,
               reconnectMode:
                 tab.profile.kind === 'ssh' ? options?.reattach : undefined,
@@ -717,6 +819,8 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
               ...tab,
               status: 'connecting' as const,
               connectOnMount: true,
+              terminalId: undefined,
+              transferId: undefined,
               reconnectRequest: tab.reconnectRequest + 1,
               reconnectMode:
                 tab.profile.kind === 'ssh' ? options?.reattach : undefined,

--- a/client/src/state/workspace-layout.ts
+++ b/client/src/state/workspace-layout.ts
@@ -41,6 +41,7 @@ export interface PersistableTerminalTab {
   title: string;
   profile: SessionProfile;
   color?: string;
+  pinned?: boolean;
 }
 
 export interface RestoredTerminalTab extends PersistableTerminalTab {
@@ -279,6 +280,7 @@ export function serializeWorkspace(
         profile: tab.profile,
         cwdHint: tab.profile.kind === 'local' ? tab.profile.cwd : undefined,
         color: tab.color,
+        pinned: tab.pinned,
         offerReconnect: true,
       })),
       activeTabId,
@@ -320,6 +322,7 @@ export function restoreWorkspace(
         title: tab.title,
         profile,
         color: tab.color,
+        pinned: tab.pinned,
         connectOnMount:
           profile.kind === 'local' || (options?.connectRemote === true && tab.offerReconnect),
       });

--- a/client/src/tab-drag.ts
+++ b/client/src/tab-drag.ts
@@ -1,0 +1,42 @@
+export const TAB_TRANSFER_MIME = 'application/x-muxus-tab';
+const TEXT_PREFIX = 'muxus-tab:';
+
+let active: { tabId: string; transferId: string } | undefined;
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Start the synchronous portion of an HTML drag; cross-window setup stays lazy. */
+export function beginTabDrag(tabId: string): string {
+  const transferId = randomId();
+  active = { tabId, transferId };
+  return transferId;
+}
+
+export function activeTabTransfer(): { tabId: string; transferId: string } | undefined {
+  return active;
+}
+
+export function endTabDrag(transferId: string): void {
+  if (active?.transferId === transferId) active = undefined;
+}
+
+export function writeTabTransfer(dataTransfer: DataTransfer, transferId: string): void {
+  dataTransfer.setData(TAB_TRANSFER_MIME, transferId);
+  dataTransfer.setData('text/plain', `${TEXT_PREFIX}${transferId}`);
+}
+
+export function hasTabTransfer(dataTransfer: DataTransfer): boolean {
+  // Custom types are listed during dragover in every supported browser, so a
+  // text/plain fallback here would only make ordinary text drags look droppable.
+  return Array.from(dataTransfer.types).includes(TAB_TRANSFER_MIME);
+}
+
+export function readTabTransfer(dataTransfer: DataTransfer): string | undefined {
+  const custom = dataTransfer.getData(TAB_TRANSFER_MIME);
+  if (custom) return custom;
+  const text = dataTransfer.getData('text/plain');
+  return text.startsWith(TEXT_PREFIX) ? text.slice(TEXT_PREFIX.length) : undefined;
+}

--- a/client/src/tab-transfer.ts
+++ b/client/src/tab-transfer.ts
@@ -16,12 +16,14 @@ const SOURCE_TTL_MS = 2 * 60_000;
 type TransferMessage =
   | { kind: 'claim'; requestId: string; transferId: string }
   | { kind: 'offer'; requestId: string; transferId: string; tab?: TransferableTab }
+  | { kind: 'cancel'; transferId: string }
   | { kind: 'complete'; transferId: string };
 
 interface TransferSource {
   tabId: string;
   prepare: () => Promise<boolean>;
   snapshot: () => TransferableTab | undefined;
+  cancel: () => void;
   complete: () => void;
   prepared?: Promise<TransferableTab | undefined>;
   expires: ReturnType<typeof setTimeout>;
@@ -69,6 +71,14 @@ function transferChannel(): BroadcastChannel | undefined {
       claim.resolve(message.tab);
       return;
     }
+    if (message.kind === 'cancel') {
+      const source = sources.get(message.transferId);
+      if (source) {
+        source.cancel();
+        source.prepared = undefined;
+      }
+      return;
+    }
     if (message.kind === 'complete') {
       const source = sources.get(message.transferId);
       if (!source) return;
@@ -86,28 +96,43 @@ function randomId(): string {
 
 async function prepareTabTransfer(tabId: string): Promise<boolean> {
   if (!(await confirmDiscardRemoteEditors([tabId]))) return false;
-  await terminalHandle(tabId)?.persistSnapshot();
+  const handle = terminalHandle(tabId);
+  const initial = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
+  const live = !!initial?.profile && initial.status !== 'closed' && !!initial.terminalId;
+  let prepared = false;
+  if (live) {
+    if (!handle || !(await handle.prepareTransfer())) return false;
+    prepared = true;
+  }
+  await handle?.persistSnapshot();
   const transferable = () => {
     const tab = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
     return (
       !tab ||
       !tab.profile ||
       tab.status === 'closed' ||
-      (tab.status === 'connected' && !!tab.terminalId)
+      !!tab.terminalId
     );
   };
-  if (transferable()) return useTabsStore.getState().tabs.some((tab) => tab.id === tabId);
+  if (transferable()) {
+    const exists = useTabsStore.getState().tabs.some((tab) => tab.id === tabId);
+    if (!exists && prepared) handle?.cancelTransfer();
+    return exists;
+  }
   return new Promise((resolve) => {
     const finish = () => {
       clearTimeout(timer);
       unsubscribe();
-      resolve(useTabsStore.getState().tabs.some((tab) => tab.id === tabId));
+      const exists = useTabsStore.getState().tabs.some((tab) => tab.id === tabId);
+      if (!exists && prepared) handle?.cancelTransfer();
+      resolve(exists);
     };
     const unsubscribe = useTabsStore.subscribe(() => {
       if (transferable()) finish();
     });
     const timer = setTimeout(() => {
       unsubscribe();
+      if (prepared) handle?.cancelTransfer();
       resolve(false);
     }, 5_000);
   });
@@ -124,6 +149,7 @@ export function registerTabTransferSource(transferId: string, tabId: string): vo
       const { paneId: _paneId, ...snapshot } = tab;
       return snapshot;
     },
+    cancel: () => terminalHandle(tabId)?.cancelTransfer(),
     complete: () => useTabsStore.getState().close(tabId),
   });
 }
@@ -133,9 +159,13 @@ export function registerTabTransferSourceOptions(transferId: string, options: {
   tabId: string;
   prepare: () => Promise<boolean>;
   snapshot: () => TransferableTab | undefined;
+  cancel: () => void;
   complete: () => void;
 }): void {
-  const expires = setTimeout(() => sources.delete(transferId), SOURCE_TTL_MS);
+  const expires = setTimeout(() => {
+    sources.get(transferId)?.cancel();
+    sources.delete(transferId);
+  }, SOURCE_TTL_MS);
   sources.set(transferId, { ...options, expires });
   transferChannel();
 }
@@ -146,6 +176,7 @@ export function finishLocalTabTransfer(transferId: string): void {
   if (!source) return;
   clearTimeout(source.expires);
   sources.delete(transferId);
+  source.cancel();
 }
 
 /** Resolve a cross-window token over a same-origin channel. */
@@ -165,6 +196,7 @@ export function claimTabTransfer(transferId: string): Promise<TransferableTab | 
     const timer = setTimeout(() => {
       clearInterval(retry);
       claims.delete(requestId);
+      transferChannelInstance.postMessage({ kind: 'cancel', transferId } satisfies TransferMessage);
       resolve(undefined);
     }, CLAIM_TIMEOUT_MS);
     claims.set(requestId, { resolve, retry, timer });
@@ -206,13 +238,11 @@ export async function receiveTabTransfer(
 ): Promise<void> {
   const offered = await claimTabTransfer(transferId);
   if (!offered) {
+    transferChannel()?.postMessage({ kind: 'cancel', transferId } satisfies TransferMessage);
     showToast('warning', 'The tab could not be moved from the other window.');
     return;
   }
-  const live =
-    offered.profile !== null &&
-    offered.status === 'connected' &&
-    !!offered.terminalId;
+  const live = offered.profile !== null && !!offered.terminalId;
   const incoming: TransferableTab = offered.profile
     ? {
         ...offered,
@@ -222,6 +252,7 @@ export async function receiveTabTransfer(
       }
     : { ...offered, transferId: undefined };
   if (!adoptTransferredTab(incoming, paneId, targetId, edge)) {
+    transferChannel()?.postMessage({ kind: 'cancel', transferId } satisfies TransferMessage);
     showToast('warning', 'A tab with the same identity already exists in this window.');
     return;
   }

--- a/client/src/tab-transfer.ts
+++ b/client/src/tab-transfer.ts
@@ -1,0 +1,229 @@
+import { confirmDiscardRemoteEditors } from './editor/remote-editor-registry.js';
+import {
+  insertIntoPane,
+  useTabsStore,
+  type TerminalTab,
+  type TransferableTab,
+} from './state/tabs.js';
+import { findPane } from './state/workspace-layout.js';
+import { showToast } from './state/toast.js';
+import { terminalHandle } from './terminal/terminal-registry.js';
+
+const CHANNEL_NAME = 'muxus-tab-transfer-v1';
+const CLAIM_TIMEOUT_MS = 10_000;
+const SOURCE_TTL_MS = 2 * 60_000;
+
+type TransferMessage =
+  | { kind: 'claim'; requestId: string; transferId: string }
+  | { kind: 'offer'; requestId: string; transferId: string; tab?: TransferableTab }
+  | { kind: 'complete'; transferId: string };
+
+interface TransferSource {
+  tabId: string;
+  prepare: () => Promise<boolean>;
+  snapshot: () => TransferableTab | undefined;
+  complete: () => void;
+  prepared?: Promise<TransferableTab | undefined>;
+  expires: ReturnType<typeof setTimeout>;
+}
+
+let channel: BroadcastChannel | undefined;
+const sources = new Map<string, TransferSource>();
+const claims = new Map<
+  string,
+  {
+    resolve: (tab: TransferableTab | undefined) => void;
+    retry: ReturnType<typeof setInterval>;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
+
+function transferChannel(): BroadcastChannel | undefined {
+  if (channel || typeof BroadcastChannel === 'undefined') return channel;
+  channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.addEventListener('message', (event: MessageEvent<TransferMessage>) => {
+    const message = event.data;
+    if (!message || typeof message !== 'object') return;
+    if (message.kind === 'claim') {
+      const source = sources.get(message.transferId);
+      if (!source) return;
+      source.prepared ??= (async () => {
+        try {
+          if (!(await source.prepare())) return undefined;
+          return source.snapshot();
+        } catch {
+          return undefined;
+        }
+      })();
+      void source.prepared.then((tab) => {
+        channel?.postMessage({ ...message, kind: 'offer', tab } satisfies TransferMessage);
+      });
+      return;
+    }
+    if (message.kind === 'offer') {
+      const claim = claims.get(message.requestId);
+      if (!claim || message.transferId === '') return;
+      clearInterval(claim.retry);
+      clearTimeout(claim.timer);
+      claims.delete(message.requestId);
+      claim.resolve(message.tab);
+      return;
+    }
+    if (message.kind === 'complete') {
+      const source = sources.get(message.transferId);
+      if (!source) return;
+      clearTimeout(source.expires);
+      sources.delete(message.transferId);
+      source.complete();
+    }
+  });
+  return channel;
+}
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function prepareTabTransfer(tabId: string): Promise<boolean> {
+  if (!(await confirmDiscardRemoteEditors([tabId]))) return false;
+  await terminalHandle(tabId)?.persistSnapshot();
+  const transferable = () => {
+    const tab = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
+    return (
+      !tab ||
+      !tab.profile ||
+      tab.status === 'closed' ||
+      (tab.status === 'connected' && !!tab.terminalId)
+    );
+  };
+  if (transferable()) return useTabsStore.getState().tabs.some((tab) => tab.id === tabId);
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      unsubscribe();
+      resolve(useTabsStore.getState().tabs.some((tab) => tab.id === tabId));
+    };
+    const unsubscribe = useTabsStore.subscribe(() => {
+      if (transferable()) finish();
+    });
+    const timer = setTimeout(() => {
+      unsubscribe();
+      resolve(false);
+    }, 5_000);
+  });
+}
+
+/** Register one store tab as the source of a cross-window handoff. */
+export function registerTabTransferSource(transferId: string, tabId: string): void {
+  registerTabTransferSourceOptions(transferId, {
+    tabId,
+    prepare: () => prepareTabTransfer(tabId),
+    snapshot: () => {
+      const tab = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
+      if (!tab || (tab.profile && tab.status !== 'closed' && !tab.terminalId)) return undefined;
+      const { paneId: _paneId, ...snapshot } = tab;
+      return snapshot;
+    },
+    complete: () => useTabsStore.getState().close(tabId),
+  });
+}
+
+/** Register a source without putting its profile or credentials in DataTransfer. */
+export function registerTabTransferSourceOptions(transferId: string, options: {
+  tabId: string;
+  prepare: () => Promise<boolean>;
+  snapshot: () => TransferableTab | undefined;
+  complete: () => void;
+}): void {
+  const expires = setTimeout(() => sources.delete(transferId), SOURCE_TTL_MS);
+  sources.set(transferId, { ...options, expires });
+  transferChannel();
+}
+
+/** Retire a token after a move handled entirely inside this renderer. */
+export function finishLocalTabTransfer(transferId: string): void {
+  const source = sources.get(transferId);
+  if (!source) return;
+  clearTimeout(source.expires);
+  sources.delete(transferId);
+}
+
+/** Resolve a cross-window token over a same-origin channel. */
+export function claimTabTransfer(transferId: string): Promise<TransferableTab | undefined> {
+  const transferChannelInstance = transferChannel();
+  if (!transferChannelInstance) return Promise.resolve(undefined);
+  const requestId = randomId();
+  return new Promise((resolve) => {
+    const request = () => {
+      transferChannelInstance.postMessage({
+        kind: 'claim',
+        requestId,
+        transferId,
+      } satisfies TransferMessage);
+    };
+    const retry = setInterval(request, 250);
+    const timer = setTimeout(() => {
+      clearInterval(retry);
+      claims.delete(requestId);
+      resolve(undefined);
+    }, CLAIM_TIMEOUT_MS);
+    claims.set(requestId, { resolve, retry, timer });
+    request();
+  });
+}
+
+export function completeTabTransfer(transferId: string): void {
+  transferChannel()?.postMessage({ kind: 'complete', transferId } satisfies TransferMessage);
+}
+
+export function adoptTransferredTab(
+  tab: TransferableTab,
+  paneId: string,
+  targetId?: string,
+  edge: 'before' | 'after' = 'after',
+): boolean {
+  const state = useTabsStore.getState();
+  if (
+    state.tabs.some((candidate) => candidate.id === tab.id) ||
+    !findPane(state.root, paneId) ||
+    (targetId !== undefined &&
+      !state.tabs.some((candidate) => candidate.id === targetId && candidate.paneId === paneId))
+  ) {
+    return false;
+  }
+  const adopted = { ...tab, paneId } as TerminalTab;
+  useTabsStore.setState({ tabs: insertIntoPane(state.tabs, adopted, paneId, targetId, edge) });
+  useTabsStore.getState().activate(tab.id);
+  return true;
+}
+
+/** Claim and adopt a tab dropped into this renderer. */
+export async function receiveTabTransfer(
+  transferId: string,
+  paneId: string,
+  targetId?: string,
+  edge: 'before' | 'after' = 'after',
+): Promise<void> {
+  const offered = await claimTabTransfer(transferId);
+  if (!offered) {
+    showToast('warning', 'The tab could not be moved from the other window.');
+    return;
+  }
+  const live =
+    offered.profile !== null &&
+    offered.status === 'connected' &&
+    !!offered.terminalId;
+  const incoming: TransferableTab = offered.profile
+    ? {
+        ...offered,
+        restored: true,
+        connectOnMount: live,
+        transferId: live ? transferId : undefined,
+      }
+    : { ...offered, transferId: undefined };
+  if (!adoptTransferredTab(incoming, paneId, targetId, edge)) {
+    showToast('warning', 'A tab with the same identity already exists in this window.');
+    return;
+  }
+  if (!live) completeTabTransfer(transferId);
+}

--- a/client/src/terminal/terminal-registry.ts
+++ b/client/src/terminal/terminal-registry.ts
@@ -19,6 +19,10 @@ export interface TerminalHandle {
   bufferHtml(): string;
   /** Persist the latest screen + scrollback before handing this tab to another window. */
   persistSnapshot(): Promise<void>;
+  /** Freeze server output and drain xterm's write queue before taking that snapshot. */
+  prepareTransfer(): Promise<boolean>;
+  /** Resume server output when a prepared transfer is abandoned. */
+  cancelTransfer(): void;
   zoomIn(): void;
   zoomOut(): void;
   zoomReset(): void;

--- a/client/src/terminal/terminal-registry.ts
+++ b/client/src/terminal/terminal-registry.ts
@@ -17,6 +17,8 @@ export interface TerminalHandle {
   bufferText(): string;
   /** Standalone HTML document of the buffer with colors preserved. */
   bufferHtml(): string;
+  /** Persist the latest screen + scrollback before handing this tab to another window. */
+  persistSnapshot(): Promise<void>;
   zoomIn(): void;
   zoomOut(): void;
   zoomReset(): void;

--- a/docs/guide/tabs-and-panes.md
+++ b/docs/guide/tabs-and-panes.md
@@ -51,7 +51,7 @@ serial, or a remote editor.
 <figure markdown="span">
   ![The tab context menu](../assets/screenshots/tab-menu.png#only-light){ .shadow }
   ![The tab context menu](../assets/screenshots/tab-menu-dark.png#only-dark){ .shadow }
-  <figcaption>The tab menu: rename, duplicate, colour flag, open in a window, add to multi-exec, and reconnect.</figcaption>
+  <figcaption>The tab menu: pin, rename, duplicate, colour flag, open in a window, add to multi-exec, and reconnect.</figcaption>
 </figure>
 
 - **New tab**: ++ctrl+shift+t++, or the **+** in the strip.
@@ -59,11 +59,15 @@ serial, or a remote editor.
   the shell.
 - **Switch**: ++alt+1++ … ++alt+9++ by position (++alt+9++ is always the last tab), or
   ++ctrl+pgup++ / ++ctrl+pgdn++.
-- **Reorder**: ++ctrl+shift+pgup++ / ++ctrl+shift+pgdn++, or drag.
+- **Reorder or move**: ++ctrl+shift+pgup++ / ++ctrl+shift+pgdn++ reorders in the current
+  strip. Drag a tab to an exact position in this strip, another split, or another Muxus
+  window. A cross-window drop hands off the live terminal and restores its scrollback.
+- **Pin**: choose **Pin tab** from the right-click menu. Pinned tabs stay at the left of the
+  strip, keep their own drag order, and are preserved by **Close other tabs**.
 - **Rename**: double-click the title.
 - **Duplicate**: ++ctrl+shift+d++ opens a second session on the same host.
 - **Colour flags**: assigned from the right-click menu.
-- **Open in new window**: moves the tab into its own window, on the same transport.
+- **Open in new window**: opens the same profile as a fresh session in its own window.
 
 Each tab shows a status dot: amber while connecting, green when connected, red when the
 transport is gone.
@@ -74,6 +78,8 @@ transport is gone.
 - Moving a tab toward a direction where **no pane exists** splits one off.
 - Layout changes never remount a terminal, so the shell, scrollback and SSH channel survive
   every split, close and move.
+- Dragging a connected tab between **Muxus windows** transfers ownership of its running
+  backend session; it does not start a second login.
 - Keystrokes typed into a pane that is **still connecting** are delivered once it is ready.
 
 ## Default chord selection

--- a/server/src/routes/workspaces.ts
+++ b/server/src/routes/workspaces.ts
@@ -21,6 +21,7 @@ const workspaceTabSchema = z.discriminatedUnion('kind', [
     profile: sessionProfileSchema,
     cwdHint: z.string().optional(),
     color: z.string().max(32).optional(),
+    pinned: z.boolean().optional(),
     offerReconnect: z.boolean(),
   }),
   z.object({

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import type { FastifyInstance } from 'fastify';
 import type { WebSocket } from 'ws';
 import { nanoid } from 'nanoid';
@@ -20,6 +21,132 @@ const KEEPALIVE_MS = 30_000;
 const BACKPRESSURE_HIGH = 4 * 1024 * 1024;
 const BACKPRESSURE_POLL_MS = 50;
 
+const REPLAYED_CONTROL_OPS = [
+  'session',
+  'status',
+  'auth-prompt',
+  'host-key',
+  'ready',
+  'logging-state',
+  'connection-health',
+] as const;
+const replayedControlOps = new Set<string>(REPLAYED_CONTROL_OPS);
+
+/**
+ * Stable socket facade whose underlying browser socket can be replaced. The
+ * terminal lifecycle listens to this facade's `close`, so swapping renderers
+ * does not tear down the PTY, serial port, Telnet stream, or SSH channel.
+ */
+export class TransferableTerminalSocket extends EventEmitter {
+  readonly OPEN = 1;
+  private current: WebSocket;
+  private closed = false;
+  private readonly controls = new Map<string, string>();
+
+  constructor(readonly terminalId: string, socket: WebSocket) {
+    super();
+    this.current = socket;
+    this.bind(socket);
+  }
+
+  get readyState(): number {
+    return this.closed ? 3 : this.current.readyState;
+  }
+
+  get bufferedAmount(): number {
+    return this.current.bufferedAmount;
+  }
+
+  /** Feed the already-consumed first frame into the normal session handler. */
+  push(data: Buffer, isBinary: boolean): void {
+    this.handleMessage(data, isBinary);
+  }
+
+  /** Move this terminal to a new renderer without emitting lifecycle close. */
+  attach(socket: WebSocket, cols: number, rows: number): boolean {
+    if (this.closed) return false;
+    const previous = this.current;
+    this.unbind(previous);
+    this.current = socket;
+    this.bind(socket);
+    if (previous.readyState === previous.OPEN) previous.close(1000, 'terminal transferred');
+    for (const op of REPLAYED_CONTROL_OPS) {
+      const frame = this.controls.get(op);
+      if (frame && socket.readyState === socket.OPEN) socket.send(frame);
+    }
+    this.handleMessage(
+      Buffer.from(JSON.stringify({ op: 'resize', cols, rows })),
+      false,
+    );
+    return true;
+  }
+
+  send(data: string | Buffer, options?: { binary?: boolean }): void {
+    if (typeof data === 'string') {
+      try {
+        const message = JSON.parse(data) as { op?: string };
+        if (message.op && replayedControlOps.has(message.op)) {
+          this.controls.set(message.op, data);
+          if (message.op === 'ready') {
+            this.controls.delete('status');
+            this.controls.delete('auth-prompt');
+            this.controls.delete('host-key');
+          }
+        }
+      } catch {
+        /* ordinary text frame */
+      }
+    }
+    if (this.current.readyState === this.current.OPEN) {
+      if (options) this.current.send(data, options);
+      else this.current.send(data);
+    }
+  }
+
+  ping(): void {
+    if (this.current.readyState === this.current.OPEN) this.current.ping();
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.closed) return;
+    const socket = this.current;
+    this.finish();
+    if (socket.readyState === socket.OPEN) socket.close(code, reason);
+  }
+
+  private readonly handleMessage = (data: Buffer, isBinary: boolean): void => {
+    if (!isBinary) {
+      try {
+        const message = JSON.parse(data.toString('utf8')) as { op?: string };
+        if (message.op === 'auth-response') this.controls.delete('auth-prompt');
+        if (message.op === 'host-key-response') this.controls.delete('host-key');
+      } catch {
+        /* terminal text input */
+      }
+    }
+    this.emit('message', data, isBinary);
+  };
+
+  private readonly handleClose = (): void => this.finish();
+
+  private bind(socket: WebSocket): void {
+    socket.on('message', this.handleMessage);
+    socket.once('close', this.handleClose);
+  }
+
+  private unbind(socket: WebSocket): void {
+    socket.removeListener('message', this.handleMessage);
+    socket.removeListener('close', this.handleClose);
+  }
+
+  private finish(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.unbind(this.current);
+    this.emit('close');
+  }
+}
+
 /**
  * /ws/terminal — one socket per terminal tab. Binary frames are terminal
  * bytes both ways; text frames are JSON control (see shared/ws-protocol).
@@ -28,17 +155,61 @@ const BACKPRESSURE_POLL_MS = 50;
  * `auth-prompt`/`host-key` round-trips before `ready`.
  */
 export function registerTerminalSocket(app: FastifyInstance, ctx: AppContext): void {
+  const sessions = new Map<string, TransferableTerminalSocket>();
   app.get('/ws/terminal', { websocket: true }, (socket) => {
-    void handleSession(socket, ctx, app).catch((err) => {
-      app.log.warn({ err }, 'terminal session failed');
-      sendControl(socket, {
-        op: 'exit',
-        code: 1,
-        message: err instanceof Error ? err.message : String(err),
-        reason: 'failed',
+    const timer = setTimeout(() => socket.close(1008, 'timed out waiting for connect'), CONNECT_TIMEOUT_MS);
+    const firstMessage = (data: Buffer, isBinary: boolean): void => {
+      clearTimeout(timer);
+      socket.removeListener('message', firstMessage);
+      if (isBinary) {
+        socket.close(1008, 'expected connect or attach');
+        return;
+      }
+      let first: TerminalClientMessage | undefined;
+      try {
+        const parsed = terminalClientMessageSchema.safeParse(JSON.parse(data.toString('utf8')));
+        if (parsed.success) first = parsed.data;
+      } catch {
+        /* rejected below */
+      }
+      if (!first || !['connect', 'dial', 'attach'].includes(first.op)) {
+        socket.close(1008, 'expected connect or attach');
+        return;
+      }
+      if (first.op === 'attach') {
+        const session = sessions.get(first.terminalId);
+        if (!session?.attach(socket, first.cols, first.rows)) {
+          sendControl(socket, {
+            op: 'exit',
+            code: 1,
+            message: 'The terminal session is no longer available.',
+            reason: 'disconnected',
+          });
+          socket.close();
+        }
+        return;
+      }
+
+      const terminalId = `terminal-${nanoid(16)}`;
+      const transferable = new TransferableTerminalSocket(terminalId, socket);
+      sessions.set(terminalId, transferable);
+      transferable.once('close', () => sessions.delete(terminalId));
+      const stableSocket = transferable as unknown as WebSocket;
+      void handleSession(stableSocket, ctx, app).catch((err) => {
+        app.log.warn({ err }, 'terminal session failed');
+        sendControl(stableSocket, {
+          op: 'exit',
+          code: 1,
+          message: err instanceof Error ? err.message : String(err),
+          reason: 'failed',
+        });
+        stableSocket.close();
       });
-      socket.close();
-    });
+      transferable.push(data, false);
+      sendControl(stableSocket, { op: 'session', terminalId });
+    };
+    socket.once('close', () => clearTimeout(timer));
+    socket.on('message', firstMessage);
   });
 }
 

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -42,6 +42,9 @@ export class TransferableTerminalSocket extends EventEmitter {
   private current: WebSocket;
   private closed = false;
   private readonly controls = new Map<string, string>();
+  private bufferingTransfer = false;
+  private bufferedTransferBytes = 0;
+  private readonly transferBuffer: Buffer[] = [];
 
   constructor(readonly terminalId: string, socket: WebSocket) {
     super();
@@ -54,7 +57,7 @@ export class TransferableTerminalSocket extends EventEmitter {
   }
 
   get bufferedAmount(): number {
-    return this.current.bufferedAmount;
+    return this.current.bufferedAmount + this.bufferedTransferBytes;
   }
 
   /** Feed the already-consumed first frame into the normal session handler. */
@@ -74,6 +77,8 @@ export class TransferableTerminalSocket extends EventEmitter {
       const frame = this.controls.get(op);
       if (frame && socket.readyState === socket.OPEN) socket.send(frame);
     }
+    this.bufferingTransfer = false;
+    this.flushTransferBuffer(socket);
     this.handleMessage(
       Buffer.from(JSON.stringify({ op: 'resize', cols, rows })),
       false,
@@ -97,6 +102,12 @@ export class TransferableTerminalSocket extends EventEmitter {
         /* ordinary text frame */
       }
     }
+    if (this.bufferingTransfer && Buffer.isBuffer(data) && options?.binary) {
+      const buffered = Buffer.from(data);
+      this.transferBuffer.push(buffered);
+      this.bufferedTransferBytes += buffered.byteLength;
+      return;
+    }
     if (this.current.readyState === this.current.OPEN) {
       if (options) this.current.send(data, options);
       else this.current.send(data);
@@ -118,6 +129,18 @@ export class TransferableTerminalSocket extends EventEmitter {
     if (!isBinary) {
       try {
         const message = JSON.parse(data.toString('utf8')) as { op?: string };
+        if (message.op === 'prepare-transfer') {
+          this.bufferingTransfer = true;
+          if (this.current.readyState === this.current.OPEN) {
+            this.current.send(JSON.stringify({ op: 'transfer-ready' }));
+          }
+          return;
+        }
+        if (message.op === 'cancel-transfer') {
+          this.bufferingTransfer = false;
+          this.flushTransferBuffer(this.current);
+          return;
+        }
         if (message.op === 'auth-response') this.controls.delete('auth-prompt');
         if (message.op === 'host-key-response') this.controls.delete('host-key');
       } catch {
@@ -139,9 +162,18 @@ export class TransferableTerminalSocket extends EventEmitter {
     socket.removeListener('close', this.handleClose);
   }
 
+  private flushTransferBuffer(socket: WebSocket): void {
+    const buffered = this.transferBuffer.splice(0);
+    this.bufferedTransferBytes = 0;
+    if (socket.readyState !== socket.OPEN) return;
+    for (const data of buffered) socket.send(data, { binary: true });
+  }
+
   private finish(): void {
     if (this.closed) return;
     this.closed = true;
+    this.transferBuffer.length = 0;
+    this.bufferedTransferBytes = 0;
     this.unbind(this.current);
     this.emit('close');
   }

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -485,6 +485,8 @@ export type WorkspaceTabLayout =
       cwdHint?: string;
       /** User-set color flag marking the tab. */
       color?: string;
+      /** Pinned tabs stay at the start of their pane's tab strip. */
+      pinned?: boolean;
       /** Restoring a layout may offer a fresh connection; it never resumes a process. */
       offerReconnect: boolean;
     }

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -129,6 +129,13 @@ export const terminalClientMessageSchema = z.discriminatedUnion('op', [
    * lease, forwards started on the connId) is gone.
    */
   z.object({ op: z.literal('dial'), profile: sshProfileSchema }),
+  /** Take ownership of a live terminal session from another app window. */
+  z.object({
+    op: z.literal('attach'),
+    terminalId: z.string().min(1).max(200),
+    cols: z.number().int().positive(),
+    rows: z.number().int().positive(),
+  }),
   z.object({ op: z.literal('resize'), cols: z.number().int().positive(), rows: z.number().int().positive() }),
   /** Answers to the last `auth-prompt`, in prompt order. */
   z.object({
@@ -156,6 +163,8 @@ export type TerminalClientMessage = z.infer<typeof terminalClientMessageSchema>;
 
 /** Text frames the server sends on /ws/terminal. */
 export type TerminalServerMessage =
+  /** Stable server-side terminal identity used for cross-window handoff. */
+  | { op: 'session'; terminalId: string }
   /** Connection progress worth echoing into the terminal ("Connecting …"). */
   | { op: 'status'; message: string; transient?: boolean }
   /** Passive SSH transport health derived from the existing keepalive lifecycle. */

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -136,6 +136,10 @@ export const terminalClientMessageSchema = z.discriminatedUnion('op', [
     cols: z.number().int().positive(),
     rows: z.number().int().positive(),
   }),
+  /** Freeze outbound bytes before the source renderer snapshots its buffer. */
+  z.object({ op: z.literal('prepare-transfer') }),
+  /** Resume the source renderer when a prepared handoff is abandoned. */
+  z.object({ op: z.literal('cancel-transfer') }),
   z.object({ op: z.literal('resize'), cols: z.number().int().positive(), rows: z.number().int().positive() }),
   /** Answers to the last `auth-prompt`, in prompt order. */
   z.object({
@@ -165,6 +169,8 @@ export type TerminalClientMessage = z.infer<typeof terminalClientMessageSchema>;
 export type TerminalServerMessage =
   /** Stable server-side terminal identity used for cross-window handoff. */
   | { op: 'session'; terminalId: string }
+  /** Outbound terminal bytes are frozen and can now be snapshotted without a gap. */
+  | { op: 'transfer-ready' }
   /** Connection progress worth echoing into the terminal ("Connecting …"). */
   | { op: 'status'; message: string; transient?: boolean }
   /** Passive SSH transport health derived from the existing keepalive lifecycle. */

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -27,6 +27,7 @@ function handle(sendInput: TerminalHandle['sendInput']): TerminalHandle {
     zoomPercent: () => 100,
     paste: vi.fn(),
     setLogging: vi.fn(() => true),
+    persistSnapshot: vi.fn(async () => undefined),
   };
 }
 

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -28,6 +28,8 @@ function handle(sendInput: TerminalHandle['sendInput']): TerminalHandle {
     paste: vi.fn(),
     setLogging: vi.fn(() => true),
     persistSnapshot: vi.fn(async () => undefined),
+    prepareTransfer: vi.fn(async () => true),
+    cancelTransfer: vi.fn(),
   };
 }
 

--- a/tests/unit/client/tab-transfer.test.ts
+++ b/tests/unit/client/tab-transfer.test.ts
@@ -83,18 +83,27 @@ describe('cross-window tab transfer', () => {
     expect(transfer.adoptTransferredTab(incoming, 'pane-test')).toBe(false);
   });
 
-  it('offers a tab to another renderer and removes the source only after completion', async () => {
+  it('transfers an interrupted live tab and removes the source only after completion', async () => {
     vi.stubGlobal('BroadcastChannel', TestBroadcastChannel);
     vi.resetModules();
     const source = await import('../../../client/src/tab-transfer.js');
     vi.resetModules();
     const destination = await import('../../../client/src/tab-transfer.js');
+    const { useTabsStore } = await import('../../../client/src/state/tabs.js');
+    useTabsStore.setState({
+      tabs: [],
+      unreadOutputIds: new Set(),
+      root: { id: 'pane-test', type: 'pane', activeTabId: null },
+      activePaneId: 'pane-test',
+      activeId: null,
+      zoomedPaneId: null,
+    });
     const complete = vi.fn();
     const tab = {
       id: 'tab-live',
       title: 'Router',
       profile: { kind: 'ssh' as const, target: 'router' },
-      status: 'connected' as const,
+      status: 'interrupted' as const,
       connectOnMount: true as const,
       terminalId: 'terminal-live',
       sftpOpen: false,
@@ -109,10 +118,17 @@ describe('cross-window tab transfer', () => {
       tabId: tab.id,
       prepare: vi.fn(async () => true),
       snapshot: () => tab,
+      cancel: vi.fn(),
       complete,
     });
 
-    await expect(destination.claimTabTransfer(transferId)).resolves.toEqual(tab);
+    await destination.receiveTabTransfer(transferId, 'pane-test');
+    expect(useTabsStore.getState().tabs[0]).toMatchObject({
+      id: tab.id,
+      status: 'interrupted',
+      connectOnMount: true,
+      transferId,
+    });
     expect(complete).not.toHaveBeenCalled();
 
     destination.completeTabTransfer(transferId);

--- a/tests/unit/client/tab-transfer.test.ts
+++ b/tests/unit/client/tab-transfer.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+class TestBroadcastChannel {
+  static readonly instances = new Set<TestBroadcastChannel>();
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+
+  constructor(readonly name: string) {
+    TestBroadcastChannel.instances.add(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (type === 'message') this.listeners.add(listener);
+  }
+
+  postMessage(data: unknown): void {
+    for (const channel of TestBroadcastChannel.instances) {
+      if (channel === this || channel.name !== this.name) continue;
+      queueMicrotask(() => {
+        for (const listener of channel.listeners) listener({ data } as MessageEvent);
+      });
+    }
+  }
+}
+
+class TestDataTransfer {
+  private readonly values = new Map<string, string>();
+
+  get types(): string[] {
+    return [...this.values.keys()];
+  }
+
+  setData(type: string, value: string): void {
+    this.values.set(type, value);
+  }
+
+  getData(type: string): string {
+    return this.values.get(type) ?? '';
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  TestBroadcastChannel.instances.clear();
+});
+
+describe('cross-window tab transfer', () => {
+  it('adopts a live tab and keeps pinned tabs first', async () => {
+    vi.resetModules();
+    const transfer = await import('../../../client/src/tab-transfer.js');
+    const { useTabsStore } = await import('../../../client/src/state/tabs.js');
+    useTabsStore.setState({
+      tabs: [],
+      unreadOutputIds: new Set(),
+      root: { id: 'pane-test', type: 'pane', activeTabId: null },
+      activePaneId: 'pane-test',
+      activeId: null,
+      zoomedPaneId: null,
+    });
+    const existingId = useTabsStore.getState().open({ kind: 'local' }, 'Existing');
+    const incoming = {
+      id: 'tab-from-window',
+      title: 'Router',
+      profile: { kind: 'ssh' as const, target: 'router' },
+      status: 'connected' as const,
+      connectOnMount: true as const,
+      terminalId: 'terminal-live',
+      transferId: 'transfer-live',
+      pinned: true,
+      sftpOpen: false,
+      searchRequest: 0,
+      editorPaths: [],
+      loggingPaused: false,
+      captureInput: false,
+      reconnectRequest: 0,
+    };
+
+    expect(transfer.adoptTransferredTab(incoming, 'pane-test', existingId, 'after')).toBe(true);
+
+    const state = useTabsStore.getState();
+    expect(state.tabs.map((tab) => tab.id)).toEqual(['tab-from-window', existingId]);
+    expect(state.tabs[0]).toMatchObject({ paneId: 'pane-test', pinned: true });
+    expect(state.activeId).toBe('tab-from-window');
+    expect(transfer.adoptTransferredTab(incoming, 'pane-test')).toBe(false);
+  });
+
+  it('offers a tab to another renderer and removes the source only after completion', async () => {
+    vi.stubGlobal('BroadcastChannel', TestBroadcastChannel);
+    vi.resetModules();
+    const source = await import('../../../client/src/tab-transfer.js');
+    vi.resetModules();
+    const destination = await import('../../../client/src/tab-transfer.js');
+    const complete = vi.fn();
+    const tab = {
+      id: 'tab-live',
+      title: 'Router',
+      profile: { kind: 'ssh' as const, target: 'router' },
+      status: 'connected' as const,
+      connectOnMount: true as const,
+      terminalId: 'terminal-live',
+      sftpOpen: false,
+      searchRequest: 0,
+      editorPaths: [],
+      loggingPaused: false,
+      captureInput: false,
+      reconnectRequest: 0,
+    };
+    const transferId = 'opaque-live-token';
+    source.registerTabTransferSourceOptions(transferId, {
+      tabId: tab.id,
+      prepare: vi.fn(async () => true),
+      snapshot: () => tab,
+      complete,
+    });
+
+    await expect(destination.claimTabTransfer(transferId)).resolves.toEqual(tab);
+    expect(complete).not.toHaveBeenCalled();
+
+    destination.completeTabTransfer(transferId);
+    await vi.waitFor(() => expect(complete).toHaveBeenCalledOnce());
+  });
+
+  it('puts only the opaque transfer token in the drag payload', async () => {
+    vi.stubGlobal('BroadcastChannel', TestBroadcastChannel);
+    vi.resetModules();
+    const transfer = await import('../../../client/src/tab-drag.js');
+    const data = new TestDataTransfer();
+
+    transfer.writeTabTransfer(data as never, 'opaque-token');
+
+    expect(transfer.hasTabTransfer(data as never)).toBe(true);
+    expect(transfer.readTabTransfer(data as never)).toBe('opaque-token');
+    expect(data.getData(transfer.TAB_TRANSFER_MIME)).toBe('opaque-token');
+    expect(data.getData('text/plain')).toBe('muxus-tab:opaque-token');
+  });
+});

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -6,6 +6,7 @@ import {
 import { useDialogStore } from '../../../client/src/state/dialogs.js';
 import { usePrefsStore } from '../../../client/src/state/prefs.js';
 import { useTabsStore } from '../../../client/src/state/tabs.js';
+import { findPane } from '../../../client/src/state/workspace-layout.js';
 
 /** Let the close flow run up to the point where it raises its dialog. */
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -619,6 +620,44 @@ describe('keyboard pane focus', () => {
 });
 
 describe('moving tabs between panes', () => {
+  it('drops a background tab at an exact position in another pane', () => {
+    const store = useTabsStore.getState();
+    const movingId = store.open({ kind: 'local' }, 'Moving');
+    const stayingId = store.open({ kind: 'local' }, 'Staying');
+    const rightPane = store.split('pane-test', 'right')!;
+    const firstRightId = useTabsStore.getState().open({ kind: 'local' }, 'Right one');
+    const secondRightId = useTabsStore.getState().open({ kind: 'local' }, 'Right two');
+
+    expect(
+      useTabsStore.getState().moveTabToPane(movingId, rightPane, secondRightId, 'before'),
+    ).toBe(true);
+
+    const state = useTabsStore.getState();
+    expect(
+      state.tabs.filter((tab) => tab.paneId === rightPane).map((tab) => tab.id),
+    ).toEqual([firstRightId, movingId, secondRightId]);
+    expect(findPane(state.root, 'pane-test')?.activeTabId).toBe(stayingId);
+    expect(state).toMatchObject({ activePaneId: rightPane, activeId: movingId });
+  });
+
+  it('collapses a split after its last tab is dropped into its sibling', () => {
+    const store = useTabsStore.getState();
+    const leftId = store.open({ kind: 'local' }, 'Left');
+    const rightPane = store.split('pane-test', 'right')!;
+    const movingId = useTabsStore.getState().open({ kind: 'local' }, 'Right');
+
+    expect(useTabsStore.getState().moveTabToPane(movingId, 'pane-test', leftId)).toBe(true);
+
+    const state = useTabsStore.getState();
+    expect(state.root).toMatchObject({ id: 'pane-test', type: 'pane', activeTabId: movingId });
+    expect(state.tabs.map((tab) => [tab.id, tab.paneId])).toEqual([
+      [leftId, 'pane-test'],
+      [movingId, 'pane-test'],
+    ]);
+    expect(state.activePaneId).toBe('pane-test');
+    expect(rightPane).not.toBe('pane-test');
+  });
+
   it('sends the active tab to the neighbouring pane', () => {
     const store = useTabsStore.getState();
     const stayId = store.open({ kind: 'local' }, 'Local');
@@ -671,6 +710,66 @@ describe('moving tabs between panes', () => {
     expect(useTabsStore.getState().moveTabWithinPane(-1)).toBe(true);
     expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([secondId, firstId]);
     expect(useTabsStore.getState().moveTabWithinPane(-1)).toBe(false);
+  });
+
+  it('reorders a dragged tab relative to its drop target', () => {
+    const store = useTabsStore.getState();
+    const firstId = store.open({ kind: 'local' }, 'One');
+    const secondId = store.open({ kind: 'local' }, 'Two');
+    const thirdId = store.open({ kind: 'local' }, 'Three');
+
+    expect(useTabsStore.getState().reorderTab(firstId, thirdId, 'after')).toBe(true);
+    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([
+      secondId,
+      thirdId,
+      firstId,
+    ]);
+    expect(useTabsStore.getState().reorderTab(firstId, thirdId, 'after')).toBe(false);
+  });
+
+  it('groups pinned tabs first and reorders only within the same pin group', () => {
+    const store = useTabsStore.getState();
+    const firstId = store.open({ kind: 'local' }, 'One');
+    const secondId = store.open({ kind: 'local' }, 'Two');
+    const thirdId = store.open({ kind: 'local' }, 'Three');
+
+    expect(useTabsStore.getState().setPinned(secondId, true)).toBe(true);
+    expect(useTabsStore.getState().setPinned(thirdId, true)).toBe(true);
+    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([
+      secondId,
+      thirdId,
+      firstId,
+    ]);
+    expect(useTabsStore.getState().reorderTab(firstId, secondId, 'before')).toBe(false);
+    expect(useTabsStore.getState().reorderTab(thirdId, secondId, 'before')).toBe(true);
+    expect(useTabsStore.getState().setPinned(thirdId, false)).toBe(true);
+    expect(useTabsStore.getState().tabs.map((tab) => [tab.id, !!tab.pinned])).toEqual([
+      [secondId, true],
+      [thirdId, false],
+      [firstId, false],
+    ]);
+  });
+
+  it('keeps a pinned tab ahead of unpinned tabs when moving it to another pane', () => {
+    const store = useTabsStore.getState();
+    store.open({ kind: 'local' }, 'Stay');
+    const pinnedId = store.open({ kind: 'local' }, 'Pinned');
+    useTabsStore.getState().setPinned(pinnedId, true);
+    const rightPane = useTabsStore.getState().split('pane-test', 'right')!;
+    const firstRightId = useTabsStore.getState().open({ kind: 'ssh', target: 'one' }, 'One');
+    const secondRightId = useTabsStore.getState().open({ kind: 'ssh', target: 'two' }, 'Two');
+    useTabsStore.getState().activate(pinnedId);
+
+    expect(useTabsStore.getState().moveTabToDirection('right')).toBe(true);
+    expect(
+      useTabsStore.getState().tabs
+        .filter((tab) => tab.paneId === rightPane)
+        .map((tab) => [tab.id, !!tab.pinned]),
+    ).toEqual([
+      [pinnedId, true],
+      [firstRightId, false],
+      [secondRightId, false],
+    ]);
   });
 
   it('activates tabs by position within the focused pane', () => {

--- a/tests/unit/client/workspace-layout.test.ts
+++ b/tests/unit/client/workspace-layout.test.ts
@@ -158,6 +158,40 @@ describe('directional pane navigation', () => {
 });
 
 describe('workspace serialization', () => {
+  it('round-trips pinned tabs in their strip order', () => {
+    const layout = serializeWorkspace(
+      { id: 'pane', type: 'pane', activeTabId: 'regular-tab' },
+      [
+        {
+          id: 'pinned-tab',
+          paneId: 'pane',
+          title: 'Pinned',
+          profile: { kind: 'ssh', target: 'pinned' },
+          pinned: true,
+        },
+        {
+          id: 'regular-tab',
+          paneId: 'pane',
+          title: 'Regular',
+          profile: { kind: 'ssh', target: 'regular' },
+        },
+      ],
+      'pane',
+    );
+
+    expect(layout.root).toMatchObject({
+      type: 'pane',
+      tabs: [
+        { id: 'pinned-tab', pinned: true },
+        { id: 'regular-tab' },
+      ],
+    });
+    expect(restoreWorkspace(layout)?.tabs.map((tab) => [tab.id, !!tab.pinned])).toEqual([
+      ['pinned-tab', true],
+      ['regular-tab', false],
+    ]);
+  });
+
   it('does not persist a blank chooser as the active terminal', () => {
     const layout = serializeWorkspace(
       { id: 'pane', type: 'pane', activeTabId: 'blank-tab' },

--- a/tests/unit/server/terminal-socket-dial.test.ts
+++ b/tests/unit/server/terminal-socket-dial.test.ts
@@ -1,10 +1,14 @@
 import { EventEmitter } from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
-import { registerTerminalSocket } from '../../../server/src/ws/terminal-socket.js';
+import {
+  registerTerminalSocket,
+  TransferableTerminalSocket,
+} from '../../../server/src/ws/terminal-socket.js';
 
 class TestSocket extends EventEmitter {
   readonly OPEN = 1;
   readyState = this.OPEN;
+  bufferedAmount = 0;
   readonly send = vi.fn();
   readonly ping = vi.fn();
 
@@ -14,6 +18,43 @@ class TestSocket extends EventEmitter {
     this.emit('close');
   }
 }
+
+describe('transferable terminal sockets', () => {
+  it('swaps renderer sockets without closing the terminal lifecycle', () => {
+    const source = new TestSocket();
+    const destination = new TestSocket();
+    const terminal = new TransferableTerminalSocket('terminal-1', source as never);
+    const onClose = vi.fn();
+    const onMessage = vi.fn();
+    terminal.on('close', onClose);
+    terminal.on('message', onMessage);
+    terminal.send(JSON.stringify({ op: 'session', terminalId: 'terminal-1' }));
+    terminal.send(JSON.stringify({ op: 'ready', connId: 'connection-1' }));
+    source.send.mockClear();
+
+    expect(terminal.attach(destination as never, 132, 43)).toBe(true);
+
+    expect(source.readyState).toBe(3);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(destination.send).toHaveBeenNthCalledWith(
+      1,
+      JSON.stringify({ op: 'session', terminalId: 'terminal-1' }),
+    );
+    expect(destination.send).toHaveBeenNthCalledWith(
+      2,
+      JSON.stringify({ op: 'ready', connId: 'connection-1' }),
+    );
+    expect(onMessage).toHaveBeenCalledWith(
+      Buffer.from(JSON.stringify({ op: 'resize', cols: 132, rows: 43 })),
+      false,
+    );
+
+    destination.emit('message', Buffer.from('hello'), true);
+    expect(onMessage).toHaveBeenLastCalledWith(Buffer.from('hello'), true);
+    destination.close();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});
 
 describe('terminal socket dial mode', () => {
   it('does not announce readiness until post-auth password saving finishes', async () => {
@@ -87,7 +128,35 @@ describe('terminal socket dial mode', () => {
         }),
       ),
     );
-    socket.close();
+    const sessionFrame = socket.send.mock.calls
+      .map(([frame]) => JSON.parse(String(frame)) as { op: string; terminalId?: string })
+      .find((frame) => frame.op === 'session');
+    expect(sessionFrame?.terminalId).toBeTruthy();
+
+    const destination = new TestSocket();
+    route(destination);
+    destination.emit(
+      'message',
+      Buffer.from(JSON.stringify({
+        op: 'attach',
+        terminalId: sessionFrame!.terminalId,
+        cols: 100,
+        rows: 30,
+      })),
+      false,
+    );
+
+    expect(socket.readyState).toBe(3);
+    expect(release).not.toHaveBeenCalled();
+    expect(destination.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        op: 'ready',
+        connId: 'connection-1',
+        host: 'router.example',
+        user: 'alice',
+      }),
+    );
+    destination.close();
     expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/server/terminal-socket-dial.test.ts
+++ b/tests/unit/server/terminal-socket-dial.test.ts
@@ -20,7 +20,7 @@ class TestSocket extends EventEmitter {
 }
 
 describe('transferable terminal sockets', () => {
-  it('swaps renderer sockets without closing the terminal lifecycle', () => {
+  it('buffers handoff output until attach and resumes it when cancelled', () => {
     const source = new TestSocket();
     const destination = new TestSocket();
     const terminal = new TransferableTerminalSocket('terminal-1', source as never);
@@ -31,6 +31,21 @@ describe('transferable terminal sockets', () => {
     terminal.send(JSON.stringify({ op: 'session', terminalId: 'terminal-1' }));
     terminal.send(JSON.stringify({ op: 'ready', connId: 'connection-1' }));
     source.send.mockClear();
+
+    source.emit('message', Buffer.from(JSON.stringify({ op: 'prepare-transfer' })), false);
+    expect(source.send).toHaveBeenCalledWith(JSON.stringify({ op: 'transfer-ready' }));
+    source.send.mockClear();
+    terminal.send(Buffer.from('cancelled output'), { binary: true });
+    expect(source.send).not.toHaveBeenCalled();
+
+    source.emit('message', Buffer.from(JSON.stringify({ op: 'cancel-transfer' })), false);
+    expect(source.send).toHaveBeenCalledWith(Buffer.from('cancelled output'), { binary: true });
+    source.send.mockClear();
+
+    source.emit('message', Buffer.from(JSON.stringify({ op: 'prepare-transfer' })), false);
+    source.send.mockClear();
+    terminal.send(Buffer.from('handoff output'), { binary: true });
+    expect(source.send).not.toHaveBeenCalled();
 
     expect(terminal.attach(destination as never, 132, 43)).toBe(true);
 
@@ -43,6 +58,11 @@ describe('transferable terminal sockets', () => {
     expect(destination.send).toHaveBeenNthCalledWith(
       2,
       JSON.stringify({ op: 'ready', connId: 'connection-1' }),
+    );
+    expect(destination.send).toHaveBeenNthCalledWith(
+      3,
+      Buffer.from('handoff output'),
+      { binary: true },
     );
     expect(onMessage).toHaveBeenCalledWith(
       Buffer.from(JSON.stringify({ op: 'resize', cols: 132, rows: 43 })),

--- a/tests/unit/server/workspace-routes.test.ts
+++ b/tests/unit/server/workspace-routes.test.ts
@@ -44,6 +44,7 @@ const layout = {
             title: 'Production',
             profile: { kind: 'ssh', target: 'production' },
             cwdHint: '/srv/app',
+            pinned: true,
             offerReconnect: true,
           },
         ],

--- a/tests/unit/shared/ws-protocol.test.ts
+++ b/tests/unit/shared/ws-protocol.test.ts
@@ -126,6 +126,17 @@ describe('terminalClientMessageSchema', () => {
     expect(parsed.success).toBe(true);
   });
 
+  it('accepts attaching another renderer to a live terminal', () => {
+    expect(
+      terminalClientMessageSchema.safeParse({
+        op: 'attach',
+        terminalId: 'terminal-live',
+        cols: 120,
+        rows: 40,
+      }).success,
+    ).toBe(true);
+  });
+
   it('rejects connect with non-positive dimensions', () => {
     expect(
       terminalClientMessageSchema.safeParse({ op: 'connect', profile: { kind: 'local' }, cols: 0, rows: 24 }).success,

--- a/tests/unit/shared/ws-protocol.test.ts
+++ b/tests/unit/shared/ws-protocol.test.ts
@@ -137,6 +137,11 @@ describe('terminalClientMessageSchema', () => {
     ).toBe(true);
   });
 
+  it('accepts preparing and cancelling a live terminal handoff', () => {
+    expect(terminalClientMessageSchema.safeParse({ op: 'prepare-transfer' }).success).toBe(true);
+    expect(terminalClientMessageSchema.safeParse({ op: 'cancel-transfer' }).success).toBe(true);
+  });
+
   it('rejects connect with non-positive dimensions', () => {
     expect(
       terminalClientMessageSchema.safeParse({ op: 'connect', profile: { kind: 'local' }, cols: 0, rows: 24 }).success,


### PR DESCRIPTION
## Summary

- add pin and unpin actions, persist pinned state in workspaces, and keep pinned tabs grouped first
- support drag-and-drop reordering within panes and moving tabs across panes and application windows
- safely hand off live terminal sessions between windows without exposing connection data in the drag payload
- document the new interactions and cover tab ordering, persistence, transfer, and terminal handoff behavior with tests

## Why

Tabs could not previously be pinned or rearranged, which made larger terminal workspaces harder to organize. This implements the tab-management improvements requested in issue #40.

## User impact

Users can organize tabs directly from the tab strip, retain pinned state across saved workspaces, and move active sessions between panes or windows.

## Validation

- `pnpm typecheck`
- `pnpm test` — 693 passed, 3 skipped
- `pnpm lint`
- `pnpm check:bundle`

Closes #40