### PR TITLE
Show per-session reasons for skipped imports

### DIFF
--- a/client/src/components/SessionImportDialog.tsx
+++ b/client/src/components/SessionImportDialog.tsx
@@ -60,6 +60,8 @@ interface AutoImportSource {
   load: () => Promise<SessionImportSource | undefined>;
 }
 
+const SKIPPED_SESSIONS_PER_PAGE = 50;
+
 export function SessionImportDialog<T extends ImportedSession>({
   onClose,
   vendorName,
@@ -253,31 +255,7 @@ export function SessionImportDialog<T extends ImportedSession>({
                   {pending.parsed.ignoredCount} unsupported or incomplete{' '}
                   {pending.parsed.ignoredCount === 1 ? 'session was' : 'sessions were'} skipped.
                 </Typography>
-                <Box
-                  component="ul"
-                  aria-label="Skipped sessions"
-                  sx={{ m: 0, mt: 1, p: 0, maxHeight: 180, overflowY: 'auto', listStyle: 'none' }}
-                >
-                  {pending.parsed.skippedSessions.map((session) => (
-                    <Box
-                      component="li"
-                      key={session.id}
-                      sx={{
-                        display: 'grid',
-                        gridTemplateColumns: { xs: '1fr', sm: 'minmax(180px, 0.7fr) 1fr' },
-                        columnGap: 2,
-                        py: 0.75,
-                        borderTop: 1,
-                        borderColor: 'warning.dark',
-                      }}
-                    >
-                      <Typography variant="body2" sx={{ fontWeight: 650 }} noWrap>
-                        {skippedSessionName(session)}
-                      </Typography>
-                      <Typography variant="body2">{session.reason}</Typography>
-                    </Box>
-                  ))}
-                </Box>
+                <SkippedSessionList sessions={pending.parsed.skippedSessions} />
               </Alert>
             ) : null}
 
@@ -503,6 +481,70 @@ function searchableSessionValues(session: ImportedSession): Array<string | undef
 
 function skippedSessionName(session: SkippedImportedSession): string {
   return session.folder ? `${session.folder}/${session.name}` : session.name;
+}
+
+function SkippedSessionList({ sessions }: { sessions: readonly SkippedImportedSession[] }) {
+  const [page, setPage] = useState(0);
+  const pageCount = Math.ceil(sessions.length / SKIPPED_SESSIONS_PER_PAGE);
+  const currentPage = Math.min(page, Math.max(0, pageCount - 1));
+  const start = currentPage * SKIPPED_SESSIONS_PER_PAGE;
+  const end = Math.min(start + SKIPPED_SESSIONS_PER_PAGE, sessions.length);
+  const visibleSessions = sessions.slice(start, end);
+
+  return (
+    <>
+      <Box
+        component="ul"
+        aria-label="Skipped sessions"
+        sx={{ m: 0, mt: 1, p: 0, maxHeight: 180, overflowY: 'auto', listStyle: 'none' }}
+      >
+        {visibleSessions.map((session) => (
+          <Box
+            component="li"
+            key={session.id}
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: 'minmax(180px, 0.7fr) 1fr' },
+              columnGap: 2,
+              py: 0.75,
+              borderTop: 1,
+              borderColor: 'warning.dark',
+            }}
+          >
+            <Typography variant="body2" sx={{ fontWeight: 650 }} noWrap>
+              {skippedSessionName(session)}
+            </Typography>
+            <Typography variant="body2">{session.reason}</Typography>
+          </Box>
+        ))}
+      </Box>
+      {pageCount > 1 ? (
+        <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mt: 0.5 }}>
+          <Typography variant="caption" aria-live="polite">
+            Showing {start + 1}–{end} of {sessions.length}
+          </Typography>
+          <Stack direction="row" spacing={0.5}>
+            <Button
+              color="inherit"
+              size="small"
+              disabled={currentPage === 0}
+              onClick={() => setPage(Math.max(0, currentPage - 1))}
+            >
+              Previous
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              disabled={currentPage === pageCount - 1}
+              onClick={() => setPage(Math.min(pageCount - 1, currentPage + 1))}
+            >
+              Next
+            </Button>
+          </Stack>
+        </Stack>
+      ) : null}
+    </>
+  );
 }
 
 function sessionDetails(session: ImportedSession): string {

--- a/client/src/components/SessionImportDialog.tsx
+++ b/client/src/components/SessionImportDialog.tsx
@@ -39,6 +39,7 @@ import {
 import type {
   ImportedSession,
   ImportedSessionParseResult,
+  SkippedImportedSession,
 } from '../session-import.js';
 import { errorDetails, showToast } from '../state/toast.js';
 
@@ -248,8 +249,35 @@ export function SessionImportDialog<T extends ImportedSession>({
             <Alert severity="info">{reviewNotice}</Alert>
             {pending.parsed.ignoredCount > 0 ? (
               <Alert severity="warning">
-                {pending.parsed.ignoredCount} unsupported or incomplete{' '}
-                {pending.parsed.ignoredCount === 1 ? 'session was' : 'sessions were'} skipped.
+                <Typography variant="body2">
+                  {pending.parsed.ignoredCount} unsupported or incomplete{' '}
+                  {pending.parsed.ignoredCount === 1 ? 'session was' : 'sessions were'} skipped.
+                </Typography>
+                <Box
+                  component="ul"
+                  aria-label="Skipped sessions"
+                  sx={{ m: 0, mt: 1, p: 0, maxHeight: 180, overflowY: 'auto', listStyle: 'none' }}
+                >
+                  {pending.parsed.skippedSessions.map((session) => (
+                    <Box
+                      component="li"
+                      key={session.id}
+                      sx={{
+                        display: 'grid',
+                        gridTemplateColumns: { xs: '1fr', sm: 'minmax(180px, 0.7fr) 1fr' },
+                        columnGap: 2,
+                        py: 0.75,
+                        borderTop: 1,
+                        borderColor: 'warning.dark',
+                      }}
+                    >
+                      <Typography variant="body2" sx={{ fontWeight: 650 }} noWrap>
+                        {skippedSessionName(session)}
+                      </Typography>
+                      <Typography variant="body2">{session.reason}</Typography>
+                    </Box>
+                  ))}
+                </Box>
               </Alert>
             ) : null}
 
@@ -471,6 +499,10 @@ function searchableSessionValues(session: ImportedSession): Array<string | undef
   return session.kind === 'ssh'
     ? [session.name, session.alias, session.host, session.username, session.folder]
     : [session.name, session.path, String(session.baudRate), session.folder];
+}
+
+function skippedSessionName(session: SkippedImportedSession): string {
+  return session.folder ? `${session.folder}/${session.name}` : session.name;
 }
 
 function sessionDetails(session: ImportedSession): string {

--- a/client/src/mobaxterm-import.ts
+++ b/client/src/mobaxterm-import.ts
@@ -1,7 +1,9 @@
 import type { PortableConnections } from './data-transfer.js';
 import {
+  cleanImportName,
   importedConnections,
   normalizeImportFolder,
+  type SkippedImportedSession,
   type ImportedSessionParseResult,
   type ImportedSshSession,
   uniqueImportAlias,
@@ -10,6 +12,9 @@ import {
 const MOBAXTERM_SSH_SESSION_TYPE = 109;
 const BOOKMARK_SECTION_RE = /^Bookmarks(?:_\d+)?$/i;
 const SESSION_TYPE_RE = /^#(\d+)#/;
+const NON_SSH_REASON = 'Session type is not SSH (only SSH sessions can be imported)';
+const MISSING_NAME_REASON = 'SSH session has no name';
+const MISSING_HOST_REASON = 'SSH session has no hostname';
 export const MAX_MOBAXTERM_IMPORT_BYTES = 10 * 1024 * 1024;
 
 export interface MobaXtermSession extends ImportedSshSession {}
@@ -32,7 +37,16 @@ export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
   const aliases = new Set<string>();
   let inBookmarks = false;
   let currentFolder: string | undefined;
-  let ignoredCount = 0;
+  const skippedSessions: SkippedImportedSession[] = [];
+
+  const skip = (lineIndex: number, name: string, fallback: string | undefined, reason: string) => {
+    skippedSessions.push({
+      id: `mobaxterm-skipped-${lineIndex}`,
+      name: cleanImportName(name) || cleanImportName(fallback ?? '') || 'Unnamed session',
+      folder: currentFolder,
+      reason,
+    });
+  };
 
   for (const [lineIndex, rawLine] of text.split(/\r?\n/).entries()) {
     const line = rawLine.trim();
@@ -60,14 +74,18 @@ export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
     if (!typeMatch) continue;
     const type = Number.parseInt(typeMatch[1] ?? '', 10);
     if (type !== MOBAXTERM_SSH_SESSION_TYPE) {
-      ignoredCount++;
+      skip(lineIndex, name, undefined, NON_SSH_REASON);
       continue;
     }
 
     const fields = value.slice(typeMatch[0].length).split('%');
     const host = fields[1]?.trim();
-    if (!name || !host) {
-      ignoredCount++;
+    if (!name) {
+      skip(lineIndex, name, host, MISSING_NAME_REASON);
+      continue;
+    }
+    if (!host) {
+      skip(lineIndex, name, undefined, MISSING_HOST_REASON);
       continue;
     }
     const parsedPort = Number.parseInt(fields[2]?.trim() ?? '', 10);
@@ -92,7 +110,11 @@ export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
   if (sessions.length === 0) {
     throw new Error('No SSH sessions were found in this MobaXterm file.');
   }
-  return { sessions, ignoredCount };
+  return {
+    sessions,
+    ignoredCount: skippedSessions.length,
+    skippedSessions,
+  };
 }
 
 /** Convert reviewed MobaXterm rows into the existing portable restore pipeline. */

--- a/client/src/securecrt-import.ts
+++ b/client/src/securecrt-import.ts
@@ -55,7 +55,7 @@ export function parseSecureCrtSessions(text: string): SecureCrtParseResult {
   const aliases = new Set<string>();
   const profileIds = new Set<string>();
   const sessionIds = new Set<string>();
-  let ignoredCount = 0;
+  const skippedSessions: ImportedSessionParseResult['skippedSessions'] = [];
 
   const visit = (key: Element, folders: readonly string[], sourcePath: readonly string[]) => {
     const rawName = key.getAttribute('name') ?? '';
@@ -70,17 +70,29 @@ export function parseSecureCrtSessions(text: string): SecureCrtParseResult {
       return;
     }
 
-    const protocol = directValue(key, 'string', ['Protocol Name']).toLowerCase();
+    const protocol = directValue(key, 'string', ['Protocol Name']);
+    const normalizedProtocol = protocol.toLowerCase();
     const folder = normalizeImportFolder(folders.join('/'));
     const sourceKey = nextSourcePath.join('\0');
+    const skip = (reason: string, fallback?: string) => {
+      skippedSessions.push({
+        id: `securecrt-skipped-${skippedSessions.length}`,
+        name: name || fallback || 'Unnamed session',
+        folder,
+        reason,
+      });
+    };
     if (!name) {
-      ignoredCount++;
+      const fallback = cleanOptionValue(
+        directValue(key, 'string', ['Hostname', 'Mac Com Port', 'Com Port', 'Port']),
+      );
+      skip('Session has no name', fallback);
       return;
     }
-    if (protocol === 'ssh2') {
+    if (normalizedProtocol === 'ssh2') {
       const host = cleanOptionValue(directValue(key, 'string', ['Hostname']));
       if (!host) {
-        ignoredCount++;
+        skip('SSH session has no hostname');
         return;
       }
       const username = cleanOptionValue(directValue(key, 'string', ['Username'])) || undefined;
@@ -113,12 +125,12 @@ export function parseSecureCrtSessions(text: string): SecureCrtParseResult {
       });
       return;
     }
-    if (protocol === 'serial') {
+    if (normalizedProtocol === 'serial') {
       const path = cleanSerialPath(
         directValue(key, 'string', ['Mac Com Port', 'Com Port', 'Port']),
       );
       if (!path) {
-        ignoredCount++;
+        skip('Serial session has no port');
         return;
       }
       const rawBaudRate = Number.parseInt(
@@ -162,14 +174,22 @@ export function parseSecureCrtSessions(text: string): SecureCrtParseResult {
       });
       return;
     }
-    ignoredCount++;
+    skip(
+      protocol
+        ? `Protocol “${protocol}” is not supported`
+        : 'Session does not specify a supported protocol',
+    );
   };
 
   for (const key of directElements(sessionsRoot, 'key')) visit(key, [], []);
   if (sessions.length === 0) {
     throw new Error('No supported SSH or serial sessions were found in this SecureCRT file.');
   }
-  return { sessions, ignoredCount };
+  return {
+    sessions,
+    ignoredCount: skippedSessions.length,
+    skippedSessions,
+  };
 }
 
 export function secureCrtConnections(

--- a/client/src/session-import.ts
+++ b/client/src/session-import.ts
@@ -41,10 +41,21 @@ export interface ImportedSerialSession extends ImportedSessionBase {
 
 export type ImportedSession = ImportedSshSession | ImportedSerialSession;
 
+export interface SkippedImportedSession {
+  /** Stable inside one parsed file and used as the React list key. */
+  id: string;
+  /** Session name, or the hostname/path when the source omitted a name. */
+  name: string;
+  folder?: string;
+  reason: string;
+}
+
 export interface ImportedSessionParseResult<T extends ImportedSession = ImportedSession> {
   sessions: T[];
   /** Recognizable session entries that were unsupported or incomplete. */
   ignoredCount: number;
+  /** Every ignored session together with the reason it cannot be imported. */
+  skippedSessions: SkippedImportedSession[];
 }
 
 /** Convert reviewed third-party rows into the existing portable restore pipeline. */

--- a/tests/unit/client/mobaxterm-import.test.ts
+++ b/tests/unit/client/mobaxterm-import.test.ts
@@ -21,6 +21,7 @@ Key box=#109#0%key.example.com%22%root%3%rest
 
     expect(parsed).toEqual({
       ignoredCount: 0,
+      skippedSessions: [],
       sessions: [
         {
           id: expect.any(String),
@@ -66,12 +67,30 @@ My host!=#109#0%two.example.com%22%%%rest
     const parsed = parseMobaXtermSessions(`
 [Bookmarks]
 RDP=#91#0%desktop.example.com
+VNC=#5#0%desktop.example.com
 Broken SSH=#109#0%%22%root%%
 Valid=#109#0%valid.example.com%22%root%%
 `);
 
     expect(parsed.sessions).toHaveLength(1);
-    expect(parsed.ignoredCount).toBe(2);
+    expect(parsed.ignoredCount).toBe(3);
+    expect(parsed.skippedSessions).toEqual([
+      {
+        id: expect.any(String),
+        name: 'RDP',
+        reason: 'Session type is not SSH (only SSH sessions can be imported)',
+      },
+      {
+        id: expect.any(String),
+        name: 'VNC',
+        reason: 'Session type is not SSH (only SSH sessions can be imported)',
+      },
+      {
+        id: expect.any(String),
+        name: 'Broken SSH',
+        reason: 'SSH session has no hostname',
+      },
+    ]);
   });
 
   it('rejects files with no SSH bookmarks', () => {

--- a/tests/unit/client/securecrt-import.test.ts
+++ b/tests/unit/client/securecrt-import.test.ts
@@ -96,6 +96,18 @@ describe('SecureCRT session parsing', () => {
     const parsed = parseSecureCrtSessions(EXPORT);
 
     expect(parsed.ignoredCount).toBe(2);
+    expect(parsed.skippedSessions).toEqual([
+      {
+        id: expect.any(String),
+        name: 'Local terminal',
+        reason: 'Protocol “Local Shell” is not supported',
+      },
+      {
+        id: expect.any(String),
+        name: 'Broken SSH',
+        reason: 'SSH session has no hostname',
+      },
+    ]);
     expect(parsed.sessions).toHaveLength(3);
     expect(parsed.sessions[0]).toMatchObject({
       kind: 'ssh',


### PR DESCRIPTION
## Summary

- retain each unsupported or incomplete MobaXterm and SecureCRT session with its source name, folder, and exact skip reason
- show skipped sessions individually in a compact, scrollable warning list
- add parser coverage for per-session skip metadata

## Why

The import review previously showed only a total count of skipped sessions, so users could not tell which entries were affected or why they could not be imported.

## Validation

- `pnpm --filter @muxus/tests exec vitest run unit/client/mobaxterm-import.test.ts unit/client/securecrt-import.test.ts`
- `pnpm --filter @muxus/client typecheck`
- `pnpm lint`
- `pnpm --filter @muxus/client build`