### PR TITLE
Support saving keyboard-interactive SSH passwords

### DIFF
--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -45,12 +45,14 @@ The application database is in the platform data directory (`~/.local/share/muxu
 ### Are my passwords stored anywhere?
 
 Not by default. Passwords are transient unless **Remember this password** is selected on
-an SSH password prompt. Remembering creates the platform-independent password vault and
-writes authenticated ciphertext to the local database. The prompt policy can use the OS
-credential store (the default), ask once at startup, or ask whenever a credential is
-needed. The master password is always required to view or edit the saved value and is
-never stored. Private-key passphrases, 2FA codes
-and keyboard-interactive answers are never remembered. See the
+an SSH password prompt. A single hidden keyboard-interactive field explicitly labelled
+as a password is treated the same way, which covers network devices that use
+keyboard-interactive for password login. Remembering creates the platform-independent
+password vault and writes authenticated ciphertext to the local database. The prompt
+policy can use the OS credential store (the default), ask once at startup, or ask whenever
+a credential is needed. The master password is always required to view or edit the saved
+value and is never stored. Private-key passphrases, 2FA codes and all other
+keyboard-interactive answers are never remembered. See the
 [security model](../reference/security.md#password-vault).
 
 ### Why is session logging off by default?

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -64,19 +64,22 @@ method after a bounded wait. The host editor's **Specific key file** mode writes
   <figcaption>Each prompt names the hop that issued it, which identifies the hop in a jump chain.</figcaption>
 </figure>
 
-An SSH password prompt offers **Remember this password**. The password is saved only after
-authentication succeeds. The first save creates a vault and asks for a master password of
-at least twelve characters. By default, the vault key is kept in the OS credential store,
-so routine SSH use does not prompt for the master password. In **Settings → Passwords**,
-the policy can instead ask once when Muxus starts or whenever a saved credential is
-needed. The master password is always required to view or edit saved values.
+An SSH password prompt offers **Remember this password**. A single hidden
+keyboard-interactive field explicitly labelled as a password offers it too, for network
+devices that use keyboard-interactive for password login. The password is saved only
+after authentication succeeds. The first save creates a vault and asks for a master
+password of at least twelve characters. By default, the vault key is kept in the OS
+credential store, so routine SSH use does not prompt for the master password. In
+**Settings → Passwords**, the policy can instead ask once when Muxus starts or whenever a
+saved credential is needed. The master password is always required to view or edit saved
+values.
 
 If a never-prompt vault is restored without its OS credential-store entry, the next saved
 password use asks for the master password and attempts to restore automatic access. The
 credential can still be used for that connection if the OS store remains unavailable;
-the prompt policy can also be changed or the vault reset. Private-key passphrases,
-keyboard-interactive answers and 2FA codes remain transient and are never remembered. See the
-[security model](../reference/security.md#password-vault).
+the prompt policy can also be changed or the vault reset. Private-key passphrases, 2FA
+codes and all other keyboard-interactive answers remain transient and are never
+remembered. See the [security model](../reference/security.md#password-vault).
 
 ## Jump chains and ProxyCommand
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -49,9 +49,10 @@ Connection settings are not in the database. They remain in
 
 ## Password vault
 
-Password saving is off until a vault is created. On a normal SSH password
-prompt, **Remember this password** saves the password only after the server accepts it.
-Private-key passphrases, keyboard-interactive answers and 2FA codes are never remembered.
+Password saving is off until a vault is created. On a normal SSH password prompt, or a
+single hidden keyboard-interactive field explicitly labelled as a password, **Remember
+this password** saves the password only after the server accepts it. Private-key
+passphrases, 2FA codes and all other keyboard-interactive answers are never remembered.
 
 New vaults default to **Never**, using the platform credential store. The vault works as
 follows:

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -1142,6 +1142,7 @@ class AuthLadder {
   private lastPasswordCandidate: RememberedPasswordCandidate | undefined;
   private partialPasswordCandidate: RememberedPasswordCandidate | undefined;
   private savedPasswordAttempted = false;
+  private retryKeyboardInteractive = false;
   cancelled = false;
 
   constructor(
@@ -1327,16 +1328,25 @@ class AuthLadder {
       for (let attempt = 0; attempt < MAX_KEYBOARD_INTERACTIVE_ATTEMPTS; attempt++) {
         attempts.push({
           type: 'keyboard-interactive',
-          get: () =>
-            Promise.resolve({
+          get: () => {
+            // Arbitrary challenges get one attempt; only a recognized password
+            // flow may retry for stale-password replacement.
+            if (attempt > 0 && !this.retryKeyboardInteractive) {
+              return Promise.resolve(undefined);
+            }
+            this.retryKeyboardInteractive = false;
+            let challengeRound = 0;
+            return Promise.resolve({
               type: 'keyboard-interactive',
               username: user,
               prompt: (name, instructions, _lang, prompts, finish) => {
+                challengeRound += 1;
                 void this.keyboardInteractiveAnswers(
                   name,
                   instructions,
                   label,
                   prompts,
+                  challengeRound === 1,
                 )
                   .then(finish)
                   .catch(() => {
@@ -1344,7 +1354,8 @@ class AuthLadder {
                     finish(prompts.map(() => ''));
                   });
               },
-            }),
+            });
+          },
         });
       }
     }
@@ -1412,12 +1423,20 @@ class AuthLadder {
     instructions: string,
     promptLabel: string,
     prompts: Prompt[],
+    firstChallengeRound: boolean,
   ): Promise<string[]> {
     const mappedPrompts = prompts.map((prompt) => ({
       prompt: prompt.prompt,
       echo: prompt.echo !== false,
     }));
-    if (!isKeyboardInteractivePasswordPrompt(prompts)) {
+    if (
+      !firstChallengeRound ||
+      !isKeyboardInteractivePasswordPrompt(prompts)
+    ) {
+      // A later round makes the exchange multi-field, so a password offered
+      // for saving in an earlier round is no longer a safe candidate.
+      this.lastPasswordCandidate = undefined;
+      this.retryKeyboardInteractive = false;
       const response = await this.runInteraction(() =>
         this.io.prompt({
           name: name || undefined,
@@ -1430,6 +1449,7 @@ class AuthLadder {
       return response.answers;
     }
 
+    this.retryKeyboardInteractive = true;
     const credential = this.passwordCredential();
     const saved = await this.availableSavedPassword(credential);
     if (saved !== undefined) return [saved];

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -11,6 +11,7 @@ import ssh2, {
   type ClientChannel,
   type ConnectConfig,
   type ParsedKey,
+  type Prompt,
   type PseudoTtyOptions,
   type SFTPWrapper,
 } from 'ssh2';
@@ -166,6 +167,7 @@ export interface TerminalShell {
 }
 
 const MAX_JUMP_DEPTH = 8;
+const MAX_KEYBOARD_INTERACTIVE_ATTEMPTS = 3;
 const MAX_PASSWORD_ATTEMPTS = 3;
 const MAX_PASSPHRASE_ATTEMPTS = 3;
 const DEFAULT_IDENTITY_NAMES = ['id_ed25519', 'id_ecdsa', 'id_rsa', 'id_ed25519_sk', 'id_ecdsa_sk'];
@@ -1044,6 +1046,25 @@ interface RememberedPasswordCandidate {
   password: string;
 }
 
+interface PasswordCredential {
+  account: string;
+  label: string;
+  existing: boolean;
+}
+
+/**
+ * Keyboard-interactive is also used for OTPs and arbitrary challenges. Only
+ * treat an unambiguous, single hidden password field as an SSH password.
+ */
+function isKeyboardInteractivePasswordPrompt(prompts: readonly Prompt[]): boolean {
+  if (prompts.length !== 1 || prompts[0]?.echo !== false) return false;
+  const label = prompts[0].prompt.trim().replace(/:\s*$/, '').trim();
+  return (
+    /^password(?:\s+for\s+.+)?$/i.test(label) ||
+    /^.+(?:'s|’s)\s+password$/i.test(label)
+  );
+}
+
 type InteractionRunner = <T>(interaction: () => Promise<T>) => Promise<T>;
 
 class PausableDeadline {
@@ -1303,30 +1324,29 @@ class AuthLadder {
     }
 
     if (resolved.kbdInteractiveAuthentication !== false) {
-      attempts.push({
-        type: 'keyboard-interactive',
-        get: () =>
-          Promise.resolve({
-            type: 'keyboard-interactive',
-            username: user,
-            prompt: (name, instructions, _lang, prompts, finish) => {
-              this.runInteraction(() =>
-                this.io.prompt({
-                  name: name || undefined,
-                  instructions: instructions || undefined,
-                  host: label,
-                  purpose: 'authentication',
-                  prompts: prompts.map((p) => ({ prompt: p.prompt, echo: p.echo !== false })),
-                }),
-              )
-                .then((response) => finish(response.answers))
-                .catch(() => {
-                  this.cancelled = true;
-                  finish(prompts.map(() => ''));
-                });
-            },
-          }),
-      });
+      for (let attempt = 0; attempt < MAX_KEYBOARD_INTERACTIVE_ATTEMPTS; attempt++) {
+        attempts.push({
+          type: 'keyboard-interactive',
+          get: () =>
+            Promise.resolve({
+              type: 'keyboard-interactive',
+              username: user,
+              prompt: (name, instructions, _lang, prompts, finish) => {
+                void this.keyboardInteractiveAnswers(
+                  name,
+                  instructions,
+                  label,
+                  prompts,
+                )
+                  .then(finish)
+                  .catch(() => {
+                    this.cancelled = true;
+                    finish(prompts.map(() => ''));
+                  });
+              },
+            }),
+        });
+      }
     }
 
     if (resolved.passwordAuthentication !== false) {
@@ -1344,37 +1364,11 @@ class AuthLadder {
     attempt: number,
     promptLabel: string,
   ): Promise<AnyAuthMethod> {
-    const { user, resolved, port } = this.hop;
-    const account = sshPasswordAccount({
-      user,
-      host: resolved.hostname,
-      port,
-    });
-    const credentialLabel = sshPasswordLabel({
-      user,
-      host: resolved.hostname,
-      port,
-    });
-    const existing = this.vault?.hasSshPassword(account) ?? false;
-
-    if (!this.savedPasswordAttempted && this.vault) {
-      // The host's own saved password wins; folder passwords are the shared
-      // default the host falls back to, nearest folder first.
-      const source = existing
-        ? { account, label: credentialLabel }
-        : (this.hop.folderPasswords ?? []).find((folder) =>
-            this.vault!.hasSshPassword(folder.account),
-          );
-      if (source) {
-        this.savedPasswordAttempted = true;
-        const saved = await this.savedPassword(source.account, source.label);
-        if (saved !== undefined) {
-          this.io.status(`Using the saved password for ${source.label}.`, {
-            transient: true,
-          });
-          return { type: 'password', username: user, password: saved };
-        }
-      }
+    const { user } = this.hop;
+    const credential = this.passwordCredential();
+    const saved = await this.availableSavedPassword(credential);
+    if (saved !== undefined) {
+      return { type: 'password', username: user, password: saved };
     }
 
     const response = await this.runInteraction(() =>
@@ -1397,19 +1391,121 @@ class AuthLadder {
         ...(this.vault
           ? {
               rememberPassword: {
-                label: credentialLabel,
-                existing,
+                label: credential.label,
+                existing: credential.existing,
               },
             }
           : {}),
       }),
     );
     if (response.skipped) throw new Error('authentication cancelled');
-    const password = response.answers[0] ?? '';
-    this.lastPasswordCandidate = response.rememberPassword
-      ? { account, label: credentialLabel, password }
+    this.capturePasswordCandidate(response, credential);
+    return {
+      type: 'password',
+      username: user,
+      password: response.answers[0] ?? '',
+    };
+  }
+
+  private async keyboardInteractiveAnswers(
+    name: string,
+    instructions: string,
+    promptLabel: string,
+    prompts: Prompt[],
+  ): Promise<string[]> {
+    const mappedPrompts = prompts.map((prompt) => ({
+      prompt: prompt.prompt,
+      echo: prompt.echo !== false,
+    }));
+    if (!isKeyboardInteractivePasswordPrompt(prompts)) {
+      const response = await this.runInteraction(() =>
+        this.io.prompt({
+          name: name || undefined,
+          instructions: instructions || undefined,
+          host: promptLabel,
+          purpose: 'authentication',
+          prompts: mappedPrompts,
+        }),
+      );
+      return response.answers;
+    }
+
+    const credential = this.passwordCredential();
+    const saved = await this.availableSavedPassword(credential);
+    if (saved !== undefined) return [saved];
+
+    const retryInstructions = this.savedPasswordAttempted
+      ? 'The saved password was unavailable or was not accepted. Enter the current password.'
       : undefined;
-    return { type: 'password', username: user, password };
+    const response = await this.runInteraction(() =>
+      this.io.prompt({
+        name: name || undefined,
+        instructions:
+          [retryInstructions, instructions || undefined]
+            .filter((item): item is string => !!item)
+            .join('\n\n') || undefined,
+        host: promptLabel,
+        purpose: 'ssh-password',
+        prompts: mappedPrompts,
+        ...(this.vault
+          ? {
+              rememberPassword: {
+                label: credential.label,
+                existing: credential.existing,
+              },
+            }
+          : {}),
+      }),
+    );
+    this.capturePasswordCandidate(response, credential);
+    return response.answers;
+  }
+
+  private passwordCredential(): PasswordCredential {
+    const { user, resolved, port } = this.hop;
+    const input = { user, host: resolved.hostname, port };
+    const account = sshPasswordAccount(input);
+    return {
+      account,
+      label: sshPasswordLabel(input),
+      existing: this.vault?.hasSshPassword(account) ?? false,
+    };
+  }
+
+  private async availableSavedPassword(
+    credential: PasswordCredential,
+  ): Promise<string | undefined> {
+    if (this.savedPasswordAttempted || !this.vault) return undefined;
+    // The host's own saved password wins; folder passwords are the shared
+    // default the host falls back to, nearest folder first.
+    const source = credential.existing
+      ? { account: credential.account, label: credential.label }
+      : (this.hop.folderPasswords ?? []).find((folder) =>
+          this.vault!.hasSshPassword(folder.account),
+        );
+    if (!source) return undefined;
+
+    this.savedPasswordAttempted = true;
+    const saved = await this.savedPassword(source.account, source.label);
+    if (saved !== undefined) {
+      this.io.status(`Using the saved password for ${source.label}.`, {
+        transient: true,
+      });
+    }
+    return saved;
+  }
+
+  private capturePasswordCandidate(
+    response: AuthPromptResponse,
+    credential: PasswordCredential,
+  ): void {
+    this.lastPasswordCandidate = response.rememberPassword
+      ? {
+          account: credential.account,
+          label: credential.label,
+          password: response.answers[0] ?? '',
+        }
+      : undefined;
   }
 
   private async savedPassword(

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -129,6 +129,95 @@ function startKeyboardInteractiveServer(
   });
 }
 
+function startMultiRoundKeyboardInteractiveServer(): Promise<{
+  server: Server;
+  port: number;
+  capture: KeyboardInteractiveCapture;
+}> {
+  const capture: KeyboardInteractiveCapture = { authMethods: [], answers: [] };
+  const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
+    conn.on('error', () => undefined);
+    conn.on('authentication', (authCtx) => {
+      if (authCtx.method !== 'none') capture.authMethods.push(authCtx.method);
+      if (authCtx.method !== 'keyboard-interactive') {
+        authCtx.reject(['keyboard-interactive']);
+        return;
+      }
+      authCtx.prompt(
+        [{ prompt: 'Password: ', echo: false }],
+        'PASSWORD_EXPIRED',
+        (passwordAnswers) => {
+          capture.answers.push(passwordAnswers);
+          authCtx.prompt(
+            [{ prompt: 'New password: ', echo: false }],
+            'PASSWORD_EXPIRED',
+            (replacementAnswers) => {
+              capture.answers.push(replacementAnswers);
+              if (
+                passwordAnswers[0] === PASSWORD &&
+                replacementAnswers[0] === 'replacement-password'
+              ) {
+                authCtx.accept();
+              } else {
+                authCtx.reject(['keyboard-interactive']);
+              }
+            },
+          );
+        },
+      );
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        server,
+        port: (server.address() as net.AddressInfo).port,
+        capture,
+      });
+    });
+  });
+}
+
+function startKeyboardInteractiveFallbackServer(): Promise<{
+  server: Server;
+  port: number;
+  capture: KeyboardInteractiveCapture;
+}> {
+  const capture: KeyboardInteractiveCapture = { authMethods: [], answers: [] };
+  const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
+    conn.on('error', () => undefined);
+    conn.on('authentication', (authCtx) => {
+      if (authCtx.method !== 'none') capture.authMethods.push(authCtx.method);
+      if (authCtx.method === 'keyboard-interactive') {
+        authCtx.prompt(
+          [{ prompt: 'Verification code: ', echo: false }],
+          'SECOND_FACTOR',
+          (answers) => {
+            capture.answers.push(answers);
+            authCtx.reject(['keyboard-interactive', 'password']);
+          },
+        );
+      } else if (
+        authCtx.method === 'password' &&
+        authCtx.password === PASSWORD
+      ) {
+        authCtx.accept();
+      } else {
+        authCtx.reject(['keyboard-interactive', 'password']);
+      }
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        server,
+        port: (server.address() as net.AddressInfo).port,
+        capture,
+      });
+    });
+  });
+}
+
 let counter = 0;
 function makeManager(
   configFile: string,
@@ -370,6 +459,63 @@ describe('session settings from ssh config', () => {
     await lease.connection.waitForPostAuth();
     expect(started.capture.answers).toEqual([['stale-password'], [PASSWORD]]);
     await expect(vault.sshPassword(account)).resolves.toBe(PASSWORD);
+    lease.release();
+  }, 15_000);
+
+  it('does not remember a password from a multi-round keyboard-interactive exchange', async () => {
+    const started = await startMultiRoundKeyboardInteractiveServer();
+    server = started.server;
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    await vault.create('correct horse battery staple');
+    manager = makeManager(writeConfig(started.port, []), vault);
+    const purposes: Array<string | undefined> = [];
+    const io = makeIo({
+      prompt: (info) => {
+        purposes.push(info.purpose);
+        if (info.purpose === 'ssh-password') {
+          return Promise.resolve({
+            answers: [PASSWORD],
+            rememberPassword: true,
+          });
+        }
+        expect(info.rememberPassword).toBeUndefined();
+        return Promise.resolve({ answers: ['replacement-password'] });
+      },
+    });
+
+    const lease = await manager.connect(profile, io);
+    await lease.connection.waitForPostAuth();
+    expect(purposes).toEqual(['ssh-password', 'authentication']);
+    expect(started.capture.answers).toEqual([
+      [PASSWORD],
+      ['replacement-password'],
+    ]);
+    expect(vault.status().credentialCount).toBe(0);
+    lease.release();
+  }, 15_000);
+
+  it('does not retry an unrecognized keyboard-interactive challenge before password auth', async () => {
+    const started = await startKeyboardInteractiveFallbackServer();
+    server = started.server;
+    manager = makeManager(writeConfig(started.port, []));
+    const io = makeIo({
+      prompt: (info) =>
+        Promise.resolve({
+          answers: [
+            info.purpose === 'authentication' ? '123456' : PASSWORD,
+          ],
+        }),
+    });
+
+    const lease = await manager.connect(profile, io);
+    expect(started.capture.authMethods).toEqual([
+      'keyboard-interactive',
+      'password',
+    ]);
+    expect(started.capture.answers).toEqual([['123456']]);
     lease.release();
   }, 15_000);
 

--- a/tests/unit/server/connection-session.test.ts
+++ b/tests/unit/server/connection-session.test.ts
@@ -79,6 +79,56 @@ function startCapturingServer(): Promise<{ server: Server; port: number; capture
   });
 }
 
+interface KeyboardInteractiveCapture {
+  authMethods: string[];
+  answers: string[][];
+}
+
+function startKeyboardInteractiveServer(
+  prompts: Array<{ prompt: string; echo: boolean }>,
+  expectedAnswers: string[],
+): Promise<{
+  server: Server;
+  port: number;
+  capture: KeyboardInteractiveCapture;
+}> {
+  const capture: KeyboardInteractiveCapture = { authMethods: [], answers: [] };
+  const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
+    conn.on('error', () => undefined);
+    conn.on('authentication', (authCtx) => {
+      if (authCtx.method !== 'none') capture.authMethods.push(authCtx.method);
+      if (authCtx.method !== 'keyboard-interactive') {
+        authCtx.reject(['keyboard-interactive']);
+        return;
+      }
+      authCtx.prompt(
+        prompts,
+        'TEST_NETWORK_DEVICE',
+        (answers) => {
+          capture.answers.push(answers);
+          if (
+            answers.length === expectedAnswers.length &&
+            answers.every((answer, index) => answer === expectedAnswers[index])
+          ) {
+            authCtx.accept();
+          } else {
+            authCtx.reject(['keyboard-interactive']);
+          }
+        },
+      );
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        server,
+        port: (server.address() as net.AddressInfo).port,
+        capture,
+      });
+    });
+  });
+}
+
 let counter = 0;
 function makeManager(
   configFile: string,
@@ -230,6 +280,139 @@ describe('session settings from ssh config', () => {
     await expect(manager.connect(profile, io)).rejects.toThrow(/authentication/);
     expect(io.passwordPrompts).toBe(0);
     expect(started.capture.authMethods).not.toContain('password');
+  }, 15_000);
+
+  it('remembers and reuses a keyboard-interactive password prompt', async () => {
+    const started = await startKeyboardInteractiveServer(
+      [{ prompt: 'Password: ', echo: false }],
+      [PASSWORD],
+    );
+    server = started.server;
+    const config = writeConfig(started.port, []);
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    await vault.create('correct horse battery staple');
+    manager = makeManager(config, vault);
+
+    const firstIo = makeIo({
+      prompt: (info) => {
+        expect(info).toMatchObject({
+          name: 'TEST_NETWORK_DEVICE',
+          purpose: 'ssh-password',
+          rememberPassword: {
+            label: `tester@127.0.0.1:${started.port}`,
+            existing: false,
+          },
+        });
+        return Promise.resolve({
+          answers: [PASSWORD],
+          rememberPassword: true,
+        });
+      },
+    });
+    const first = await manager.connect(profile, firstIo);
+    await first.connection.waitForPostAuth();
+    expect(vault.status()).toMatchObject({ credentialCount: 1 });
+    first.release();
+    manager.closeAll();
+
+    manager = makeManager(config, vault);
+    const secondIo = makeIo({
+      prompt: (info) => {
+        throw new Error(`authentication prompt was not expected: ${info.purpose}`);
+      },
+    });
+    const second = await manager.connect(profile, secondIo);
+    expect(secondIo.passwordPrompts).toBe(0);
+    expect(started.capture.answers).toEqual([[PASSWORD], [PASSWORD]]);
+    second.release();
+  }, 15_000);
+
+  it('replaces a rejected saved keyboard-interactive password', async () => {
+    const started = await startKeyboardInteractiveServer(
+      [{ prompt: 'Password: ', echo: false }],
+      [PASSWORD],
+    );
+    server = started.server;
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    await vault.create('correct horse battery staple');
+    const account = sshPasswordAccount({
+      user: 'tester',
+      host: '127.0.0.1',
+      port: started.port,
+    });
+    await vault.rememberSshPassword(
+      account,
+      `tester@127.0.0.1:${started.port}`,
+      'stale-password',
+    );
+    manager = makeManager(writeConfig(started.port, []), vault);
+    const io = makeIo({
+      prompt: (info) => {
+        expect(info).toMatchObject({
+          purpose: 'ssh-password',
+          rememberPassword: { existing: true },
+        });
+        expect(info.instructions).toContain('not accepted');
+        return Promise.resolve({
+          answers: [PASSWORD],
+          rememberPassword: true,
+        });
+      },
+    });
+
+    const lease = await manager.connect(profile, io);
+    await lease.connection.waitForPostAuth();
+    expect(started.capture.answers).toEqual([['stale-password'], [PASSWORD]]);
+    await expect(vault.sshPassword(account)).resolves.toBe(PASSWORD);
+    lease.release();
+  }, 15_000);
+
+  it.each([
+    {
+      description: 'an OTP prompt',
+      prompts: [{ prompt: 'Verification code: ', echo: false }],
+      answers: ['123456'],
+    },
+    {
+      description: 'a combined password and OTP prompt',
+      prompts: [
+        { prompt: 'Password: ', echo: false },
+        { prompt: 'Verification code: ', echo: false },
+      ],
+      answers: [PASSWORD, '123456'],
+    },
+    {
+      description: 'a visible password prompt',
+      prompts: [{ prompt: 'Password: ', echo: true }],
+      answers: [PASSWORD],
+    },
+  ])('does not offer password saving for $description', async ({ prompts, answers }) => {
+    const started = await startKeyboardInteractiveServer(prompts, answers);
+    server = started.server;
+    database = new MuxusDatabase(':memory:');
+    vault = new PasswordVault(database, {
+      kdf: { cost: 1024, blockSize: 8, parallelism: 1 },
+    });
+    await vault.create('correct horse battery staple');
+    manager = makeManager(writeConfig(started.port, []), vault);
+    const io = makeIo({
+      prompt: (info) => {
+        expect(info.purpose).toBe('authentication');
+        expect(info.rememberPassword).toBeUndefined();
+        return Promise.resolve({ answers });
+      },
+    });
+
+    const lease = await manager.connect(profile, io);
+    await lease.connection.waitForPostAuth();
+    expect(vault.status().credentialCount).toBe(0);
+    lease.release();
   }, 15_000);
 
   it('remembers a successful password in the OS keyring and reuses it after restart', async () => {


### PR DESCRIPTION
## Summary

- recognize a single masked keyboard-interactive prompt explicitly labelled as a password
- offer the existing password-vault save, reuse, and stale-password replacement flow
- keep OTP, multi-field, visible-input, and other keyboard-interactive challenges transient
- document the supported behavior and security boundary

## Why

Cisco, Arista, and other network devices commonly use SSH keyboard-interactive authentication for a normal password prompt. Muxus previously offered password saving only for the standard SSH password method, so these devices never showed **Remember this password**.

## Impact

Users can now remember and automatically reuse passwords for supported network-device prompts without changing their SSH configuration. Authentication challenges that cannot be identified safely as passwords are unchanged.

## Validation

- `pnpm test` — 699 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`

Fixes #41