### PR TITLE
Add custom terminal background color

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -246,7 +246,9 @@ function AppearanceSection() {
   const prefs = usePrefsStore();
   const zoomInChord = useChordLabel('terminal.zoom-in');
   const zoomOutChord = useChordLabel('terminal.zoom-out');
-  const schemeForeground = terminalScheme(prefs.terminalScheme).theme.foreground ?? '#cccccc';
+  const schemeTheme = terminalScheme(prefs.terminalScheme).theme;
+  const schemeForeground = schemeTheme.foreground ?? '#cccccc';
+  const schemeBackground = schemeTheme.background ?? '#1e1e1e';
 
   return (
     <Stack spacing={3}>
@@ -317,6 +319,39 @@ function AppearanceSection() {
             ])}
           </Select>
         </FormControl>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mt: 2 }}>
+          <Typography variant="body2" color="text.secondary">
+            Background color
+          </Typography>
+          <Box
+            component="input"
+            type="color"
+            aria-label="Background color"
+            value={prefs.backgroundColor || schemeBackground}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              prefs.set({ backgroundColor: event.target.value })
+            }
+            sx={{
+              width: 30,
+              height: 26,
+              p: 0.25,
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 0.75,
+              bgcolor: 'transparent',
+              cursor: 'pointer',
+            }}
+          />
+          {prefs.backgroundColor ? (
+            <Button size="small" onClick={() => prefs.set({ backgroundColor: '' })}>
+              Use scheme color
+            </Button>
+          ) : (
+            <Typography variant="caption" color="text.secondary">
+              Following the color scheme
+            </Typography>
+          )}
+        </Stack>
       </Box>
       <Box>
         <SectionTitle>Font</SectionTitle>

--- a/client/src/components/TerminalView.tsx
+++ b/client/src/components/TerminalView.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense } from 'react';
 import Box from '@mui/material/Box';
 import type { SessionTab } from '../state/tabs.js';
 import { usePrefsStore } from '../state/prefs.js';
-import { terminalScheme } from '../terminal/palette.js';
+import { terminalScheme, themeWithColorOverrides } from '../terminal/palette.js';
 import { loadTerminalViewImpl } from '../lazy-features.js';
 
 const TerminalViewImpl = lazy(loadTerminalViewImpl);
@@ -10,8 +10,14 @@ const TerminalViewImpl = lazy(loadTerminalViewImpl);
 /** Thin Suspense wrapper so xterm and its terminal addons stay off the first paint. */
 export function TerminalView({ tab, active }: { tab: SessionTab; active: boolean }) {
   const schemeId = usePrefsStore((s) => s.terminalScheme);
+  const backgroundColor = usePrefsStore((s) => s.backgroundColor);
+  const background = themeWithColorOverrides(
+    terminalScheme(schemeId).theme,
+    '',
+    backgroundColor,
+  ).background;
   return (
-    <Suspense fallback={<Box sx={{ height: '100%', bgcolor: terminalScheme(schemeId).theme.background }} />}>
+    <Suspense fallback={<Box sx={{ height: '100%', bgcolor: background }} />}>
       <TerminalViewImpl tab={tab} active={active} />
     </Suspense>
   );

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -43,7 +43,7 @@ import { useTabsStore, type SessionTab } from '../state/tabs.js';
 import {
   TERMINAL_MINIMUM_CONTRAST_RATIO,
   terminalScheme,
-  themeWithFontColor,
+  themeWithColorOverrides,
 } from '../terminal/palette.js';
 import { attachCommandTracker } from '../terminal/shell-integration.js';
 import { attachOsc52Clipboard } from '../terminal/osc52-clipboard.js';
@@ -162,8 +162,13 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const scrollback = usePrefsStore((s) => s.scrollback);
   const schemeId = usePrefsStore((s) => s.terminalScheme);
   const fontColor = usePrefsStore((s) => s.fontColor);
+  const backgroundColor = usePrefsStore((s) => s.backgroundColor);
   const globalKeywordHighlights = usePrefsStore((s) => s.keywordHighlights);
   const scheme = terminalScheme(schemeId);
+  const terminalTheme = useMemo(
+    () => themeWithColorOverrides(scheme.theme, fontColor, backgroundColor),
+    [scheme, fontColor, backgroundColor],
+  );
   const { data: sshConfig } = useSshConfig(tab.profile.kind === 'ssh' && tab.profile.useConfig !== false);
   const savedProfileId =
     tab.profile.kind === 'telnet' || tab.profile.kind === 'serial'
@@ -288,7 +293,11 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       allowProposedApi: true,
       // ImageAddon uses a bottom layer for negative-z Kitty placements.
       allowTransparency: true,
-      theme: themeWithFontColor(terminalScheme(prefs.terminalScheme).theme, prefs.fontColor),
+      theme: themeWithColorOverrides(
+        terminalScheme(prefs.terminalScheme).theme,
+        prefs.fontColor,
+        prefs.backgroundColor,
+      ),
       // ANSI uses the same palette entries for foregrounds and backgrounds,
       // so combinations chosen by remote tools are not always legible in
       // every theme. Let xterm adjust only the rendered foreground as needed.
@@ -973,9 +982,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     term.options.cursorBlink = cursorBlink;
     term.options.cursorStyle = cursorStyle;
     term.options.scrollback = scrollback;
-    term.options.theme = themeWithFontColor(scheme.theme, fontColor);
+    term.options.theme = terminalTheme;
     fitTerminal();
-  }, [monoFontSize, fontFamily, lineHeight, cursorBlink, cursorStyle, scrollback, scheme, fontColor, generation]);
+  }, [monoFontSize, fontFamily, lineHeight, cursorBlink, cursorStyle, scrollback, terminalTheme, generation]);
 
   useEffect(() => {
     keywordHighlighterRef.current?.setRules(keywordHighlights);
@@ -1044,7 +1053,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         onContextMenu={onContextMenu}
         sx={{
           height: '100%',
-          bgcolor: scheme.theme.background,
+          bgcolor: terminalTheme.background,
           border: 1,
           borderColor: theme.palette.mode === 'dark' && !scheme.light ? 'transparent' : theme.palette.divider,
           borderRadius: 1,

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -40,6 +40,7 @@ const PREFERENCE_KEYS = [
   'lineHeight',
   'terminalScheme',
   'fontColor',
+  'backgroundColor',
   'scrollback',
   'cursorBlink',
   'cursorStyle',
@@ -617,6 +618,9 @@ export function sanitizePreferences(input: BackupPreferences): Partial<PrefsStat
   }
   if (input.fontColor === '' || validHexColor(input.fontColor)) {
     output.fontColor = input.fontColor;
+  }
+  if (input.backgroundColor === '' || validHexColor(input.backgroundColor)) {
+    output.backgroundColor = input.backgroundColor;
   }
   if (
     Number.isInteger(input.scrollback) &&

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -49,6 +49,8 @@ export interface PrefsState {
   terminalScheme: string;
   /** Terminal text color; empty follows the color scheme's foreground. */
   fontColor: string;
+  /** Terminal background color; empty follows the color scheme's background. */
+  backgroundColor: string;
   /** Scrollback lines kept per terminal. */
   scrollback: number;
   cursorBlink: boolean;
@@ -168,6 +170,7 @@ export const usePrefsStore = create<PrefsState>()(
       lineHeight: 1.0,
       terminalScheme: 'vscode-dark',
       fontColor: '',
+      backgroundColor: '',
       scrollback: 10_000,
       cursorBlink: true,
       cursorStyle: 'block',

--- a/client/src/terminal/palette.ts
+++ b/client/src/terminal/palette.ts
@@ -425,5 +425,21 @@ export function terminalScheme(id: string | undefined): TerminalScheme {
  * so a stale stored value cannot blank the terminal.
  */
 export function themeWithFontColor(theme: ITheme, fontColor: string): ITheme {
-  return /^#[0-9a-f]{6}$/i.test(fontColor) ? { ...theme, foreground: fontColor } : theme;
+  return themeWithColorOverrides(theme, fontColor, '');
+}
+
+/** Apply valid user-selected foreground and background colors to a scheme. */
+export function themeWithColorOverrides(
+  theme: ITheme,
+  fontColor: string,
+  backgroundColor: string,
+): ITheme {
+  const foreground = /^#[0-9a-f]{6}$/i.test(fontColor) ? fontColor : undefined;
+  const background = /^#[0-9a-f]{6}$/i.test(backgroundColor) ? backgroundColor : undefined;
+  if (!foreground && !background) return theme;
+  return {
+    ...theme,
+    ...(foreground ? { foreground } : {}),
+    ...(background ? { background } : {}),
+  };
 }

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -19,7 +19,8 @@ because storage policy should not change under a running recorder.
 - **Application theme**: light, dark, or follow the system.
 - **Interface scale**: the size of the whole window. Terminal text has a separate zoom
   (++ctrl+shift+equal++ / ++ctrl+shift+minus++ / ++ctrl+wheel++).
-- **Terminal colour scheme**: fifteen schemes, grouped into light and dark sets.
+- **Terminal colour scheme**: fifteen schemes, grouped into light and dark sets, with
+  optional text and background colour overrides.
 - **Font**: family, size and line height. JetBrains Mono and the Nerd Font symbols are
   bundled; any other family must be installed on the machine.
 

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -19,7 +19,7 @@ const apiFetchMock = vi.mocked(apiFetch);
 
 beforeEach(() => {
   apiFetchMock.mockReset();
-  usePrefsStore.setState({ notifyOnNewVersion: true });
+  usePrefsStore.setState({ notifyOnNewVersion: true, backgroundColor: '' });
 });
 
 const connections = {
@@ -138,13 +138,14 @@ function mockBackupSnapshot(folders: unknown[] = []): void {
 }
 
 describe('backing up preferences', () => {
-  it('includes the update notification choice', async () => {
-    usePrefsStore.setState({ notifyOnNewVersion: false });
+  it('includes display and update-notification choices', async () => {
+    usePrefsStore.setState({ notifyOnNewVersion: false, backgroundColor: '#102030' });
     mockBackupSnapshot();
 
     const document = await createBackupDocument();
 
     expect(document.data.preferences.notifyOnNewVersion).toBe(false);
+    expect(document.data.preferences.backgroundColor).toBe('#102030');
   });
 });
 
@@ -337,6 +338,25 @@ describe('restoring the font color preference', () => {
     expect(sanitizePreferences(prefs({ fontColor: 'red' })).fontColor).toBeUndefined();
     expect(sanitizePreferences(prefs({ fontColor: '#fff' })).fontColor).toBeUndefined();
     expect(sanitizePreferences(prefs({ fontColor: 42 })).fontColor).toBeUndefined();
+  });
+});
+
+describe('restoring the background color preference', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores a hex override and the explicit scheme-default empty string', () => {
+    expect(sanitizePreferences(prefs({ backgroundColor: '#102030' }))).toMatchObject({
+      backgroundColor: '#102030',
+    });
+    expect(sanitizePreferences(prefs({ backgroundColor: '' }))).toMatchObject({
+      backgroundColor: '',
+    });
+  });
+
+  it('drops a malformed background color rather than importing it', () => {
+    expect(sanitizePreferences(prefs({ backgroundColor: 'black' })).backgroundColor).toBeUndefined();
+    expect(sanitizePreferences(prefs({ backgroundColor: '#000' })).backgroundColor).toBeUndefined();
+    expect(sanitizePreferences(prefs({ backgroundColor: 42 })).backgroundColor).toBeUndefined();
   });
 });
 

--- a/tests/unit/client/terminal-palette.test.ts
+++ b/tests/unit/client/terminal-palette.test.ts
@@ -3,6 +3,7 @@ import {
   TERMINAL_MINIMUM_CONTRAST_RATIO,
   TERMINAL_SCHEMES,
   terminalScheme,
+  themeWithColorOverrides,
   themeWithFontColor,
 } from '../../../client/src/terminal/palette.js';
 
@@ -109,5 +110,34 @@ describe('themeWithFontColor', () => {
     expect(themeWithFontColor(theme, '')).toBe(theme);
     expect(themeWithFontColor(theme, 'orange')).toBe(theme);
     expect(themeWithFontColor(theme, '#ff0')).toBe(theme);
+  });
+});
+
+describe('themeWithColorOverrides', () => {
+  const theme = terminalScheme('vscode-dark').theme;
+
+  it('replaces the foreground and background without mutating the scheme', () => {
+    const overridden = themeWithColorOverrides(theme, '#FF8800', '#102030');
+
+    expect(overridden.foreground).toBe('#FF8800');
+    expect(overridden.background).toBe('#102030');
+    expect(theme.foreground).toBe('#cccccc');
+    expect(theme.background).toBe('#181818');
+  });
+
+  it('applies either valid override independently', () => {
+    expect(themeWithColorOverrides(theme, '', '#102030')).toMatchObject({
+      foreground: theme.foreground,
+      background: '#102030',
+    });
+    expect(themeWithColorOverrides(theme, '#FF8800', '')).toMatchObject({
+      foreground: '#FF8800',
+      background: theme.background,
+    });
+  });
+
+  it('leaves the scheme alone when neither override is valid', () => {
+    expect(themeWithColorOverrides(theme, '', '')).toBe(theme);
+    expect(themeWithColorOverrides(theme, 'orange', '#123')).toBe(theme);
   });
 });


### PR DESCRIPTION
## Summary

- add an optional terminal background color override in Appearance settings
- apply the override immediately to active terminals and loading placeholders
- persist the preference and include it in validated backup and restore data
- document the setting and cover color overrides with unit tests

## Testing

- `pnpm --filter @muxus/tests exec vitest run unit/client/terminal-palette.test.ts unit/client/data-transfer.test.ts`
- `pnpm typecheck`
- scoped `oxlint --deny-warnings`
- `git diff --check`