### PR TITLE
Move tabs into new split panes from context menu

### DIFF
--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -112,6 +112,7 @@ export function TabStrip({
   const equalizePanes = useTabsStore((s) => s.equalizePanes);
   const update = useTabsStore((s) => s.update);
   const setPinned = useTabsStore((s) => s.setPinned);
+  const moveTabToNewPane = useTabsStore((s) => s.moveTabToNewPane);
   const reconnect = useTabsStore((s) => s.reconnect);
   const multiExecTargets = useMultiExecStore((s) => s.selectedIds);
   const multiExecSelected = new Set(multiExecTargets);
@@ -177,6 +178,9 @@ export function TabStrip({
 
   const openMenu = (tab: TerminalTab, position: { top: number; left: number }) => setMenu({ position, tab });
   const menuTab = menu ? allTabs.find((t) => t.id === menu.tab.id) : undefined;
+  const canSplitMenuTab = !!menuTab && allTabs.some(
+    (tab) => tab.paneId === menuTab.paneId && tab.id !== menuTab.id,
+  );
 
   const commitRename = () => {
     if (renaming && renameValue.trim()) update(renaming.id, { title: renameValue.trim() });
@@ -791,6 +795,31 @@ export function TabStrip({
             <OpenInNewOutlinedIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Open in new window</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem
+          disabled={!canSplitMenuTab}
+          onClick={() => {
+            if (menuTab) moveTabToNewPane(menuTab.id, 'right');
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <VerticalSplitOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Move tab to split right</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={!canSplitMenuTab}
+          onClick={() => {
+            if (menuTab) moveTabToNewPane(menuTab.id, 'down');
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <HorizontalSplitOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Move tab to split down</ListItemText>
         </MenuItem>
         {menuTab?.profile && menuTab.status === 'closed' ? (
           <>

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -147,6 +147,8 @@ interface TabsState {
   cyclePane: (backwards: boolean) => boolean;
   /** Move the active tab to the bordering pane, splitting off a new one when there is none. */
   moveTabToDirection: (direction: PaneDirection) => boolean;
+  /** Split a specific tab into a newly created neighbouring pane. */
+  moveTabToNewPane: (id: string, direction: PaneDirection) => boolean;
   /** Fill the canvas with one pane (tmux-style zoom), or restore the layout. */
   toggleZoom: (paneId?: string) => boolean;
   resizeSplit: (splitId: string, ratio: number) => void;
@@ -626,6 +628,17 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     // Splitting off the only tab of a pane would just move the pane around.
     if (!neighbor && sourceTabs.length < 2) return false;
     const targetId = neighbor ?? state.split(sourceId, direction);
+    return targetId ? get().moveTabToPane(tab.id, targetId) : false;
+  },
+  moveTabToNewPane: (id, direction) => {
+    const state = get();
+    const tab = state.tabs.find((candidate) => candidate.id === id);
+    if (!tab) return false;
+    const sourceTabs = state.tabs.filter((candidate) => candidate.paneId === tab.paneId);
+    // Splitting away the only tab would leave an empty source pane and merely
+    // relocate the session, rather than turning a tabbed pair into two panes.
+    if (sourceTabs.length < 2) return false;
+    const targetId = state.split(tab.paneId, direction);
     return targetId ? get().moveTabToPane(tab.id, targetId) : false;
   },
   toggleZoom: (paneId) => {

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -694,6 +694,50 @@ describe('moving tabs between panes', () => {
     expect(state.tabs.find((tab) => tab.id === secondId)?.paneId).toBe(state.activePaneId);
   });
 
+  it('splits a specific background tab into a new right pane', () => {
+    const store = useTabsStore.getState();
+    const movingId = store.open({ kind: 'local' }, 'Move me');
+    const stayingId = store.open({ kind: 'ssh', target: 'router' }, 'Stay here');
+
+    expect(useTabsStore.getState().moveTabToNewPane(movingId, 'right')).toBe(true);
+
+    const state = useTabsStore.getState();
+    expect(state.root).toMatchObject({
+      type: 'split',
+      direction: 'horizontal',
+      children: [
+        { id: 'pane-test', activeTabId: stayingId },
+        { activeTabId: movingId },
+      ],
+    });
+    expect(state.tabs.find((tab) => tab.id === movingId)?.paneId).toBe(state.activePaneId);
+    expect(state.activeId).toBe(movingId);
+  });
+
+  it('splits a specific tab into a new lower pane', () => {
+    const store = useTabsStore.getState();
+    const stayingId = store.open({ kind: 'local' }, 'Stay here');
+    const movingId = store.open({ kind: 'ssh', target: 'router' }, 'Move me');
+
+    expect(useTabsStore.getState().moveTabToNewPane(movingId, 'down')).toBe(true);
+
+    expect(useTabsStore.getState().root).toMatchObject({
+      type: 'split',
+      direction: 'vertical',
+      children: [
+        { id: 'pane-test', activeTabId: stayingId },
+        { activeTabId: movingId },
+      ],
+    });
+  });
+
+  it('does not move the only tab into a new pane', () => {
+    const id = useTabsStore.getState().open({ kind: 'local' }, 'Only tab');
+
+    expect(useTabsStore.getState().moveTabToNewPane(id, 'right')).toBe(false);
+    expect(useTabsStore.getState().root).toMatchObject({ id: 'pane-test', type: 'pane' });
+  });
+
   it('declines to move the only tab of a pane into a new pane', () => {
     const store = useTabsStore.getState();
     store.open({ kind: 'local' }, 'Local');


### PR DESCRIPTION
## Summary

- add right-click actions to move a tab into a new pane on the right or below
- move the exact selected tab instead of duplicating its session
- disable the actions when the pane has only one tab
- cover background-tab moves, both split orientations, and the single-tab guard

## Why

Pane split actions currently create a new pane and may start another session. When several sessions are already open as tabs, there is no direct context-menu action to arrange an existing tab beside another one.

## User impact

A user with multiple tabs in one pane can right-click any tab and choose **Move tab to split right** or **Move tab to split down**. The selected live session moves into the new pane and becomes active while the other tab remains in the original pane.

## Validation

- `pnpm exec vitest run unit/client/tabs.test.ts` — 51 tests passed
- focused `oxlint` — passed
- `pnpm --filter @muxus/client typecheck` — passed
- `pnpm --filter @muxus/client build` — passed