### PR TITLE
Load installed terminal fonts in Electron

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -69,6 +69,11 @@ import { showErrorToast, showToast } from '../state/toast.js';
 import { confirmAction } from '../state/dialogs.js';
 import { useUiStore } from '../state/ui.js';
 import { TERMINAL_SCHEMES, terminalScheme, type TerminalScheme } from '../terminal/palette.js';
+import {
+  readInstalledTerminalFontFamilies,
+  terminalFontFamilies,
+  terminalFontIsAvailable,
+} from '../terminal/font-catalog.js';
 import { chordSx } from './chord-style.js';
 import { KeywordHighlightRulesEditor } from './KeywordHighlightRulesEditor.js';
 import { SessionLoggingPolicyFields } from './SessionLoggingPolicyFields.js';
@@ -100,19 +105,6 @@ const SECTIONS: Array<{ id: Section; label: string; icon: React.ReactNode }> = [
   { id: 'data', label: 'Backup & data', icon: <BackupOutlinedIcon fontSize="small" /> },
   { id: 'debug', label: 'Debug', icon: <BugReportOutlinedIcon fontSize="small" /> },
   { id: 'about', label: 'About', icon: <InfoOutlinedIcon fontSize="small" /> },
-];
-
-const FONT_PRESETS = [
-  'JetBrains Mono',
-  'Fira Code',
-  'Cascadia Code',
-  'Consolas',
-  'Menlo',
-  'Monaco',
-  'Source Code Pro',
-  'Ubuntu Mono',
-  'DejaVu Sans Mono',
-  'monospace',
 ];
 
 const TERMINAL_SCHEME_GROUPS = [
@@ -244,6 +236,31 @@ function SectionTitle({ children }: { children: string }) {
 
 function AppearanceSection() {
   const prefs = usePrefsStore();
+  const [installedFontFamilies, setInstalledFontFamilies] = useState<readonly string[]>();
+  const [fontCatalogLoading, setFontCatalogLoading] = useState(
+    () => window.muxusDesktop?.listLocalFontFamilies !== undefined,
+  );
+  useEffect(() => {
+    let active = true;
+    void readInstalledTerminalFontFamilies()
+      .then((families) => {
+        if (active) setInstalledFontFamilies(families);
+      })
+      .finally(() => {
+        if (active) setFontCatalogLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+  const fontFamilies = useMemo(
+    () => terminalFontFamilies(installedFontFamilies),
+    [installedFontFamilies],
+  );
+  const selectedFontAvailable = terminalFontIsAvailable(
+    prefs.fontFamily,
+    installedFontFamilies,
+  );
   const zoomInChord = useChordLabel('terminal.zoom-in');
   const zoomOutChord = useChordLabel('terminal.zoom-out');
   const schemeTheme = terminalScheme(prefs.terminalScheme).theme;
@@ -358,14 +375,24 @@ function AppearanceSection() {
         <Stack spacing={2}>
           <Autocomplete
             freeSolo
-            options={FONT_PRESETS}
+            loading={fontCatalogLoading}
+            options={fontFamilies}
             inputValue={prefs.fontFamily}
             onInputChange={(_e, value) => prefs.set({ fontFamily: value })}
             renderInput={(params) => (
               <TextField
                 {...params}
                 label="Font family"
-                helperText="JetBrains Mono and Nerd Font symbols ship with Muxus; other text fonts must be installed on this machine."
+                error={!fontCatalogLoading && selectedFontAvailable === false}
+                helperText={
+                  fontCatalogLoading
+                    ? 'Reading installed fonts…'
+                    : selectedFontAvailable === false
+                      ? `${prefs.fontFamily.trim() || 'This font'} is not installed; JetBrains Mono is being used as the fallback.`
+                      : installedFontFamilies
+                        ? 'JetBrains Mono is bundled; the other choices are installed on this machine.'
+                        : 'JetBrains Mono is bundled; custom font names use the system installation when available.'
+                }
               />
             )}
           />

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -280,9 +280,14 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     }
 
     const prefs = usePrefsStore.getState();
+    const initialFontSize = Math.min(
+      MAX_FONT_SIZE,
+      Math.max(MIN_FONT_SIZE, prefs.monoFontSize + zoomRef.current),
+    );
+    const initialFontStack = terminalFontStack(prefs.fontFamily);
     const term = new Terminal({
-      fontSize: Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, prefs.monoFontSize + zoomRef.current)),
-      fontFamily: terminalFontStack(prefs.fontFamily),
+      fontSize: initialFontSize,
+      fontFamily: initialFontStack,
       lineHeight: prefs.lineHeight,
       cursorBlink: prefs.cursorBlink,
       cursorStyle: prefs.cursorStyle,
@@ -340,12 +345,19 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     // first real size; until then the session keeps xterm's own default.
     let fitted = fitTerminal();
     keywordHighlighterRef.current = attachKeywordHighlighter(term, keywordHighlights);
-    // Webfonts load lazily. Force the bundled Nerd Font face to load, then
-    // repaint any prompt glyphs that arrived while the browser still had a
-    // placeholder face. The text font remains user-selectable; this face is
-    // only reached for Powerline/Nerd Font code points it does not contain.
-    void document.fonts
-      ?.load(`${prefs.monoFontSize}px ${TERMINAL_SYMBOL_FONT}`, '\ue0b0\uf015\uf31b\u276f')
+    // Webfonts load lazily. Wait for both the selected text face and bundled
+    // symbol face, then recalculate cells and repaint anything that arrived
+    // while Chromium was still showing a fallback.
+    void Promise.all([
+      document.fonts.load(
+        `${initialFontSize}px ${initialFontStack}`,
+        '[15:58:10] root@rocker1:~',
+      ),
+      document.fonts.load(
+        `${initialFontSize}px ${TERMINAL_SYMBOL_FONT}`,
+        '\ue0b0\uf015\uf31b\u276f',
+      ),
+    ])
       .then(() => {
         if (termRef.current !== term) return;
         term.refresh(0, term.rows - 1);
@@ -988,14 +1000,33 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   useEffect(() => {
     const term = termRef.current;
     if (!term) return;
-    term.options.fontSize = Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, monoFontSize + zoomRef.current));
-    term.options.fontFamily = terminalFontStack(fontFamily);
+    const nextFontSize = Math.min(
+      MAX_FONT_SIZE,
+      Math.max(MIN_FONT_SIZE, monoFontSize + zoomRef.current),
+    );
+    const nextFontStack = terminalFontStack(fontFamily);
+    term.options.fontSize = nextFontSize;
+    term.options.fontFamily = nextFontStack;
     term.options.lineHeight = lineHeight;
     term.options.cursorBlink = cursorBlink;
     term.options.cursorStyle = cursorStyle;
     term.options.scrollback = scrollback;
     term.options.theme = terminalTheme;
     fitTerminal();
+    void document.fonts
+      .load(`${nextFontSize}px ${nextFontStack}`, '[15:58:10] root@rocker1:~')
+      .then(() => {
+        if (
+          termRef.current !== term ||
+          term.options.fontFamily !== nextFontStack ||
+          term.options.fontSize !== nextFontSize
+        ) {
+          return;
+        }
+        term.refresh(0, term.rows - 1);
+        fitTerminal();
+      })
+      .catch(() => undefined);
   }, [monoFontSize, fontFamily, lineHeight, cursorBlink, cursorStyle, scrollback, terminalTheme, generation]);
 
   useEffect(() => {

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -29,6 +29,8 @@ declare global {
       selectPrivateKey(): Promise<string | undefined>;
       /** Read bookmark-only sessions from the current Windows user's MobaXterm install. */
       readMobaXtermSessions(): Promise<MobaXtermSessionSource | undefined>;
+      /** List font families installed for the current operating-system user. */
+      listLocalFontFamilies(): Promise<string[] | undefined>;
       /** Open a secondary native application window. */
       openWindow(launch: AppWindowLaunch): void;
       /** Subscribe to the OS close-window chord (Cmd/Ctrl+W); returns unsubscribe. */

--- a/client/src/terminal/font-catalog.ts
+++ b/client/src/terminal/font-catalog.ts
@@ -1,0 +1,56 @@
+export const BUNDLED_TERMINAL_FONT_FAMILIES = ['JetBrains Mono'] as const;
+export const GENERIC_TERMINAL_FONT_FAMILIES = ['monospace'] as const;
+
+const MAX_FONT_FAMILY_LENGTH = 200;
+
+function normalizedFamily(family: string): string {
+  let value = family.trim();
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    value = value.slice(1, -1).trim();
+  }
+  return value.toLowerCase();
+}
+
+/** Bundled, installed and generic terminal fonts without case-only duplicates. */
+export function terminalFontFamilies(installed: readonly string[] = []): string[] {
+  const families = new Map<string, string>();
+  const add = (family: string) => {
+    const trimmed = family.trim();
+    if (!trimmed || trimmed.length > MAX_FONT_FAMILY_LENGTH) return;
+    families.set(normalizedFamily(trimmed), trimmed);
+  };
+
+  for (const family of BUNDLED_TERMINAL_FONT_FAMILIES) add(family);
+  for (const family of [...installed].sort((left, right) => left.localeCompare(right))) {
+    if (!families.has(normalizedFamily(family))) add(family);
+  }
+  for (const family of GENERIC_TERMINAL_FONT_FAMILIES) add(family);
+  return [...families.values()];
+}
+
+/** Undefined means the browser could not enumerate local fonts. */
+export function terminalFontIsAvailable(
+  family: string,
+  installed: readonly string[] | undefined,
+): boolean | undefined {
+  const selected = normalizedFamily(family);
+  if (!selected) return true;
+  if (
+    [...BUNDLED_TERMINAL_FONT_FAMILIES, ...GENERIC_TERMINAL_FONT_FAMILIES].some(
+      (candidate) => normalizedFamily(candidate) === selected,
+    )
+  ) {
+    return true;
+  }
+  if (installed === undefined) return undefined;
+  return installed.some((candidate) => normalizedFamily(candidate) === selected);
+}
+
+/** Read the host font catalog through Electron's isolated preload bridge. */
+export function readInstalledTerminalFontFamilies(): Promise<string[] | undefined> {
+  return window.muxusDesktop?.listLocalFontFamilies?.() ?? Promise.resolve(undefined);
+}

--- a/client/src/terminal/font-catalog.ts
+++ b/client/src/terminal/font-catalog.ts
@@ -1,6 +1,22 @@
 export const BUNDLED_TERMINAL_FONT_FAMILIES = ['JetBrains Mono'] as const;
 export const GENERIC_TERMINAL_FONT_FAMILIES = ['monospace'] as const;
 
+const CSS_GENERIC_FONT_FAMILIES = new Set([
+  'serif',
+  'sans-serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'ui-serif',
+  'ui-sans-serif',
+  'ui-monospace',
+  'ui-rounded',
+  'emoji',
+  'math',
+  'fangsong',
+]);
+
 const MAX_FONT_FAMILY_LENGTH = 200;
 
 function normalizedFamily(family: string): string {
@@ -13,6 +29,17 @@ function normalizedFamily(family: string): string {
     value = value.slice(1, -1).trim();
   }
   return value.toLowerCase();
+}
+
+function isCssGenericFamily(family: string): boolean {
+  const trimmed = family.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return false;
+  }
+  return CSS_GENERIC_FONT_FAMILIES.has(trimmed.toLowerCase());
 }
 
 /** Bundled, installed and generic terminal fonts without case-only duplicates. */
@@ -40,9 +67,9 @@ export function terminalFontIsAvailable(
   const selected = normalizedFamily(family);
   if (!selected) return true;
   if (
-    [...BUNDLED_TERMINAL_FONT_FAMILIES, ...GENERIC_TERMINAL_FONT_FAMILIES].some(
+    BUNDLED_TERMINAL_FONT_FAMILIES.some(
       (candidate) => normalizedFamily(candidate) === selected,
-    )
+    ) || isCssGenericFamily(family)
   ) {
     return true;
   }

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -21,8 +21,9 @@ because storage policy should not change under a running recorder.
   (++ctrl+shift+equal++ / ++ctrl+shift+minus++ / ++ctrl+wheel++).
 - **Terminal colour scheme**: fifteen schemes, grouped into light and dark sets, with
   optional text and background colour overrides.
-- **Font**: family, size and line height. JetBrains Mono and the Nerd Font symbols are
-  bundled; any other family must be installed on the machine.
+- **Font**: family, size and line height. The desktop selector includes JetBrains Mono,
+  which is bundled, plus the font families installed for the current operating-system
+  user. Nerd Font symbols remain an automatic bundled fallback.
 
 ## Terminal
 

--- a/docs/guide/terminal.md
+++ b/docs/guide/terminal.md
@@ -32,8 +32,10 @@ correctly and low-contrast remote colour choices stay readable.
 
 The bundled stack is JetBrains Mono plus a **Nerd Font / Powerline** symbol face, so
 Starship prompts, `lsd`, `eza` icons and TUI box drawing render without a local font
-install. `fontFamily` accepts any installed family; the symbol face remains as a fallback
-for missing glyphs.
+install. In the desktop app, the font selector reads the families installed for the
+current operating-system user. `fontFamily` also accepts a custom family name; the
+bundled text and symbol faces remain as fallbacks when it is unavailable or lacks a
+glyph.
 
 <figure markdown="span">
   ![The colour scheme and font settings](../assets/screenshots/settings.png#only-light){ .shadow }

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -33,6 +33,42 @@ const windowLaunch: AppWindowLaunch | undefined = (() => {
   }
 })();
 
+interface LocalFontData {
+  family?: unknown;
+}
+
+type QueryLocalFonts = () => Promise<LocalFontData[]>;
+
+let localFontFamilies: Promise<string[] | undefined> | undefined;
+
+/**
+ * Chromium owns the cross-platform OS-font lookup. Keep the fingerprintable
+ * result inside the trusted desktop app and expose family names only.
+ */
+function listLocalFontFamilies(): Promise<string[] | undefined> {
+  localFontFamilies ??= (async () => {
+    const fontWindow = globalThis as typeof globalThis & {
+      queryLocalFonts?: QueryLocalFonts;
+    };
+    const query = fontWindow.queryLocalFonts;
+    if (!query) return undefined;
+    try {
+      const fonts = await query.call(fontWindow);
+      const families = new Map<string, string>();
+      for (const font of fonts) {
+        if (typeof font.family !== 'string') continue;
+        const family = font.family.trim();
+        if (!family || family.length > 200) continue;
+        families.set(family.toLowerCase(), family);
+      }
+      return [...families.values()].sort((left, right) => left.localeCompare(right));
+    } catch {
+      return undefined;
+    }
+  })();
+  return localFontFamilies;
+}
+
 // The disk-side write failed in the main process: mirror the snapshot into
 // origin-scoped localStorage so a relaunch on the same origin can migrate it
 // back (muxusStateStorage.getItem reads browser storage when the desktop
@@ -83,6 +119,8 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   readMobaXtermSessions(): Promise<MobaXtermSessionSource | undefined> {
     return ipcRenderer.invoke('muxus:read-mobaxterm-sessions');
   },
+  /** List font families exposed by the operating system to Chromium. */
+  listLocalFontFamilies,
   openWindow(launch: AppWindowLaunch): void {
     ipcRenderer.send('muxus:open-window', launch);
   },

--- a/tests/unit/client/terminal-fonts.test.ts
+++ b/tests/unit/client/terminal-fonts.test.ts
@@ -23,4 +23,26 @@ describe('terminal font catalog', () => {
     expect(terminalFontIsAvailable('DejaVu Sans Mono', [])).toBe(false);
     expect(terminalFontIsAvailable('DejaVu Sans Mono', undefined)).toBeUndefined();
   });
+
+  it('recognizes CSS generic families without requiring local enumeration', () => {
+    for (const family of [
+      'serif',
+      'sans-serif',
+      'monospace',
+      'cursive',
+      'fantasy',
+      'system-ui',
+      'ui-serif',
+      'ui-sans-serif',
+      'ui-monospace',
+      'ui-rounded',
+      'emoji',
+      'math',
+      'fangsong',
+    ]) {
+      expect(terminalFontIsAvailable(family, []), family).toBe(true);
+    }
+    expect(terminalFontIsAvailable('UI-MONOSPACE', [])).toBe(true);
+    expect(terminalFontIsAvailable('"ui-monospace"', [])).toBe(false);
+  });
 });

--- a/tests/unit/client/terminal-fonts.test.ts
+++ b/tests/unit/client/terminal-fonts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  terminalFontFamilies,
+  terminalFontIsAvailable,
+} from '../../../client/src/terminal/font-catalog.js';
+
+describe('terminal font catalog', () => {
+  it('combines bundled, installed and generic families without duplicates', () => {
+    expect(
+      terminalFontFamilies([
+        'Ubuntu Mono',
+        'DejaVu Sans Mono',
+        'jetbrains mono',
+        ' DejaVu Sans Mono ',
+        '',
+      ]),
+    ).toEqual(['JetBrains Mono', 'DejaVu Sans Mono', 'Ubuntu Mono', 'monospace']);
+  });
+
+  it('reports unavailable selections only when enumeration succeeded', () => {
+    expect(terminalFontIsAvailable('JetBrains Mono', [])).toBe(true);
+    expect(terminalFontIsAvailable('"DejaVu Sans Mono"', ['DejaVu Sans Mono'])).toBe(true);
+    expect(terminalFontIsAvailable('DejaVu Sans Mono', [])).toBe(false);
+    expect(terminalFontIsAvailable('DejaVu Sans Mono', undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- enumerate installed OS font families through the isolated Electron preload bridge
- replace static font presets with bundled and installed font options
- warn when a selected family is unavailable and JetBrains Mono is active as the fallback
- wait for selected text and symbol fonts before refreshing and refitting xterm
- add font catalog tests and update the documentation

## Why

The static selector offered families such as DejaVu Sans Mono even when they were not installed for the operating-system user. In that case Chromium silently fell back to bundled JetBrains Mono, making the selection appear ineffective. Live changes could also refresh before a font had finished loading.

## Impact

Desktop users can select every font family Electron can read from the OS alongside bundled JetBrains Mono. Missing custom families are identified instead of silently looking unchanged, and open terminals refresh after the selected face is ready.

## Validation

- `pnpm test` — 731 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build-docs`
- client and Electron builds
- automated Electron smoke test confirmed 247 system families and 249 selector options