### PR TITLE
Add searchable saved command menu

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,6 +26,7 @@ import {
   loadHostEditorDialog,
   loadFolderDialog,
   loadHostOrganizationDialog,
+  loadCommandButtonMenu,
   loadCommandButtonsDialog,
   loadSettingsDialog,
   loadShortcutsDialog,
@@ -62,6 +63,9 @@ const ToastHost = lazy(() =>
     default: module.ToastHost,
   })),
 );
+const CommandButtonMenu = lazy(() =>
+  loadCommandButtonMenu().then((module) => ({ default: module.CommandButtonMenu })),
+);
 const CommandButtonsDialog = lazy(() =>
   loadCommandButtonsDialog().then((module) => ({ default: module.CommandButtonsDialog })),
 );
@@ -92,6 +96,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const hostOrganizerOpen = useUiStore((s) => !!s.hostOrganizer);
   const folderDialogOpen = useUiStore((s) => !!s.folderDialog);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
+  const commandButtonMenuOpen = useUiStore((s) => s.commandButtonMenuOpen);
   const commandButtonsOpen = useUiStore((s) => s.commandButtonsOpen);
   const shortcutsOpen = useUiStore((s) => s.shortcutsOpen);
   const historyOpen = useUiStore((s) => s.historyOpen);
@@ -142,6 +147,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
         {hostOrganizerOpen ? <HostOrganizationDialog /> : null}
         {folderDialogOpen ? <FolderDialog /> : null}
         {settingsOpen ? <SettingsDialog /> : null}
+        {commandButtonMenuOpen ? <CommandButtonMenu /> : null}
         {commandButtonsOpen ? <CommandButtonsDialog /> : null}
         {shortcutsOpen ? <ShortcutsDialog /> : null}
         {historyOpen ? <SessionHistoryDialog /> : null}

--- a/client/src/command-buttons.ts
+++ b/client/src/command-buttons.ts
@@ -1,5 +1,20 @@
 import type { CommandButton } from './state/prefs.js';
 
+const SEARCH_WORD_SEPARATOR = /\s+/;
+
+/** Match every search word against a saved command's label or command text. */
+export function filterCommandButtons(
+  buttons: readonly CommandButton[],
+  query: string,
+): readonly CommandButton[] {
+  const words = query.trim().toLowerCase().split(SEARCH_WORD_SEPARATOR).filter(Boolean);
+  if (words.length === 0) return buttons;
+  return buttons.filter((button) => {
+    const searchable = `${button.label} ${button.command}`.toLowerCase();
+    return words.every((word) => searchable.includes(word));
+  });
+}
+
 /** Convert saved, possibly multiline text to terminal Enter characters. */
 export function commandButtonInput(button: CommandButton): string {
   const command = button.command.replace(/\r\n|\n/g, '\r');

--- a/client/src/components/ActionBar.tsx
+++ b/client/src/components/ActionBar.tsx
@@ -13,9 +13,10 @@ import { terminalHandle } from '../terminal/terminal-registry.js';
 
 export const ActionBar = memo(function ActionBar() {
   const buttons = usePrefsStore((state) => state.commandButtons);
+  const showCommandBar = usePrefsStore((state) => state.showCommandBar);
   const activeTab = useTabsStore((state) => state.tabs.find((tab) => tab.id === state.activeId));
   const setOpen = useUiStore((state) => state.setCommandButtonsOpen);
-  if (buttons.length === 0) return null;
+  if (!showCommandBar || buttons.length === 0) return null;
   const connected = activeTab?.status === 'connected';
 
   return (

--- a/client/src/components/CommandButtonMenu.tsx
+++ b/client/src/components/CommandButtonMenu.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import Divider from '@mui/material/Divider';
+import InputAdornment from '@mui/material/InputAdornment';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListSubheader from '@mui/material/ListSubheader';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import SearchIcon from '@mui/icons-material/Search';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import { commandButtonInput, filterCommandButtons } from '../command-buttons.js';
+import { usePrefsStore, type CommandButton } from '../state/prefs.js';
+import { showToast } from '../state/toast.js';
+import { useTabsStore } from '../state/tabs.js';
+import { useUiStore } from '../state/ui.js';
+import { terminalHandle, type TerminalAnchorPosition } from '../terminal/terminal-registry.js';
+
+const menuCenter = (): TerminalAnchorPosition => ({
+  top: Math.round(window.innerHeight / 2),
+  left: Math.round(window.innerWidth / 2),
+});
+
+/** Compact, keyboard-first picker for the commands shown in the action bar. */
+export function CommandButtonMenu() {
+  const buttons = usePrefsStore((state) => state.commandButtons);
+  const activeId = useTabsStore((state) => state.activeId);
+  const connected = useTabsStore((state) =>
+    state.tabs.some((tab) => tab.id === state.activeId && tab.status === 'connected'),
+  );
+  const setMenuOpen = useUiStore((state) => state.setCommandButtonMenuOpen);
+  const setButtonsOpen = useUiStore((state) => state.setCommandButtonsOpen);
+  const [query, setQuery] = useState('');
+  const [anchorPosition] = useState(
+    () => terminalHandle(activeId)?.cursorAnchorPosition() ?? menuCenter(),
+  );
+  const searchRef = useRef<HTMLInputElement>(null);
+  const firstResultRef = useRef<HTMLLIElement>(null);
+  const manageRef = useRef<HTMLLIElement>(null);
+  const filteredButtons = useMemo(() => filterCommandButtons(buttons, query), [buttons, query]);
+  const firstEnabledButton = connected
+    ? filteredButtons.find((button) => button.command.trim())
+    : undefined;
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => searchRef.current?.focus({ preventScroll: true }));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  const restoreTerminalFocus = () => {
+    requestAnimationFrame(() => terminalHandle(activeId)?.focus());
+  };
+  const close = () => {
+    setMenuOpen(false);
+    restoreTerminalFocus();
+  };
+  const send = (button: CommandButton) => {
+    setMenuOpen(false);
+    const sent = terminalHandle(activeId)?.sendInput(commandButtonInput(button)) ?? false;
+    if (!sent) showToast('warning', 'The active terminal is not connected.');
+    restoreTerminalFocus();
+  };
+  const onSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // Keep MenuList's built-in type-ahead from stealing printable keys from
+    // the search box. Once a result has focus, its native arrow/Enter behavior
+    // takes over.
+    event.stopPropagation();
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      (firstResultRef.current ?? manageRef.current)?.focus();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      manageRef.current?.focus();
+    } else if (event.key === 'Enter') {
+      if (!firstEnabledButton) return;
+      event.preventDefault();
+      send(firstEnabledButton);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  };
+
+  return (
+    <Menu
+      open
+      autoFocus={false}
+      onClose={close}
+      anchorReference="anchorPosition"
+      anchorPosition={anchorPosition}
+      slotProps={{
+        list: { 'aria-label': 'Saved commands', dense: true },
+        paper: { sx: { minWidth: 280, maxWidth: 420, maxHeight: 360 } },
+      }}
+    >
+      <ListSubheader sx={{ py: 1, lineHeight: 1, bgcolor: 'background.paper' }}>
+        <TextField
+          inputRef={searchRef}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={onSearchKeyDown}
+          placeholder="Search commands"
+          fullWidth
+          slotProps={{
+            htmlInput: { 'aria-label': 'Search saved commands' },
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ fontSize: 18 }} />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+      </ListSubheader>
+      {buttons.length === 0 ? <MenuItem disabled>No saved commands yet</MenuItem> : null}
+      {buttons.length > 0 && filteredButtons.length === 0 ? (
+        <MenuItem disabled>No matching commands</MenuItem>
+      ) : null}
+      {filteredButtons.map((button) => {
+        const label = button.label.trim() || button.command.trim() || 'Command';
+        const command = button.command.trim();
+        return (
+          <MenuItem
+            key={button.id}
+            ref={button.id === firstEnabledButton?.id ? firstResultRef : undefined}
+            disabled={!connected || !command}
+            title={command || undefined}
+            onClick={() => send(button)}
+          >
+            <Typography variant="body2" noWrap sx={{ maxWidth: 370 }}>
+              {label}
+            </Typography>
+          </MenuItem>
+        );
+      })}
+      <Divider />
+      <MenuItem
+        ref={manageRef}
+        onClick={() => {
+          setMenuOpen(false);
+          setButtonsOpen(true);
+        }}
+      >
+        <ListItemIcon>
+          <SettingsOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        Manage command buttons…
+      </MenuItem>
+    </Menu>
+  );
+}

--- a/client/src/components/CommandButtonsDialog.tsx
+++ b/client/src/components/CommandButtonsDialog.tsx
@@ -25,6 +25,7 @@ export function CommandButtonsDialog() {
   const open = useUiStore((state) => state.commandButtonsOpen);
   const setOpen = useUiStore((state) => state.setCommandButtonsOpen);
   const buttons = usePrefsStore((state) => state.commandButtons);
+  const showCommandBar = usePrefsStore((state) => state.showCommandBar);
   const setPrefs = usePrefsStore((state) => state.set);
   const setButtons = (commandButtons: CommandButton[]) => setPrefs({ commandButtons });
 
@@ -44,10 +45,31 @@ export function CommandButtonsDialog() {
       <DialogTitle>Command buttons</DialogTitle>
       <DialogContent>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Save commands you use often. They appear in a one-click action bar above the active
-          terminal and stay in the order shown here.
+          Save commands you use often. Open them with Ctrl+Space or keep the optional
+          one-click bar above the active terminal. Commands stay in the order shown here.
         </Typography>
         <Stack spacing={1.25}>
+          <Paper variant="outlined" sx={{ p: 1.25 }}>
+            <FormControlLabel
+              sx={{ m: 0 }}
+              control={
+                <Switch
+                  size="small"
+                  checked={showCommandBar}
+                  onChange={(event) => setPrefs({ showCommandBar: event.target.checked })}
+                />
+              }
+              label={
+                <Box>
+                  <Typography variant="body2">Show command bar</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Display saved commands above the terminal. The Ctrl+Space menu always
+                    remains available.
+                  </Typography>
+                </Box>
+              }
+            />
+          </Paper>
           {buttons.length === 0 ? (
             <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>
               <Typography variant="body2" color="text.secondary">

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -399,6 +399,18 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
 
     const unregister = registerTerminal(tab.id, {
       focus: () => term.focus(),
+      cursorAnchorPosition: () => {
+        const screen = term.element?.querySelector<HTMLElement>('.xterm-screen');
+        if (!screen || term.cols <= 0 || term.rows <= 0) return undefined;
+        const bounds = screen.getBoundingClientRect();
+        const cursor = term.buffer.active;
+        const column = Math.min(Math.max(cursor.cursorX, 0), term.cols - 1);
+        const row = Math.min(Math.max(cursor.cursorY, 0), term.rows - 1);
+        return {
+          left: Math.round(bounds.left + ((column + 0.5) * bounds.width) / term.cols),
+          top: Math.round(bounds.top + ((row + 1) * bounds.height) / term.rows),
+        };
+      },
       sendInput,
       clear: () => term.clear(),
       selectAll: () => term.selectAll(),

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -51,6 +51,7 @@ const PREFERENCE_KEYS = [
   'confirmCloseConnected',
   'notifyOnNewVersion',
   'commandButtons',
+  'showCommandBar',
   'keywordHighlights',
   'sidebarCollapsed',
   'sidebarWidth',
@@ -653,6 +654,9 @@ export function sanitizePreferences(input: BackupPreferences): Partial<PrefsStat
     input.commandButtons.every(validCommandButton)
   ) {
     output.commandButtons = input.commandButtons;
+  }
+  if (typeof input.showCommandBar === 'boolean') {
+    output.showCommandBar = input.showCommandBar;
   }
   if (
     Array.isArray(input.keywordHighlights) &&

--- a/client/src/keymap/commands.ts
+++ b/client/src/keymap/commands.ts
@@ -299,6 +299,19 @@ export const KEY_COMMANDS: readonly KeyCommand[] = [
     },
   },
   {
+    id: 'terminal.command-menu',
+    title: 'Show saved command menu',
+    category: 'terminal',
+    // Ctrl+Space deliberately takes NUL from the shell: it matches the
+    // MobaXterm macro picker and remains Control (not Command) on macOS.
+    defaultChords: ['Ctrl+Space'],
+    keywords: ['command buttons', 'commands', 'macros', 'MobaXterm'],
+    run: () => {
+      useUiStore.getState().setCommandButtonMenuOpen(true);
+      return true;
+    },
+  },
+  {
     id: 'terminal.find',
     title: 'Find in terminal',
     category: 'terminal',

--- a/client/src/lazy-features.ts
+++ b/client/src/lazy-features.ts
@@ -5,6 +5,7 @@ export const loadFolderDialog = () => import('./components/sidebar/FolderDialog.
 /** Sidebar surfaces that only exist once the user right-clicks or launches. */
 export const loadSidebarMenus = () => import('./components/sidebar/SidebarMenus.js');
 export const loadSettingsDialog = () => import('./components/SettingsDialog.js');
+export const loadCommandButtonMenu = () => import('./components/CommandButtonMenu.js');
 export const loadCommandButtonsDialog = () => import('./components/CommandButtonsDialog.js');
 export const loadShortcutsDialog = () => import('./components/ShortcutsDialog.js');
 export const loadSessionHistoryDialog = () => import('./components/SessionHistoryDialog.js');

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -82,6 +82,8 @@ export interface PrefsState {
   keybindings: Record<string, string[]>;
   /** One-click commands shown in the action bar. */
   commandButtons: CommandButton[];
+  /** Show saved commands as buttons above the terminal in addition to the keyboard menu. */
+  showCommandBar: boolean;
   /** Rules applied to every terminal; hosts may add to or replace these. */
   keywordHighlights: KeywordHighlightRule[];
   /** Whether the whole hosts sidebar is hidden — not to be confused with
@@ -184,6 +186,7 @@ export const usePrefsStore = create<PrefsState>()(
       splitInheritsSession: true,
       keybindings: {},
       commandButtons: [],
+      showCommandBar: true,
       keywordHighlights: [],
       sidebarCollapsed: false,
       sidebarWidth: DEFAULT_SIDEBAR_WIDTH,

--- a/client/src/state/ui.ts
+++ b/client/src/state/ui.ts
@@ -25,6 +25,7 @@ export type FolderDialogState =
 
 interface UiState {
   settingsOpen: boolean;
+  commandButtonMenuOpen: boolean;
   commandButtonsOpen: boolean;
   shortcutsOpen: boolean;
   quickLauncherOpen: boolean;
@@ -42,6 +43,7 @@ interface UiState {
   /** Diagnostic log viewer (settings → debug). */
   logViewerOpen: boolean;
   setSettingsOpen: (open: boolean) => void;
+  setCommandButtonMenuOpen: (open: boolean) => void;
   setCommandButtonsOpen: (open: boolean) => void;
   setShortcutsOpen: (open: boolean) => void;
   setQuickLauncherOpen: (open: boolean) => void;
@@ -57,6 +59,7 @@ interface UiState {
 
 export const useUiStore = create<UiState>()((set) => ({
   settingsOpen: false,
+  commandButtonMenuOpen: false,
   commandButtonsOpen: false,
   shortcutsOpen: false,
   quickLauncherOpen: false,
@@ -69,6 +72,7 @@ export const useUiStore = create<UiState>()((set) => ({
   forwardingOpen: false,
   logViewerOpen: false,
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
+  setCommandButtonMenuOpen: (commandButtonMenuOpen) => set({ commandButtonMenuOpen }),
   setCommandButtonsOpen: (commandButtonsOpen) => set({ commandButtonsOpen }),
   setShortcutsOpen: (shortcutsOpen) => set({ shortcutsOpen }),
   setQuickLauncherOpen: (quickLauncherOpen) => set({ quickLauncherOpen }),

--- a/client/src/terminal/terminal-registry.ts
+++ b/client/src/terminal/terminal-registry.ts
@@ -4,8 +4,15 @@
  * terminal through its handle; the component registers on mount and
  * unregisters on dispose.
  */
+export interface TerminalAnchorPosition {
+  top: number;
+  left: number;
+}
+
 export interface TerminalHandle {
   focus(): void;
+  /** Viewport position immediately below the terminal cursor. */
+  cursorAnchorPosition(): TerminalAnchorPosition | undefined;
   /** Write raw input directly to this terminal's PTY transport. */
   sendInput(data: string | Uint8Array<ArrayBuffer>): boolean;
   /** Clear screen + scrollback. */

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -9,8 +9,8 @@ into several sessions at once.
 
 ## Command buttons
 
-Saved commands appear in a bar above the terminal. One click sends the command to the
-focused session.
+By default, saved commands appear in a bar above the terminal. One click sends the command
+to the focused session.
 
 <figure markdown="span">
   ![The command button bar above a session](../assets/screenshots/command-buttons.png#only-light){ .shadow }
@@ -28,6 +28,9 @@ Insert-only is the appropriate mode for destructive commands.
 
 Buttons are disabled while the focused tab is not connected, and their order is
 configurable.
+
+Turn off **Show command bar** in the command-button manager to reclaim the vertical space
+and use only the keyboard menu. This hides the bar without deleting any saved commands.
 
 ### Keyboard menu
 

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -29,6 +29,16 @@ Insert-only is the appropriate mode for destructive commands.
 Buttons are disabled while the focused tab is not connected, and their order is
 configurable.
 
+### Keyboard menu
+
+Press ++ctrl+space++ to open a compact menu beside the active terminal cursor. Start
+typing to search command labels and command text, use ++up++ and ++down++ to choose a
+result, then press ++enter++ to send it. The menu also links to **Manage command
+buttons** so commands can be added or reordered without reaching for the mouse.
+
+The shortcut is rebindable under **Terminal → Show saved command menu** in the
+[keyboard sheet](../reference/keyboard-shortcuts.md).
+
 ## Multi-execution
 
 Multi-execution mirrors keystrokes into several live terminals at once.

--- a/docs/guide/the-window.md
+++ b/docs/guide/the-window.md
@@ -33,7 +33,7 @@ window controls sit inside it. From left to right:
 | :material-cog: | [Settings](settings.md) |
 
 Below it, an optional **action bar** appears once [command buttons](commands.md) have been
-saved. Each button sends its command to the focused terminal.
+saved and the bar is enabled. Each button sends its command to the focused terminal.
 
 ## Hosts sidebar
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -53,6 +53,7 @@ resetting them.
 | --- | --- |
 | Copy selection | ++ctrl+shift+c++ |
 | Paste | ++ctrl+shift+v++ |
+| Show [saved command menu](../guide/commands.md#keyboard-menu) | ++ctrl+space++ |
 | Find in terminal | ++ctrl+shift+f++ |
 | Select all output | ++ctrl+shift+a++ |
 | Clear scrollback | ++ctrl+shift+k++ |

--- a/tests/unit/client/command-buttons.test.ts
+++ b/tests/unit/client/command-buttons.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import { commandButtonInput } from '../../../client/src/command-buttons.js';
+import {
+  commandButtonInput,
+  filterCommandButtons,
+} from '../../../client/src/command-buttons.js';
+
+const buttons = [
+  { id: 'status', label: 'Service status', command: 'systemctl status nginx', sendEnter: true },
+  { id: 'disk', label: 'Disk usage', command: 'df -h', sendEnter: true },
+  { id: 'restart', label: 'Restart edge', command: 'sudo systemctl restart edge', sendEnter: false },
+];
+
+describe('filterCommandButtons', () => {
+  it('matches labels and command text case-insensitively', () => {
+    expect(filterCommandButtons(buttons, 'DISK')).toEqual([buttons[1]]);
+    expect(filterCommandButtons(buttons, 'systemctl')).toEqual([buttons[0], buttons[2]]);
+  });
+
+  it('requires every search word and preserves the saved order', () => {
+    expect(filterCommandButtons(buttons, 'systemctl edge')).toEqual([buttons[2]]);
+    expect(filterCommandButtons(buttons, '   ')).toBe(buttons);
+  });
+});
 
 describe('commandButtonInput', () => {
   it('appends Enter to commands configured to run immediately', () => {

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -19,7 +19,7 @@ const apiFetchMock = vi.mocked(apiFetch);
 
 beforeEach(() => {
   apiFetchMock.mockReset();
-  usePrefsStore.setState({ notifyOnNewVersion: true });
+  usePrefsStore.setState({ notifyOnNewVersion: true, showCommandBar: true });
 });
 
 const connections = {
@@ -138,13 +138,14 @@ function mockBackupSnapshot(folders: unknown[] = []): void {
 }
 
 describe('backing up preferences', () => {
-  it('includes the update notification choice', async () => {
-    usePrefsStore.setState({ notifyOnNewVersion: false });
+  it('includes display and update-notification choices', async () => {
+    usePrefsStore.setState({ notifyOnNewVersion: false, showCommandBar: false });
     mockBackupSnapshot();
 
     const document = await createBackupDocument();
 
     expect(document.data.preferences.notifyOnNewVersion).toBe(false);
+    expect(document.data.preferences.showCommandBar).toBe(false);
   });
 });
 
@@ -362,6 +363,18 @@ describe('restoring the update notification preference', () => {
     expect(
       sanitizePreferences(prefs({ notifyOnNewVersion: 'disabled' }))
         .notifyOnNewVersion,
+    ).toBeUndefined();
+  });
+});
+
+describe('restoring the command bar preference', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores only boolean visibility choices', () => {
+    expect(sanitizePreferences(prefs({ showCommandBar: false })))
+      .toMatchObject({ showCommandBar: false });
+    expect(
+      sanitizePreferences(prefs({ showCommandBar: 'hidden' })).showCommandBar,
     ).toBeUndefined();
   });
 });

--- a/tests/unit/client/keymap.test.ts
+++ b/tests/unit/client/keymap.test.ts
@@ -19,6 +19,7 @@ import {
   parseChord,
 } from '../../../client/src/keymap/chords.js';
 import { KEY_COMMANDS, keyCommand } from '../../../client/src/keymap/commands.js';
+import { useUiStore } from '../../../client/src/state/ui.js';
 
 const keyEvent = (
   key: string,
@@ -121,6 +122,17 @@ describe('default bindings', () => {
     expect(commandsForChord('Mod+Shift+M').map((command) => command.id)).toEqual([
       'terminal.multi-exec',
     ]);
+  });
+
+  it('opens the saved command menu with Control+Space', () => {
+    useUiStore.getState().setCommandButtonMenuOpen(false);
+    const commands = commandsForChord('Ctrl+Space');
+
+    expect(commands.map((command) => command.id)).toEqual(['terminal.command-menu']);
+    expect(commands[0]?.run()).toBe(true);
+    expect(useUiStore.getState().commandButtonMenuOpen).toBe(true);
+
+    useUiStore.getState().setCommandButtonMenuOpen(false);
   });
 
   it('gives every direction its own split, focus, and move-tab chord', () => {

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -14,6 +14,7 @@ import {
 function handle(sendInput: TerminalHandle['sendInput']): TerminalHandle {
   return {
     focus: vi.fn(),
+    cursorAnchorPosition: () => undefined,
     sendInput,
     clear: vi.fn(),
     selectAll: vi.fn(),


### PR DESCRIPTION
## Summary

- add a rebindable `Ctrl+Space` shortcut for opening saved commands beside the active terminal cursor
- support searchable command labels and command text, plus arrow-key, Enter, and Escape navigation
- preserve each command button's insert-only or run-immediately behavior and keep command management accessible from the menu
- add a persistent **Show command bar** option so the keyboard menu can be used without the bar consuming terminal space
- include the command-bar preference in backup and restore
- document the keyboard workflow and cover the shortcut, filtering, and preference behavior with tests

## Why

Saved command buttons act like lightweight terminal macros. A compact keyboard-first picker makes them faster to find and run without moving focus away from the terminal, while the visibility option lets keyboard-oriented users reclaim the command bar's vertical space.

## Validation

- `pnpm test` — 724 passed, 3 skipped
- `pnpm lint`
- `pnpm check:bundle`
- `pnpm build-docs`
- browser smoke tests covering search focus, multi-word filtering, arrow navigation, command execution, command-bar visibility, persistence across reloads, and continued menu access