### PR TITLE
Improve multiline paste confirmation

### DIFF
--- a/client/src/components/PasteConfirmDialog.tsx
+++ b/client/src/components/PasteConfirmDialog.tsx
@@ -1,63 +1,144 @@
+import { useMemo, useRef, useState, type UIEvent } from 'react';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { pasteLineCount } from '../terminal/paste-safety.js';
 
-const MAX_PREVIEW_LINES = 12;
-
 export function PasteConfirmDialog({
-  text,
+  initialText,
   onCancel,
   onConfirm,
 }: {
-  text: string | null;
+  initialText: string;
   onCancel: () => void;
   onConfirm: (text: string) => void;
 }) {
-  const lines = text?.split(/\r\n|\r|\n/) ?? [];
-  const lineCount = text === null ? 0 : pasteLineCount(text);
-  const preview = lines.slice(0, MAX_PREVIEW_LINES).join('\n');
-  const hidden = Math.max(0, lines.length - MAX_PREVIEW_LINES);
+  const [text, setText] = useState(initialText);
+  const pasteButtonRef = useRef<HTMLButtonElement>(null);
+  const lineNumbersRef = useRef<HTMLPreElement>(null);
+  const lineCount = text.length === 0 ? 0 : pasteLineCount(text);
+  const visibleLineCount = Math.max(1, lineCount);
+  const lineNumbers = useMemo(
+    () => Array.from({ length: visibleLineCount }, (_, index) => index + 1).join('\n'),
+    [visibleLineCount],
+  );
+  const gutterWidth = 30 + String(visibleLineCount).length * 8;
+
+  const syncLineNumberScroll = (scrollTop: number) => {
+    if (lineNumbersRef.current) {
+      lineNumbersRef.current.style.transform = `translateY(${-scrollTop}px)`;
+    }
+  };
 
   return (
-    <Dialog open={text !== null} onClose={onCancel} maxWidth="sm" fullWidth>
-      <DialogTitle>Paste {lineCount} lines into the terminal?</DialogTitle>
+    <Dialog
+      open
+      onClose={onCancel}
+      maxWidth="md"
+      fullWidth
+      slotProps={{ transition: { onEntered: () => pasteButtonRef.current?.focus() } }}
+    >
+      <DialogTitle>
+        {lineCount === 0 ? 'Nothing to paste' : `Paste ${lineCount} lines into the terminal?`}
+      </DialogTitle>
       <DialogContent>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-          Multiple lines may run several commands immediately. Review the content before sending it.
+          Multiple lines may run several commands immediately. Review or edit the content before sending it.
         </Typography>
-        <Typography
-          component="pre"
-          sx={{
-            m: 0,
-            p: 1.5,
-            maxHeight: 280,
-            overflow: 'auto',
-            borderRadius: 1,
-            bgcolor: 'action.hover',
-            border: 1,
-            borderColor: 'divider',
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: 12,
-            whiteSpace: 'pre-wrap',
-            overflowWrap: 'anywhere',
-          }}
-        >
-          {preview}
-          {hidden > 0 ? `\n… ${hidden} more line${hidden === 1 ? '' : 's'}` : ''}
+        <Box sx={{ position: 'relative' }}>
+          <Box
+            aria-hidden
+            sx={{
+              position: 'absolute',
+              zIndex: 1,
+              top: 1,
+              bottom: 1,
+              left: 1,
+              width: gutterWidth,
+              overflow: 'hidden',
+              pointerEvents: 'none',
+              bgcolor: 'action.hover',
+              borderRight: 1,
+              borderColor: 'divider',
+              borderRadius: '3px 0 0 3px',
+            }}
+          >
+            <Box
+              ref={lineNumbersRef}
+              component="pre"
+              data-testid="paste-line-numbers"
+              sx={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                m: 0,
+                pt: '16.5px',
+                pr: 1.25,
+                color: 'text.disabled',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: 12,
+                lineHeight: 1.5,
+                textAlign: 'right',
+                userSelect: 'none',
+                willChange: 'transform',
+              }}
+            >
+              {lineNumbers}
+            </Box>
+          </Box>
+          <TextField
+            value={text}
+            onChange={(event) => {
+              setText(event.target.value);
+              syncLineNumberScroll(event.currentTarget.scrollTop);
+            }}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter' || (!event.ctrlKey && !event.metaKey)) return;
+              event.preventDefault();
+              if (text.length > 0) onConfirm(text);
+            }}
+            multiline
+            minRows={8}
+            maxRows={18}
+            fullWidth
+            slotProps={{
+              htmlInput: {
+                'aria-label': 'Content to paste',
+                spellCheck: false,
+                wrap: 'off',
+                onScroll: (event: UIEvent<HTMLTextAreaElement>) =>
+                  syncLineNumberScroll(event.currentTarget.scrollTop),
+              },
+            }}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                pl: `${gutterWidth + 12}px`,
+              },
+              '& .MuiInputBase-inputMultiline': {
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: 12,
+                lineHeight: 1.5,
+              },
+            }}
+          />
+        </Box>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          Enter adds a new line while editing. Press Ctrl+Enter or ⌘Enter to paste.
         </Typography>
       </DialogContent>
       <DialogActions>
         <Button onClick={onCancel}>Cancel</Button>
         <Button
+          ref={pasteButtonRef}
           variant="contained"
           color="warning"
-          onClick={() => {
-            if (text !== null) onConfirm(text);
-          }}
+          disabled={text.length === 0}
+          onClick={() => onConfirm(text)}
         >
           Paste
         </Button>

--- a/client/src/components/PasteConfirmDialog.tsx
+++ b/client/src/components/PasteConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, type UIEvent } from 'react';
+import { useLayoutEffect, useRef, useState, type UIEvent } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -7,7 +7,28 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { pasteLineNumberWindow } from '../terminal/paste-line-numbers.js';
 import { pasteLineCount } from '../terminal/paste-safety.js';
+
+function updateLineNumberGutter(
+  gutter: HTMLPreElement | null,
+  lineCount: number,
+  scrollTop: number,
+  lineHeightPx: number,
+) {
+  if (!gutter) return;
+  const window = pasteLineNumberWindow(lineCount, scrollTop, lineHeightPx);
+  if (gutter.textContent !== window.labels) gutter.textContent = window.labels;
+  gutter.style.transform = `translateY(${-window.offsetPx}px)`;
+}
+
+function measureEditorLineHeight(textArea: HTMLTextAreaElement, lineCount: number): number {
+  if (lineCount > 1 && textArea.scrollHeight > textArea.clientHeight) {
+    return textArea.scrollHeight / lineCount;
+  }
+  const measured = Number.parseFloat(getComputedStyle(textArea).lineHeight);
+  return Number.isFinite(measured) && measured > 0 ? measured : 18;
+}
 
 export function PasteConfirmDialog({
   initialText,
@@ -21,19 +42,25 @@ export function PasteConfirmDialog({
   const [text, setText] = useState(initialText);
   const pasteButtonRef = useRef<HTMLButtonElement>(null);
   const lineNumbersRef = useRef<HTMLPreElement>(null);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const lineHeightRef = useRef(18);
   const lineCount = text.length === 0 ? 0 : pasteLineCount(text);
   const visibleLineCount = Math.max(1, lineCount);
-  const lineNumbers = useMemo(
-    () => Array.from({ length: visibleLineCount }, (_, index) => index + 1).join('\n'),
-    [visibleLineCount],
-  );
+  const initialLineNumbers = pasteLineNumberWindow(visibleLineCount, 0).labels;
   const gutterWidth = 30 + String(visibleLineCount).length * 8;
 
-  const syncLineNumberScroll = (scrollTop: number) => {
-    if (lineNumbersRef.current) {
-      lineNumbersRef.current.style.transform = `translateY(${-scrollTop}px)`;
+  useLayoutEffect(() => {
+    const textArea = textAreaRef.current;
+    if (textArea) {
+      lineHeightRef.current = measureEditorLineHeight(textArea, visibleLineCount);
     }
-  };
+    updateLineNumberGutter(
+      lineNumbersRef.current,
+      visibleLineCount,
+      textArea?.scrollTop ?? 0,
+      lineHeightRef.current,
+    );
+  }, [visibleLineCount]);
 
   return (
     <Dialog
@@ -88,15 +115,13 @@ export function PasteConfirmDialog({
                 willChange: 'transform',
               }}
             >
-              {lineNumbers}
+              {initialLineNumbers}
             </Box>
           </Box>
           <TextField
+            inputRef={textAreaRef}
             value={text}
-            onChange={(event) => {
-              setText(event.target.value);
-              syncLineNumberScroll(event.currentTarget.scrollTop);
-            }}
+            onChange={(event) => setText(event.target.value)}
             onKeyDown={(event) => {
               if (event.key !== 'Enter' || (!event.ctrlKey && !event.metaKey)) return;
               event.preventDefault();
@@ -111,8 +136,18 @@ export function PasteConfirmDialog({
                 'aria-label': 'Content to paste',
                 spellCheck: false,
                 wrap: 'off',
-                onScroll: (event: UIEvent<HTMLTextAreaElement>) =>
-                  syncLineNumberScroll(event.currentTarget.scrollTop),
+                onScroll: (event: UIEvent<HTMLTextAreaElement>) => {
+                  lineHeightRef.current = measureEditorLineHeight(
+                    event.currentTarget,
+                    visibleLineCount,
+                  );
+                  updateLineNumberGutter(
+                    lineNumbersRef.current,
+                    visibleLineCount,
+                    event.currentTarget.scrollTop,
+                    lineHeightRef.current,
+                  );
+                },
               },
             }}
             sx={{

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -1333,15 +1333,17 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       </Menu>
       <AuthPromptDialog request={authPrompt} onSubmit={answerAuth} />
       <HostKeyDialog request={hostKey} onAnswer={answerHostKey} />
-      <PasteConfirmDialog
-        text={pendingPaste}
-        onCancel={() => setPendingPaste(null)}
-        onConfirm={(text) => {
-          setPendingPaste(null);
-          termRef.current?.paste(text);
-          termRef.current?.focus();
-        }}
-      />
+      {pendingPaste !== null ? (
+        <PasteConfirmDialog
+          initialText={pendingPaste}
+          onCancel={() => setPendingPaste(null)}
+          onConfirm={(text) => {
+            setPendingPaste(null);
+            termRef.current?.paste(text);
+            termRef.current?.focus();
+          }}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/client/src/terminal/paste-line-numbers.ts
+++ b/client/src/terminal/paste-line-numbers.ts
@@ -1,0 +1,35 @@
+const EDITOR_LINE_HEIGHT_PX = 18;
+const MAX_RENDERED_LINE_NUMBERS = 20;
+
+export interface PasteLineNumberWindow {
+  labels: string;
+  offsetPx: number;
+}
+
+/** Return only the line-number labels visible in the fixed-height paste editor. */
+export function pasteLineNumberWindow(
+  lineCount: number,
+  scrollTop: number,
+  lineHeightPx = EDITOR_LINE_HEIGHT_PX,
+): PasteLineNumberWindow {
+  const boundedLineCount = Math.max(1, Math.floor(lineCount));
+  const boundedScrollTop = Math.max(0, scrollTop);
+  const boundedLineHeight =
+    Number.isFinite(lineHeightPx) && lineHeightPx > 0 ? lineHeightPx : EDITOR_LINE_HEIGHT_PX;
+  const firstIndex = Math.min(
+    Math.floor(boundedScrollTop / boundedLineHeight),
+    boundedLineCount - 1,
+  );
+  const endIndex = Math.min(boundedLineCount, firstIndex + MAX_RENDERED_LINE_NUMBERS);
+
+  let labels = '';
+  for (let index = firstIndex; index < endIndex; index += 1) {
+    if (labels) labels += '\n';
+    labels += String(index + 1);
+  }
+
+  return {
+    labels,
+    offsetPx: boundedScrollTop - firstIndex * boundedLineHeight,
+  };
+}

--- a/client/src/terminal/paste-safety.ts
+++ b/client/src/terminal/paste-safety.ts
@@ -3,5 +3,15 @@ export function requiresPasteConfirmation(text: string): boolean {
 }
 
 export function pasteLineCount(text: string): number {
-  return text.split(/\r\n|\r|\n/).length;
+  let count = 1;
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code === 10) {
+      count += 1;
+    } else if (code === 13) {
+      count += 1;
+      if (text.charCodeAt(index + 1) === 10) index += 1;
+    }
+  }
+  return count;
 }

--- a/tests/unit/client/paste-line-numbers.test.ts
+++ b/tests/unit/client/paste-line-numbers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { pasteLineNumberWindow } from '../../../client/src/terminal/paste-line-numbers.js';
+
+describe('paste line-number window', () => {
+  it('renders at most the visible gutter window for a very large paste', () => {
+    const window = pasteLineNumberWindow(1_000_000, 0);
+
+    expect(window.labels.split('\n')).toHaveLength(20);
+    expect(window.labels).toMatch(/^1\n2\n/);
+    expect(window.labels).toMatch(/\n19\n20$/);
+    expect(window.offsetPx).toBe(0);
+  });
+
+  it('moves the bounded window to match the editor scroll position', () => {
+    const window = pasteLineNumberWindow(1_000_000, 999_980 * 18 + 7);
+    const labels = window.labels.split('\n');
+
+    expect(labels).toHaveLength(20);
+    expect(labels[0]).toBe('999981');
+    expect(labels.at(-1)).toBe('1000000');
+    expect(window.offsetPx).toBe(7);
+  });
+
+  it('uses the measured editor line height when the interface is scaled', () => {
+    const window = pasteLineNumberWindow(1_000, 981 * 21.3571, 21.3571);
+    const labels = window.labels.split('\n');
+
+    expect(labels[0]).toBe('982');
+    expect(labels.at(-1)).toBe('1000');
+    expect(window.offsetPx).toBeCloseTo(0);
+  });
+});

--- a/tests/unit/client/paste-safety.test.ts
+++ b/tests/unit/client/paste-safety.test.ts
@@ -16,4 +16,8 @@ describe('terminal paste safety', () => {
       expect(pasteLineCount(text)).toBe(2);
     }
   });
+
+  it('counts a very large paste without allocating a line array', () => {
+    expect(pasteLineCount('line\n'.repeat(100_000))).toBe(100_001);
+  });
 });


### PR DESCRIPTION
## Summary

- replace the read-only multiline paste preview with an editable command buffer
- add synchronized logical line numbers and scrolling for long pastes
- focus the Paste action so Return confirms immediately, while Ctrl/Cmd+Enter confirms from the editor
- keep bracketed-paste handling unchanged so confirmation and shell execution remain separate

## User impact

Users can review and correct multiline commands directly before sending them, navigate long pastes with stable line numbers, and confirm without reaching for the mouse.

Addresses #58.

## Validation

- `pnpm lint`
- `pnpm --filter @muxus/client build`
- `pnpm test` — 737 passed, 3 skipped
- browser verification for initial focus, editing, line-number scrolling, Ctrl+Enter confirmation, and delivery to the terminal