### PR TITLE
Support single-quoted SSH config arguments

### DIFF
--- a/server/src/ssh/folder-auth.ts
+++ b/server/src/ssh/folder-auth.ts
@@ -79,8 +79,8 @@ export function folderAuthOptionLines(auth: FolderAuthSettings): OptionLine[] {
     lines.push({
       keyword,
       key: keyword.toLowerCase(),
-      // Paths may contain spaces; quote the value the way ssh_config would.
-      value: /\s/.test(raw) ? `"${raw}"` : raw,
+      // Whitespace and apostrophes need quoting to remain one OpenSSH token.
+      value: /[\s']/.test(raw) ? `"${raw}"` : raw,
       args: [raw],
     });
   if (auth.user) push('User', auth.user);

--- a/server/src/ssh/ssh-config-edit.ts
+++ b/server/src/ssh/ssh-config-edit.ts
@@ -146,9 +146,11 @@ function validateForward(f: ConfigForward): void {
 // Serialization
 // ---------------------------------------------------------------------------
 
-/** Quote one token when it contains whitespace. Never applied to multi-arg values. */
+/** Quote one token when OpenSSH would otherwise split or quote it. */
 function quoteToken(v: string): string {
-  return /\s/.test(v) ? `"${v}"` : v;
+  // An unquoted apostrophe starts a single-quoted string in OpenSSH. Keep
+  // double quotes as our canonical output for both whitespace and apostrophes.
+  return /[\s']/.test(v) ? `"${v}"` : v;
 }
 
 function forwardTarget(host: string, port: number): string {

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -144,7 +144,23 @@ function parseFile(file: string, state: ParseState, depth: number): void {
     const keyword = m[1] ?? '';
     const key = keyword.toLowerCase();
     const value = m[2] ?? '';
-    const option: OptionLine = { keyword, key, value, args: splitArgs(value) };
+    let args: string[];
+    try {
+      args = splitArgs(value);
+    } catch {
+      recordError(state, `${resolved} line ${i + 1}: invalid quotes`);
+      // Keep malformed option lines inside their block's editable range, but
+      // don't let an invalid Host/Match header leak its options into globals.
+      if (key === 'host' || key === 'match') {
+        block = null;
+        inMatch = true;
+        globals = null;
+      } else if (block && !inMatch) {
+        block.end = i + 1;
+      }
+      continue;
+    }
+    const option: OptionLine = { keyword, key, value, args };
 
     if (key === 'host') {
       const commentStart = scanPreludeComments(lines, i);
@@ -209,17 +225,33 @@ function preludeText(lines: string[], commentStart: number, hostLine: number): s
   return text || undefined;
 }
 
-/** Split a config value into tokens, honoring double quotes anywhere in a token. */
+/**
+ * Split a config value like OpenSSH's argv_split: single and double quotes may
+ * appear anywhere in a token, and basic escapes remove their leading backslash.
+ * Other backslashes (notably those in Windows paths) remain untouched.
+ */
 export function splitArgs(value: string): string[] {
   const out: string[] = [];
   let token = '';
-  let quoted = false;
+  let quote: "'" | '"' | undefined;
   let started = false;
-  for (const char of value) {
-    if (char === '"') {
-      quoted = !quoted;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i]!;
+    const next = value[i + 1];
+    if (
+      char === '\\' &&
+      (next === "'" || next === '"' || next === '\\' || (!quote && next === ' '))
+    ) {
+      token += next;
+      i++;
       started = true;
-    } else if (/\s/.test(char) && !quoted) {
+    } else if (!quote && (char === "'" || char === '"')) {
+      quote = char;
+      started = true;
+    } else if (quote && char === quote) {
+      quote = undefined;
+    } else if ((char === ' ' || char === '\t') && !quote) {
       if (!started) continue;
       out.push(token);
       token = '';
@@ -229,6 +261,7 @@ export function splitArgs(value: string): string[] {
       started = true;
     }
   }
+  if (quote) throw new Error('invalid quotes');
   if (started) out.push(token);
   return out;
 }

--- a/server/src/ssh/ssh-config.ts
+++ b/server/src/ssh/ssh-config.ts
@@ -397,11 +397,13 @@ export function resolveHost(
           break;
         }
         case 'proxyjump':
-        case 'proxycommand':
-          if (!first.has('proxyjump') && !first.has('proxycommand') && opt.value) {
-            first.set(opt.key, opt.value);
+        case 'proxycommand': {
+          const value = opt.key === 'proxyjump' ? opt.args[0] : opt.value;
+          if (!first.has('proxyjump') && !first.has('proxycommand') && value) {
+            first.set(opt.key, value);
           }
           break;
+        }
         case 'localforward':
         case 'remoteforward':
         case 'dynamicforward': {
@@ -409,10 +411,12 @@ export function resolveHost(
           if (fwd) forwards.push(fwd);
           break;
         }
-        default:
-          if (RESOLVED_KEYS.has(resolvedKey) && !first.has(resolvedKey) && opt.value) {
-            first.set(resolvedKey, opt.value);
+        default: {
+          const value = RAW_RESOLVED_VALUE_KEYS.has(resolvedKey) ? opt.value : opt.args[0];
+          if (RESOLVED_KEYS.has(resolvedKey) && !first.has(resolvedKey) && value) {
+            first.set(resolvedKey, value);
           }
+        }
       }
     }
   }
@@ -481,10 +485,9 @@ function parseChoice<T extends string>(value: string | undefined, choices: reado
 
 /** `none`, `$VAR`/`${VAR}`, and `SSH_AUTH_SOCK` indirections pass through; paths expand. */
 function parseIdentityAgent(value: string | undefined, tokens: { h: string; r: string }): string | undefined {
-  const arg = value === undefined ? undefined : splitArgs(value)[0];
-  if (!arg) return undefined;
-  if (arg.toLowerCase() === 'none' || arg.startsWith('$') || arg === 'SSH_AUTH_SOCK') return arg;
-  return expandIdentityPath(arg, tokens);
+  if (!value) return undefined;
+  if (value.toLowerCase() === 'none' || value.startsWith('$') || value === 'SSH_AUTH_SOCK') return value;
+  return expandIdentityPath(value, tokens);
 }
 
 /** Space-separated path list; `none` → []; unset → undefined (defaults). */
@@ -545,6 +548,13 @@ const RESOLVED_KEYS = new Set([
   'remotecommand',
   'requesttty',
   'stricthostkeychecking',
+]);
+
+/** Values whose consumers need the complete argument list or command text. */
+const RAW_RESOLVED_VALUE_KEYS = new Set([
+  'globalknownhostsfile',
+  'remotecommand',
+  'userknownhostsfile',
 ]);
 
 function parseProxyCommand(value: string | undefined): string | undefined {

--- a/tests/unit/server/folder-auth.test.ts
+++ b/tests/unit/server/folder-auth.test.ts
@@ -67,20 +67,22 @@ describe('mergeFolderAuth', () => {
 });
 
 describe('folderAuthOptionLines', () => {
-  it('renders one line per set field and quotes paths with spaces', () => {
+  it('renders one line per set field and quotes paths with spaces or apostrophes', () => {
     const lines = folderAuthOptionLines({
       user: 'admin',
       port: 2222,
-      identityFiles: ['/keys/my key'],
+      identityFiles: ['/keys/my key', "/keys/O'Neil"],
       identitiesOnly: true,
     });
     expect(lines.map((line) => [line.key, line.value])).toEqual([
       ['user', 'admin'],
       ['port', '2222'],
       ['identityfile', '"/keys/my key"'],
+      ['identityfile', '"/keys/O\'Neil"'],
       ['identitiesonly', 'yes'],
     ]);
     expect(lines[2]!.args).toEqual(['/keys/my key']);
+    expect(lines[3]!.args).toEqual(["/keys/O'Neil"]);
   });
 });
 

--- a/tests/unit/server/ssh-config-edit.test.ts
+++ b/tests/unit/server/ssh-config-edit.test.ts
@@ -232,4 +232,20 @@ describe('previewHost', () => {
     expect(text).toContain('  RemoteCommand tmux new -A -s main');
     expect(text).toContain('  RequestTTY yes');
   });
+
+  it('double-quotes paths containing whitespace or apostrophes', () => {
+    const root = seed('');
+    const windowsKey = String.raw`C:\Users\toweber\OneDrive - Nokia\SSH Key\toweber`;
+    const apostropheKey = String.raw`C:\Users\O'Neil\.ssh\id_ed25519`;
+    const request = req({ options: { identityFiles: [windowsKey, apostropheKey] } });
+    const text = previewHost(request, root);
+    expect(text).toContain(`  IdentityFile "${windowsKey}"`);
+    expect(text).toContain(`  IdentityFile "${apostropheKey}"`);
+
+    upsertHost(request, root);
+    expect(listHosts(loadConfigDocument(root))[0]!.options.identityFiles).toEqual([
+      windowsKey,
+      apostropheKey,
+    ]);
+  });
 });

--- a/tests/unit/server/ssh-config-edit.test.ts
+++ b/tests/unit/server/ssh-config-edit.test.ts
@@ -237,15 +237,18 @@ describe('previewHost', () => {
     const root = seed('');
     const windowsKey = String.raw`C:\Users\toweber\OneDrive - Nokia\SSH Key\toweber`;
     const apostropheKey = String.raw`C:\Users\O'Neil\.ssh\id_ed25519`;
-    const request = req({ options: { identityFiles: [windowsKey, apostropheKey] } });
+    const request = req({
+      options: { user: "O'Neil", identityFiles: [windowsKey, apostropheKey] },
+    });
     const text = previewHost(request, root);
+    expect(text).toContain('  User "O\'Neil"');
     expect(text).toContain(`  IdentityFile "${windowsKey}"`);
     expect(text).toContain(`  IdentityFile "${apostropheKey}"`);
 
     upsertHost(request, root);
-    expect(listHosts(loadConfigDocument(root))[0]!.options.identityFiles).toEqual([
-      windowsKey,
-      apostropheKey,
-    ]);
+    const host = listHosts(loadConfigDocument(root))[0]!;
+    expect(host.options.user).toBe("O'Neil");
+    expect(host.resolved.user).toBe("O'Neil");
+    expect(host.options.identityFiles).toEqual([windowsKey, apostropheKey]);
   });
 });

--- a/tests/unit/server/ssh-config.test.ts
+++ b/tests/unit/server/ssh-config.test.ts
@@ -11,6 +11,7 @@ import {
   parseProxyJumpList,
   resolveHost,
   sessionEnvironment,
+  splitArgs,
 } from '../../../server/src/ssh/ssh-config.js';
 
 const tmp = mkdtempSync(path.join(os.tmpdir(), 'muxus-sshconf-'));
@@ -27,6 +28,29 @@ function write(content: string, name?: string): string {
 function hostsOf(content: string) {
   return listHosts(loadConfigDocument(write(content)));
 }
+
+describe('splitArgs', () => {
+  it('accepts single and double quotes while preserving Windows backslashes', () => {
+    const windowsKey = String.raw`C:\Users\toweber\OneDrive - Nokia\NPI\SSH Key\keypair\toweber`;
+    expect(splitArgs(`'${windowsKey}' "double quoted" plain`)).toEqual([
+      windowsKey,
+      'double quoted',
+      'plain',
+    ]);
+  });
+
+  it('supports the basic escapes OpenSSH accepts', () => {
+    expect(splitArgs(String.raw`escaped\ space escaped\'quote C:\Users\toweber`)).toEqual([
+      'escaped space',
+      "escaped'quote",
+      String.raw`C:\Users\toweber`,
+    ]);
+  });
+
+  it('rejects unterminated quotes', () => {
+    expect(() => splitArgs("'unterminated")).toThrow('invalid quotes');
+  });
+});
 
 describe('listHosts', () => {
   it('lists concrete hosts with block options and resolved settings', () => {
@@ -89,6 +113,20 @@ describe('listHosts', () => {
     expect(app.resolved.certificateFiles).toEqual([
       path.join(os.homedir(), '.ssh', 'app_key-cert.pub'),
     ]);
+  });
+
+  it('resolves a single-quoted Windows identity path with spaces', () => {
+    const windowsKey = String.raw`C:\Users\toweber\OneDrive - Nokia\NPI\SSH Key\keypair\securecrt_created\toweber`;
+    const app = hostsOf(['Host windows', `  IdentityFile '${windowsKey}'`].join('\n'))[0]!;
+    expect(app.options.identityFiles).toEqual([windowsKey]);
+    expect(app.resolved.identityFiles).toEqual([windowsKey]);
+  });
+
+  it('reports and skips a config line with unterminated quotes', () => {
+    const file = write(["Host broken", "  IdentityFile 'C:\\broken key"].join('\n'));
+    const doc = loadConfigDocument(file);
+    expect(doc.error).toBe(`${path.resolve(file)} line 2: invalid quotes`);
+    expect(resolveHost(doc, 'broken').identityFiles).toEqual([]);
   });
 
   it('models ProxyCommand as a first-class block option', () => {


### PR DESCRIPTION
## Summary

- parse single- and double-quoted SSH config arguments
- support OpenSSH-compatible basic escapes while preserving Windows path backslashes
- report unterminated quotes as configuration errors
- safely serialize paths containing whitespace or apostrophes
- add regression coverage for single-quoted Windows `IdentityFile` paths

## Why

A single-quoted Windows `IdentityFile` path containing spaces was split at the first space. This caused Muxus to try a truncated path even though OpenSSH accepts the original configuration.

## Validation

- `pnpm test` — 707 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
