### PR TITLE
Bump version to v0.4.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "packageManager": "pnpm@11.17.0",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -27,9 +27,9 @@ describe('app routes', () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          version: 'v0.4.0',
-          releaseName: 'Muxus 0.4',
-          releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.4.0',
+          version: 'v0.5.0',
+          releaseName: 'Muxus 0.5',
+          releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.5.0',
           publishedAt: '2026-07-26T08:00:00Z',
         }),
         { status: 200, headers: { 'content-type': 'application/json' } },
@@ -46,17 +46,17 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.3.1',
-      latestVersion: '0.4.0',
-      releaseName: 'Muxus 0.4',
-      releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.4.0',
+      currentVersion: '0.4.0',
+      latestVersion: '0.5.0',
+      releaseName: 'Muxus 0.5',
+      releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.5.0',
       publishedAt: '2026-07-26T08:00:00Z',
     });
     expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.3.1' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.4.0' },
     });
   });
 
@@ -66,8 +66,8 @@ describe('app routes', () => {
       vi.fn().mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            version: '0.4.0',
-            releaseUrl: 'https://attacker.example/FloSch62/muxus/releases/tag/v0.4.0',
+            version: '0.5.0',
+            releaseUrl: 'https://attacker.example/FloSch62/muxus/releases/tag/v0.5.0',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         ),
@@ -83,8 +83,8 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.3.1',
-      latestVersion: '0.4.0',
+      currentVersion: '0.4.0',
+      latestVersion: '0.5.0',
       reason: 'missing-release-url',
     });
   });


### PR DESCRIPTION
## Summary

- Bump the root and workspace package versions from `0.3.1` to `0.4.0`.
- Advance update-check test fixtures so they continue to model a newer release.

## Why

Prepare the repository for the v0.4.0 release while keeping version-derived behavior and tests aligned.

## Impact

Build artifacts and app metadata will report version `0.4.0`. There are no runtime behavior changes.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (720 passed, 3 skipped)