### PR TITLE
Silence unavailable SSH agent fallback

### DIFF
--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -738,7 +738,15 @@ export class SshConnectionManager {
       client.on('error', (err) => {
         if (!settled && err.level === 'agent') {
           // ssh2 reports an unreachable agent mid-auth and then moves on to
-          // the next method itself; surface it without aborting the dial.
+          // the next method itself. This is an expected fallback when a stale
+          // agent socket is inherited, so keep it out of user-facing status.
+          if (err.message === 'Failed to connect to agent') {
+            this.log.debug(
+              { err, host: hop.resolved.hostname },
+              'ssh-agent unavailable; trying other authentication methods',
+            );
+            return;
+          }
           this.log.warn(
             { err, host: hop.resolved.hostname },
             'ssh-agent unavailable; trying other authentication methods',

--- a/tests/unit/server/agent-auth.test.ts
+++ b/tests/unit/server/agent-auth.test.ts
@@ -268,7 +268,7 @@ describe.skipIf(process.platform === 'win32')('ssh-agent authentication', () => 
     expect(io.passphrasePrompts).toBe(0);
   }, 15_000);
 
-  it('falls back to the next method when the agent socket is unreachable', async () => {
+  it('silently falls back when the agent socket is unreachable', async () => {
     process.env.SSH_AUTH_SOCK = path.join(tmp, 'no-such-agent.sock');
     try {
       const { server, port, events } = await startServer(agentPub);
@@ -277,7 +277,7 @@ describe.skipIf(process.platform === 'win32')('ssh-agent authentication', () => 
       await connectOnce(port, io);
       await new Promise<void>((resolve) => server.close(() => resolve()));
 
-      expect(io.statuses.some((s) => s.includes('ssh-agent unavailable'))).toBe(true);
+      expect(io.statuses.some((s) => s.includes('ssh-agent unavailable'))).toBe(false);
       expect(events.some((e) => e.method === 'password' && e.accepted)).toBe(true);
       expect(io.passwordPrompts).toBe(1);
     } finally {


### PR DESCRIPTION
## Summary

- silently fall back to other authentication methods when the configured SSH agent socket is unavailable
- retain debug-level diagnostics for the expected missing-agent condition
- preserve user-facing warnings for actionable SSH agent failures such as response timeouts
- update the agent authentication regression test to cover the silent fallback

## Why

A stale or unavailable SSH agent socket causes ssh2 to emit `Failed to connect to agent` while automatically continuing to the next authentication method. Muxus treated that expected fallback as a warning and terminal status, sometimes displaying it more than once even though authentication could continue successfully.

## Impact

Connections now continue without noisy status messages when no SSH agent is available. Other agent failures that may require user action remain visible.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (720 passed, 3 skipped)