### PR TITLE
Lower master password minimum to 8 characters

### DIFF
--- a/client/src/components/AuthPromptDialog.tsx
+++ b/client/src/components/AuthPromptDialog.tsx
@@ -46,8 +46,8 @@ export function AuthPromptDialog({
 
   const submit = () => {
     if (request.purpose === 'vault-create') {
-      if (Array.from(answers[0] ?? '').length < 12) {
-        setError('Use at least 12 characters for the master password.');
+      if (Array.from(answers[0] ?? '').length < 8) {
+        setError('Use at least 8 characters for the master password.');
         return;
       }
       if (new TextEncoder().encode(answers[0] ?? '').byteLength > 1024) {

--- a/client/src/components/PasswordVaultSection.tsx
+++ b/client/src/components/PasswordVaultSection.tsx
@@ -330,8 +330,8 @@ function MasterPasswordDialog({
   const proposed = creating ? currentPassword : nextPassword;
 
   const submit = async () => {
-    if ((creating || changing) && Array.from(proposed).length < 12) {
-      setError('Use at least 12 characters for the master password.');
+    if ((creating || changing) && Array.from(proposed).length < 8) {
+      setError('Use at least 8 characters for the master password.');
       return;
     }
     if (
@@ -393,7 +393,7 @@ function MasterPasswordDialog({
         <Stack spacing={2} sx={{ mt: 0.5 }}>
           {creating ? (
             <Typography variant="body2" color="text.secondary">
-              Use at least 12 characters. This password is always required to
+              Use at least 8 characters. This password is always required to
               view or edit saved values.
             </Typography>
           ) : null}

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -68,7 +68,7 @@ An SSH password prompt offers **Remember this password**. A single hidden
 keyboard-interactive field explicitly labelled as a password offers it too, for network
 devices that use keyboard-interactive for password login. The password is saved only
 after authentication succeeds. The first save creates a vault and asks for a master
-password of at least twelve characters. By default, the vault key is kept in the OS
+password of at least eight characters. By default, the vault key is kept in the OS
 credential store, so routine SSH use does not prompt for the master password. In
 **Settings → Passwords**, the policy can instead ask once when Muxus starts or whenever a
 saved credential is needed. The master password is always required to view or edit saved

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -100,7 +100,7 @@ second chord, and defaults are restored in one click. The sheet is also reachabl
 The password vault is optional. New vaults default to the never-prompt policy, which uses
 the operating-system credential store.
 
-- **Create password vault** sets a master password of at least 12 characters.
+- **Create password vault** sets a master password of at least 8 characters.
 - **Change prompt policy** chooses when routine SSH use needs the master password:
   **Never for saved credentials** stores the vault key in the OS credential store,
   **When Muxus starts** unlocks it into memory once, and **Whenever a saved credential is

--- a/server/src/security/password-vault.ts
+++ b/server/src/security/password-vault.ts
@@ -28,7 +28,7 @@ import {
 
 export const PASSWORD_VAULT_PROVIDER = 'muxus-master-vault';
 export const SSH_PASSWORD_SERVICE = 'muxus/ssh-password/v1';
-export const MASTER_PASSWORD_MIN_LENGTH = 12;
+export const MASTER_PASSWORD_MIN_LENGTH = 8;
 export const MASTER_PASSWORD_MAX_BYTES = 1024;
 export const SSH_PASSWORD_MAX_BYTES = 8192;
 

--- a/tests/unit/server/password-vault-routes.test.ts
+++ b/tests/unit/server/password-vault-routes.test.ts
@@ -47,7 +47,7 @@ describe('password vault routes', () => {
       method: 'POST',
       url: '/api/password-vault/create',
       headers: auth(),
-      payload: { password: '12345678901' },
+      payload: { password: '1234567' },
     });
     expect(short.statusCode).toBe(400);
 

--- a/tests/unit/server/password-vault.test.ts
+++ b/tests/unit/server/password-vault.test.ts
@@ -504,12 +504,12 @@ describe('password vault', () => {
     });
   });
 
-  it('accepts twelve-character master passwords and rejects eleven', async () => {
+  it('accepts eight-character master passwords and rejects seven', async () => {
     const store = await setup();
-    await expect(store.create('12345678901')).rejects.toThrow(
+    await expect(store.create('1234567')).rejects.toThrow(
       InvalidMasterPasswordFormatError,
     );
-    await expect(store.create('123456789012')).resolves.toBeUndefined();
+    await expect(store.create('12345678')).resolves.toBeUndefined();
     expect(store.status().unlockPolicy).toBe('never');
   });
 });


### PR DESCRIPTION
## Summary

- lower the password-vault master password minimum from 12 to 8 characters
- update both client-side and server-side validation
- align validation messages, documentation, and boundary tests

## Why

The 12-character restriction was an application policy rather than a macOS, Windows, or Linux credential-store requirement. This change restores an 8-character minimum while keeping the existing scrypt-based vault protection unchanged.

## Impact

Users can create a vault or change its master password using passwords of 8 or more characters. Passwords shorter than 8 characters remain rejected.

## Validation

- `pnpm test` — 729 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`