### PR TITLE
Handle SSH console compatibility automatically

### DIFF
--- a/client/src/api/ssh-config.ts
+++ b/client/src/api/ssh-config.ts
@@ -74,6 +74,9 @@ export function useUpdateSshMetadata(onSuccess?: (metadata: OpenSshProfileMetada
               ...(patch.keywordHighlights !== undefined
                 ? { keywordHighlights: patch.keywordHighlights ?? undefined }
                 : {}),
+              ...(patch.disableSftp !== undefined
+                ? { disableSftp: patch.disableSftp || undefined }
+                : {}),
             };
             return { ...host, metadata };
           }),

--- a/client/src/components/HostEditorDialog.tsx
+++ b/client/src/components/HostEditorDialog.tsx
@@ -211,6 +211,7 @@ function SshHostEditorContent({
         displayName: draft.displayName.trim() || null,
         group: draft.group.trim() || null,
         color: draft.color ?? null,
+        disableSftp: draft.disableSftp,
         keywordHighlights:
           highlights.inheritGlobal && highlights.rules.length === 0 ? null : highlights,
       },
@@ -274,7 +275,12 @@ function SshHostEditorContent({
     { value: 'forwards', label: 'Port forwarding', icon: <SwapHorizOutlinedIcon fontSize="small" />, count: draft.forwards.length },
     { value: 'logging', label: 'Session logging', icon: <HistoryOutlinedIcon fontSize="small" /> },
     { value: 'highlighting', label: 'Highlighting', icon: <HighlightOutlinedIcon fontSize="small" />, count: draft.keywordHighlights.rules.length },
-    { value: 'advanced', label: 'Advanced', icon: <CodeOutlinedIcon fontSize="small" />, count: draft.extras.length },
+    {
+      value: 'advanced',
+      label: 'Advanced',
+      icon: <CodeOutlinedIcon fontSize="small" />,
+      count: draft.extras.length + (draft.disableSftp ? 1 : 0),
+    },
   ];
 
   return (

--- a/client/src/components/QuickLauncherDialog.tsx
+++ b/client/src/components/QuickLauncherDialog.tsx
@@ -172,7 +172,11 @@ export function QuickLauncherDialog() {
   const history = historyResult.data?.sessions ?? EMPTY_HISTORY;
   const activeTab = tabs.find((tab) => tab.id === activeId);
   const activeConnected = activeTab?.profile && activeTab.status === 'connected';
-  const activeSsh = activeConnected && activeTab.profile.kind === 'ssh' && !!activeTab.connId;
+  const activeSsh =
+    activeConnected &&
+    activeTab.profile.kind === 'ssh' &&
+    !!activeTab.connId &&
+    activeTab.sftpAvailable !== false;
   const liveCount = tabs.filter(
     (tab) =>
       tab.profile &&

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -276,7 +276,12 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     if (!el) return;
     const shouldConnect = generation > 0;
     if (shouldConnect) {
-      updateTab(tab.id, { status: 'connecting', connId: undefined });
+      updateTab(tab.id, {
+        status: 'connecting',
+        connId: undefined,
+        sftpAvailable: undefined,
+        sftpOpen: false,
+      });
     }
 
     const prefs = usePrefsStore.getState();
@@ -740,6 +745,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             waitingForTerminalOutput = tab.transferId
               ? false
               : shouldWaitForTerminalOutput(tab.profile.kind, receivedTerminalOutput);
+            const sftpAvailable =
+              tab.profile.kind === 'ssh' ? ctl.sftpAvailable !== false : undefined;
             updateTab(tab.id, {
               status: transportSuspect
                 ? 'interrupted'
@@ -750,6 +757,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               disconnectReason: undefined,
               // Only SSH transport IDs are valid SFTP/forwarding lease keys.
               connId: tab.profile.kind === 'ssh' ? ctl.connId : undefined,
+              sftpAvailable,
+              ...(sftpAvailable === false ? { sftpOpen: false } : {}),
               transferId: undefined,
             });
             if (tab.transferId) completeTabTransfer(tab.transferId);

--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -1,8 +1,10 @@
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -41,6 +43,24 @@ export function AdvancedSection({
 
   return (
     <Stack spacing={2}>
+      <Stack spacing={0.5}>
+        <Typography variant="subtitle2">Console compatibility</Typography>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={draft.disableSftp}
+              onChange={(event) => set({ disableSftp: event.target.checked })}
+            />
+          }
+          label="Disable SFTP for this host"
+        />
+        <Typography variant="caption" color="text.secondary">
+          Opens a plain SSH shell without SFTP or Unix shell-integration probes. Muxus normally
+          detects incompatible console servers after one safe retry; enable this to skip the first
+          probe entirely.
+        </Typography>
+      </Stack>
+
       <Stack spacing={1}>
         <Typography variant="body2" color="text.secondary">
           Raw ssh_config options for algorithm policies, environment variables, known-hosts files,

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -24,6 +24,8 @@ export interface HostDraft {
   displayName: string;
   group: string;
   color?: string;
+  /** Muxus-only console compatibility: never request SFTP or shell integration. */
+  disableSftp: boolean;
   /** Target config file; '' keeps the block's file (or the root for new hosts). */
   file: string;
   hostname: string;
@@ -61,6 +63,7 @@ export function blankDraft(prefillTarget = ''): HostDraft {
     displayName: '',
     group: '',
     color: undefined,
+    disableSftp: false,
     file: '',
     hostname: parsed?.host ?? '',
     user: parsed?.user ?? '',
@@ -99,6 +102,7 @@ export function draftFromEntry(entry: SshHostEntry, duplicate: boolean): HostDra
     displayName: duplicate ? '' : (entry.metadata?.displayName ?? ''),
     group: entry.metadata?.group ?? '',
     color: entry.metadata?.color,
+    disableSftp: entry.metadata?.disableSftp ?? false,
     file: entry.file,
     hostname: o.hostname ?? '',
     user: o.user ?? '',

--- a/client/src/components/sidebar/host-details.ts
+++ b/client/src/components/sidebar/host-details.ts
@@ -16,6 +16,7 @@ export function hostDetailLines(host: ManagedHost): string[] {
     lines.push(`Key ${resolved.identityFiles.map((file) => file.split(/[\\/]/).pop()).join(', ')}`);
   }
   if (resolved.passwordOnly) lines.push('Password authentication');
+  if (host.entry.metadata?.disableSftp) lines.push('SFTP disabled');
   if (resolved.forwards.length > 0) {
     lines.push(
       `${resolved.forwards.length} port forward${resolved.forwards.length > 1 ? 's' : ''} on connect`,

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -436,6 +436,7 @@ function portableMetadata(
     color: metadata.color,
     icon: metadata.icon,
     keywordHighlights: metadata.keywordHighlights,
+    disableSftp: metadata.disableSftp,
     sortOrder: metadata.sortOrder,
   };
 }
@@ -586,6 +587,7 @@ function metadataPatch(metadata: PortableHostMetadata): OpenSshMetadataPatch {
     color: metadata.color ?? null,
     icon: metadata.icon ?? null,
     keywordHighlights: metadata.keywordHighlights ?? null,
+    disableSftp: metadata.disableSftp ?? false,
   };
 }
 

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -209,7 +209,7 @@ function PaneCanvas({
                 <EmptyPane onAddHost={onAddHost} replaceTabId={tab.id} />
               )}
             </Box>
-            {visible && tab.sftpOpen && tab.connId && (
+            {visible && tab.sftpOpen && tab.sftpAvailable !== false && tab.connId && (
               <ErrorBoundary label="The file browser">
                 <Suspense fallback={null}>
                   <SftpPanel

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -80,7 +80,7 @@ export const TopBar = memo(function TopBar() {
   const requestSearch = useTabsStore((s) => s.requestSearch);
   const { data: forwardsData } = useForwards();
   const activeForwards = forwardsData?.forwards.length ?? 0;
-  const sshReady = !!activeTab?.connId;
+  const sshReady = !!activeTab?.connId && activeTab.sftpAvailable !== false;
   const terminalReady = !!activeTab?.profile;
   const [terminalMenu, setTerminalMenu] = useState<HTMLElement | null>(null);
   const sidebarChord = useChordLabel('app.sidebar');

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -34,6 +34,8 @@ interface TabBase {
   transferId?: string;
   /** SFTP file panel visible for this tab. */
   sftpOpen: boolean;
+  /** Server-advertised capability for the current SSH transport. */
+  sftpAvailable?: boolean;
   /** Monotonic UI signal consumed by the mounted terminal search bar. */
   searchRequest: number;
   /** User-set color flag marking the tab. */
@@ -83,6 +85,7 @@ type TabUpdate = Partial<{
   terminalId: string | undefined;
   transferId: string | undefined;
   sftpOpen: boolean;
+  sftpAvailable: boolean | undefined;
   color: string | undefined;
   loggingEnabled: boolean | undefined;
   sessionLogId: string | undefined;
@@ -368,6 +371,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           connectOnMount: true as const,
           connId: undefined,
           sftpOpen: false,
+          sftpAvailable: undefined,
           searchRequest: 0,
           editorPaths: [],
           activeEditorPath: undefined,
@@ -743,6 +747,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           restored: true,
           status: tab.connectOnMount ? 'connecting' as const : 'closed' as const,
           sftpOpen: false,
+          sftpAvailable: undefined,
           searchRequest: 0,
           editorPaths: [],
           activeEditorPath: undefined,
@@ -860,7 +865,13 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
       tabs: state.tabs.map((tab) => {
         if (tab.id !== id) return tab;
         if (tab.profile) return { ...tab, ...patch };
-        const { status: _status, connId: _connId, sftpOpen: _sftpOpen, ...emptyPatch } = patch;
+        const {
+          status: _status,
+          connId: _connId,
+          sftpOpen: _sftpOpen,
+          sftpAvailable: _sftpAvailable,
+          ...emptyPatch
+        } = patch;
         return { ...tab, ...emptyPatch };
       }),
     })),

--- a/docs/guide/adding-hosts.md
+++ b/docs/guide/adding-hosts.md
@@ -95,6 +95,15 @@ Two per-host overrides of the global [settings](settings.md):
 
 ## Advanced
 
+Muxus does not request SFTP unless its initial probe identifies a supported Unix shell. If a
+console server disconnects when it sees even that probe, Muxus reconnects once in plain-console
+mode and remembers the compatibility choice until the app restarts. No manual setting is required
+for the session to connect.
+
+For known-sensitive SSH console servers and network appliances, **Disable SFTP for this host**
+skips the initial probe as well. This persistent override avoids the first reconnect entirely.
+The file-browser controls are unavailable for plain-console sessions.
+
 Any other keyword OpenSSH understands is entered here as free-form option/value pairs. The
 panel shows the **exact block** that will be written.
 

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -106,6 +106,8 @@ or to a new group file that Muxus creates and adds an `Include` for.
 Its own database holds only what OpenSSH has no field for:
 
 - display name, folder, colour and sidebar order;
+- the per-host SFTP/console-compatibility override (Muxus also falls back to plain-console mode
+  automatically when optional shell-integration setup disconnects a transport);
 - per-host keyword-highlighting rules and session-logging policy;
 - last-connected timestamps and connection counts;
 - workspaces, saved tunnels, and saved Telnet/serial hosts;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -93,6 +93,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   const connections = new SshConnectionManager(app.log, {
     vault,
     folderAuth: folderAuthResolver(database),
+    disableSftpForHost: (alias) => database.sftpDisabledForAlias(alias),
   });
   const forwards = new ForwardManager(connections, app.log);
   const historySettings = database.sessionHistorySettings();

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -373,6 +373,15 @@ const MIGRATIONS = [
         CHECK(is_locked IN (0, 1));
     `,
   },
+  {
+    version: 19,
+    name: 'host-disable-sftp',
+    sql: `
+      ALTER TABLE connection_profiles
+        ADD COLUMN disable_sftp INTEGER NOT NULL DEFAULT 0
+        CHECK(disable_sftp IN (0, 1));
+    `,
+  },
 ] as const;
 
 function migrateDraftPasswordVault(db: DatabaseSync): void {
@@ -452,6 +461,7 @@ export interface OpenSshMetadata {
   color?: string;
   icon?: string;
   keywordHighlights?: HostKeywordHighlightConfig;
+  disableSftp?: boolean;
   lastConnectedAt?: string;
   connectCount: number;
 }
@@ -631,6 +641,7 @@ export class MuxusDatabase {
         profiles.color,
         profiles.icon,
         profiles.keyword_highlights_json,
+        profiles.disable_sftp,
         profiles.last_connected_at,
         profiles.connect_count,
         groups.name AS group_name
@@ -667,6 +678,12 @@ export class MuxusDatabase {
     return row ? optionalString(row.group_name) : undefined;
   }
 
+  /** Whether this OpenSSH alias must avoid SFTP and Unix shell probing. */
+  sftpDisabledForAlias(alias: string): boolean {
+    const row = this.metadataByAlias.get(alias);
+    return Number(row?.disable_sftp) === 1;
+  }
+
   updateOpenSshMetadata(
     alias: string,
     patch: OpenSshMetadataPatch,
@@ -685,6 +702,7 @@ export class MuxusDatabase {
             color = ?,
             icon = ?,
             keyword_highlights_json = ?,
+            disable_sftp = ?,
             updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
       `)
@@ -698,6 +716,11 @@ export class MuxusDatabase {
           : patch.keywordHighlights === null
             ? null
             : JSON.stringify(patch.keywordHighlights),
+        patch.disableSftp === undefined
+          ? Number(current.disable_sftp)
+          : patch.disableSftp
+            ? 1
+            : 0,
         String(current.id),
       );
     return metadataFromRow(this.metadataByAlias.get(alias)!);
@@ -1147,6 +1170,7 @@ export class MuxusDatabase {
             color = ?,
             icon = ?,
             keyword_highlights_json = ?,
+            disable_sftp = ?,
             updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
       `)
@@ -1160,6 +1184,11 @@ export class MuxusDatabase {
           : patch.keywordHighlights === null
             ? null
             : JSON.stringify(patch.keywordHighlights),
+        patch.disableSftp === undefined
+          ? Number(current.disable_sftp)
+          : patch.disableSftp
+            ? 1
+            : 0,
         id,
       );
     return this.savedHostProfile(id)!;
@@ -1952,6 +1981,7 @@ function metadataFromRow(row: SqlRow): OpenSshMetadata {
     color: optionalString(row.color),
     icon: optionalString(row.icon),
     keywordHighlights: keywordHighlightsFromJson(row.keyword_highlights_json),
+    ...(Number(row.disable_sftp) === 1 ? { disableSftp: true } : {}),
     lastConnectedAt: optionalString(row.last_connected_at),
     connectCount: Number(row.connect_count),
   };
@@ -1973,6 +2003,7 @@ function savedHostFromRow(row: SqlRow): SavedHostProfile {
       color: optionalString(row.color),
       icon: optionalString(row.icon),
       keywordHighlights: keywordHighlightsFromJson(row.keyword_highlights_json),
+      ...(Number(row.disable_sftp) === 1 ? { disableSftp: true } : {}),
       lastConnectedAt: optionalString(row.last_connected_at),
       connectCount: Number(row.connect_count),
     },

--- a/server/src/routes/metadata-schema.ts
+++ b/server/src/routes/metadata-schema.ts
@@ -26,5 +26,6 @@ export const metadataPatchSchema = z
     color: z.string().max(64).nullable().optional(),
     icon: z.string().max(64).nullable().optional(),
     keywordHighlights: hostKeywordHighlightsSchema.nullable().optional(),
+    disableSftp: z.boolean().optional(),
   })
   .refine((patch) => Object.keys(patch).length > 0, 'at least one metadata field is required');

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -46,7 +46,10 @@ import {
   type TransportLease,
 } from './connection-leases.js';
 import { connectionAlgorithms } from './algorithms.js';
-import { openIntegratedRemoteShell } from './remote-shell-integration.js';
+import {
+  openIntegratedRemoteShell,
+  RemoteShellTransportLostError,
+} from './remote-shell-integration.js';
 import {
   CredentialVaultCorruptError,
   InvalidMasterPasswordError,
@@ -126,6 +129,8 @@ export interface ManagedConnection {
   muxKey: string;
   /** Concrete OpenSSH alias eligible for Muxus-owned recent-use metadata. */
   metadataAlias?: string;
+  /** Whether callers may open SFTP channels on this transport. */
+  sftpAvailable: boolean;
   /** *Forward lines resolved from ssh config — auto-started once the session is up. */
   configForwards: ConfigForward[];
   /** Current passive keepalive health of the transport. */
@@ -246,9 +251,12 @@ export class SshConnectionManager {
   private readonly postAuth = new WeakMap<Client, Promise<void>>();
   /** In-flight dials by mux key, so simultaneous sessions share one TCP connection and one auth round-trip. */
   private readonly pendingDials = new Map<string, Promise<ManagedConnection>>();
+  /** Dial plans whose optional integration setup killed the remote transport; reset on app restart. */
+  private readonly automaticPlainShellKeys = new Set<string>();
   private readonly loadConfig: () => ConfigDocument;
   private readonly vault: PasswordVault | undefined;
   private readonly folderAuth: FolderAuthLookup | undefined;
+  private readonly disableSftpForHost: ((alias: string) => boolean) | undefined;
   private readonly agentOperationTimeoutMs: number;
   private readonly agentWaitStatusMs: number;
   readonly knownHosts: KnownHostsStore;
@@ -261,6 +269,8 @@ export class SshConnectionManager {
       vault?: PasswordVault;
       /** Folder-inherited connection defaults per alias (Muxus sidebar folders). */
       folderAuth?: FolderAuthLookup;
+      /** Muxus-owned per-host compatibility setting; never written to ssh_config. */
+      disableSftpForHost?: (alias: string) => boolean;
       /** Test seam; production uses the exported responsive-agent defaults. */
       agentOperationTimeoutMs?: number;
       /** Test seam; production uses the exported responsive-agent defaults. */
@@ -271,6 +281,7 @@ export class SshConnectionManager {
     this.loadConfig = options.loadConfig ?? (() => loadConfigDocument());
     this.vault = options.vault;
     this.folderAuth = options.folderAuth;
+    this.disableSftpForHost = options.disableSftpForHost;
     this.agentOperationTimeoutMs =
       options.agentOperationTimeoutMs ?? DEFAULT_AGENT_OPERATION_TIMEOUT_MS;
     this.agentWaitStatusMs =
@@ -296,6 +307,7 @@ export class SshConnectionManager {
       port: conn.port,
       user: conn.user,
       metadataAlias: conn.metadataAlias,
+      sftpAvailable: conn.sftpAvailable,
     }));
   }
 
@@ -312,12 +324,19 @@ export class SshConnectionManager {
     profile: SshProfile,
     io: ConnectIo,
     owner: ConnectionLeaseOwner = 'terminal',
-    opts: { freshTransport?: boolean } = {},
+    opts: { freshTransport?: boolean; forcePlainShell?: boolean } = {},
   ): Promise<MuxedConnectionLease> {
     const doc = this.loadConfig();
     const chain = buildChain(doc, profile, this.folderAuth);
-    const key = muxKey(chain);
     const target = chain[chain.length - 1]!;
+    const metadataAlias =
+      profile.useConfig === false ? undefined : findMetadataAlias(doc, target.spec.host);
+    const regularKey = muxKey(chain, false);
+    const disableSftp =
+      (metadataAlias ? (this.disableSftpForHost?.(metadataAlias) ?? false) : false) ||
+      this.automaticPlainShellKeys.has(regularKey) ||
+      opts.forcePlainShell === true;
+    const key = muxKey(chain, disableSftp);
     const configForwards = target.resolved.forwards;
     const label = `${target.user}@${target.resolved.hostname}:${target.port}`;
     this.log.debug(
@@ -351,7 +370,15 @@ export class SshConnectionManager {
       }
     }
 
-    const dial = this.dialChain(doc, chain, profile, io, owner, key);
+    const dial = this.dialChain(
+      chain,
+      profile,
+      io,
+      owner,
+      key,
+      metadataAlias,
+      disableSftp,
+    );
     const tracked = dial.then((lease) => lease.connection);
     tracked.catch(() => undefined); // waiters observe the rejection through their own await
     this.pendingDials.set(key, tracked);
@@ -400,6 +427,9 @@ export class SshConnectionManager {
       return { lease, stream, transport: lease.reused ? 'shared' : 'new' };
     } catch (err) {
       lease.release();
+      if (err instanceof RemoteShellTransportLostError) {
+        return this.retryPlainShell(profile, io, cols, rows, term, lease, 'new', err);
+      }
       if (!lease.reused) throw err;
       this.log.info(
         { host: lease.connection.host, err: String(err) },
@@ -412,18 +442,71 @@ export class SshConnectionManager {
         return { lease: dedicated, stream, transport: 'overflow' };
       } catch (retryErr) {
         dedicated.release();
+        if (retryErr instanceof RemoteShellTransportLostError) {
+          return this.retryPlainShell(
+            profile,
+            io,
+            cols,
+            rows,
+            term,
+            dedicated,
+            'overflow',
+            retryErr,
+          );
+        }
         throw retryErr;
       }
     }
   }
 
+  private async retryPlainShell(
+    profile: SshProfile,
+    io: ConnectIo,
+    cols: number,
+    rows: number,
+    term: string,
+    failed: MuxedConnectionLease,
+    transport: TerminalShell['transport'],
+    error: RemoteShellTransportLostError,
+  ): Promise<TerminalShell> {
+    // A probe-triggered disconnect can happen for config aliases and direct
+    // profiles alike. The non-compatibility mux key is therefore the stable
+    // runtime identity to remember, without silently persisting host edits.
+    this.automaticPlainShellKeys.add(failed.connection.muxKey);
+    this.log.info(
+      { host: failed.connection.host, err: error.transportError ?? error },
+      'remote shell integration disconnected the transport; retrying as a plain console',
+    );
+    io.status(
+      'This server rejected SSH shell integration — reconnecting in plain-console mode …',
+      { transient: true },
+    );
+    const compatible = await this.connect(profile, io, 'terminal', {
+      freshTransport: true,
+      forcePlainShell: true,
+    });
+    try {
+      const stream = await compatible.connection.shell(
+        cols,
+        rows,
+        term,
+        sessionSettings(compatible.target.resolved),
+      );
+      return { lease: compatible, stream, transport };
+    } catch (retryError) {
+      compatible.release();
+      throw retryError;
+    }
+  }
+
   private async dialChain(
-    doc: ConfigDocument,
     chain: ChainHop[],
     profile: SshProfile,
     io: ConnectIo,
     owner: ConnectionLeaseOwner,
     key: string,
+    metadataAlias: string | undefined,
+    disableSftp: boolean,
   ): Promise<ConnectionLease> {
     const clients: Client[] = [];
     const postAuth: Promise<void>[] = [];
@@ -482,8 +565,6 @@ export class SshConnectionManager {
     const target = chain[chain.length - 1]!;
     const client = clients[clients.length - 1]!;
     const jumpClients = clients.slice(0, -1);
-    const metadataAlias =
-      profile.useConfig === false ? undefined : findMetadataAlias(doc, target.spec.host);
     const id = nanoid(10);
     const closeListeners = new Set<(reason?: string) => void>();
     const postAuthSettled = Promise.all(postAuth).then(() => undefined);
@@ -521,6 +602,7 @@ export class SshConnectionManager {
       user: target.user,
       muxKey: key,
       metadataAlias,
+      sftpAvailable: !disableSftp,
       health: () => transportHealth,
       configForwards: target.resolved.forwards,
       shell: async (cols, rows, term, session = sessionSettings(target.resolved)) => {
@@ -530,7 +612,7 @@ export class SshConnectionManager {
         if (session.remoteCommand) {
           return openSessionExec(client, session.remoteCommand, pty, session.env);
         }
-        if (pty) {
+        if (pty && !disableSftp) {
           const integrated = await openIntegratedRemoteShell(client, getSftp, pty, session.env);
           if (integrated) return integrated;
         }
@@ -541,7 +623,10 @@ export class SshConnectionManager {
         });
       },
       // One SFTP channel per connection, shared by every file operation.
-      sftp: getSftp,
+      sftp: () =>
+        disableSftp
+          ? Promise.reject(new Error('SFTP is disabled for this host.'))
+          : getSftp(),
       onHealth: (listener) => {
         healthListeners.add(listener);
         if (transportHealth === 'suspect') {
@@ -851,14 +936,15 @@ export class SshConnectionManager {
  * deliberately absent — they matter while establishing a transport, not for
  * attaching to an established one.
  */
-export function muxKey(chain: ChainHop[]): string {
+export function muxKey(chain: ChainHop[], disableSftp = false): string {
   const hops = chain.map(
     (hop) =>
       `${hop.user}@${hop.resolved.hostname}:${hop.port};agentForward=${hop.resolved.forwardAgent ? 'yes' : 'no'}`,
   );
   const first = chain[0];
   const proxy = first?.resolved.proxyCommand ? expandedProxyCommand(first) : undefined;
-  return (proxy ? [`proxy(${proxy})`, ...hops] : hops).join(' -> ');
+  const key = (proxy ? [`proxy(${proxy})`, ...hops] : hops).join(' -> ');
+  return disableSftp ? `${key};muxusSftp=disabled` : key;
 }
 
 function mergeConfigForwards(

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -47,7 +47,7 @@ import {
 } from './connection-leases.js';
 import { connectionAlgorithms } from './algorithms.js';
 import {
-  openIntegratedRemoteShell,
+  openRemoteShell,
   RemoteShellTransportLostError,
 } from './remote-shell-integration.js';
 import {
@@ -613,8 +613,7 @@ export class SshConnectionManager {
           return openSessionExec(client, session.remoteCommand, pty, session.env);
         }
         if (pty && !disableSftp) {
-          const integrated = await openIntegratedRemoteShell(client, getSftp, pty, session.env);
-          if (integrated) return integrated;
+          return openRemoteShell(client, getSftp, pty, session.env);
         }
         return new Promise((resolve, reject) => {
           client.shell(pty ?? false, { env: session.env }, (err, stream) =>

--- a/server/src/ssh/remote-shell-integration.ts
+++ b/server/src/ssh/remote-shell-integration.ts
@@ -59,9 +59,9 @@ type SupportedShell = {
 
 /**
  * The server dropped the whole SSH transport while Muxus was attempting the
- * optional Unix shell-integration setup. ConnectionManager uses this narrow
- * signal to redial once as a plain console session; ordinary channel
- * rejections still fall through to a plain shell on the existing transport.
+ * optional Unix shell-integration setup or transitioning to its plain-shell
+ * fallback. ConnectionManager uses this narrow signal to redial once as a
+ * plain console session; ordinary channel rejections remain ordinary errors.
  */
 export class RemoteShellTransportLostError extends Error {
   constructor(readonly transportError?: Error) {
@@ -71,16 +71,17 @@ export class RemoteShellTransportLostError extends Error {
 }
 
 /**
- * Open a zsh/bash SSH session with the same OSC 133 command lifecycle
- * reporting as local terminals. Returns undefined when the remote cannot
- * support the bootstrap so callers can open a normal shell instead.
+ * Open a remote shell, adding OSC 133 integration for supported zsh/bash
+ * hosts and falling back to a normal shell everywhere else. Transport-loss
+ * observation spans both phases: some console servers close the probe channel
+ * first and only disconnect the SSH transport while the plain shell opens.
  */
-export async function openIntegratedRemoteShell(
+export async function openRemoteShell(
   client: Client,
   getSftp: () => Promise<SFTPWrapper>,
   pty: PseudoTtyOptions,
   env?: Record<string, string>,
-): Promise<ClientChannel | undefined> {
+): Promise<ClientChannel> {
   let transportLost = false;
   let transportError: Error | undefined;
   const onTransportError = (error: Error) => {
@@ -94,25 +95,49 @@ export async function openIntegratedRemoteShell(
   client.once('close', onTransportClose);
   client.once('end', onTransportClose);
   try {
-    // Do not speculatively open SFTP against console appliances. Many expose
-    // only a plain shell channel and some disconnect the whole transport when
-    // an unsupported subsystem is requested.
-    const shell = await probeShell(client);
-    if (!shell) {
-      if (transportLost) throw new RemoteShellTransportLostError(transportError);
-      return undefined;
-    }
-    const sftp = await getSftp();
-    const root = await installIntegration(sftp, shell);
-    return await openExec(client, remoteShellCommand(shell, root), { pty, ...(env ? { env } : {}) });
-  } catch {
+    const integrated = await tryOpenIntegratedRemoteShell(client, getSftp, pty, env);
+    if (integrated) return integrated;
     if (transportLost) throw new RemoteShellTransportLostError(transportError);
-    return undefined;
+
+    try {
+      return await openShell(client, pty, env);
+    } catch (error) {
+      if (transportLost || isDisconnectedError(error)) {
+        throw new RemoteShellTransportLostError(
+          transportError ?? (error instanceof Error ? error : undefined),
+        );
+      }
+      throw error;
+    }
   } finally {
     client.off('error', onTransportError);
     client.off('close', onTransportClose);
     client.off('end', onTransportClose);
   }
+}
+
+async function tryOpenIntegratedRemoteShell(
+  client: Client,
+  getSftp: () => Promise<SFTPWrapper>,
+  pty: PseudoTtyOptions,
+  env?: Record<string, string>,
+): Promise<ClientChannel | undefined> {
+  try {
+    // Do not speculatively open SFTP against console appliances. Many expose
+    // only a plain shell channel and some disconnect the whole transport when
+    // an unsupported subsystem is requested.
+    const shell = await probeShell(client);
+    if (!shell) return undefined;
+    const sftp = await getSftp();
+    const root = await installIntegration(sftp, shell);
+    return await openExec(client, remoteShellCommand(shell, root), { pty, ...(env ? { env } : {}) });
+  } catch {
+    return undefined;
+  }
+}
+
+function isDisconnectedError(error: unknown): boolean {
+  return error instanceof Error && /^(?:Not connected|Connection lost)/.test(error.message);
 }
 
 export function parseShellProbe(output: string): SupportedShell | undefined {
@@ -230,6 +255,18 @@ function openExec(
       error ? reject(error) : resolve(channel);
     if (options) client.exec(command, options, callback);
     else client.exec(command, callback);
+  });
+}
+
+function openShell(
+  client: Client,
+  pty: PseudoTtyOptions,
+  env?: Record<string, string>,
+): Promise<ClientChannel> {
+  return new Promise((resolve, reject) => {
+    client.shell(pty, { env }, (error, channel) =>
+      error ? reject(error) : resolve(channel),
+    );
   });
 }
 

--- a/server/src/ssh/remote-shell-integration.ts
+++ b/server/src/ssh/remote-shell-integration.ts
@@ -58,6 +58,19 @@ type SupportedShell = {
 };
 
 /**
+ * The server dropped the whole SSH transport while Muxus was attempting the
+ * optional Unix shell-integration setup. ConnectionManager uses this narrow
+ * signal to redial once as a plain console session; ordinary channel
+ * rejections still fall through to a plain shell on the existing transport.
+ */
+export class RemoteShellTransportLostError extends Error {
+  constructor(readonly transportError?: Error) {
+    super('SSH transport was lost during remote shell integration setup.');
+    this.name = 'RemoteShellTransportLostError';
+  }
+}
+
+/**
  * Open a zsh/bash SSH session with the same OSC 133 command lifecycle
  * reporting as local terminals. Returns undefined when the remote cannot
  * support the bootstrap so callers can open a normal shell instead.
@@ -68,15 +81,37 @@ export async function openIntegratedRemoteShell(
   pty: PseudoTtyOptions,
   env?: Record<string, string>,
 ): Promise<ClientChannel | undefined> {
+  let transportLost = false;
+  let transportError: Error | undefined;
+  const onTransportError = (error: Error) => {
+    transportLost = true;
+    transportError = error;
+  };
+  const onTransportClose = () => {
+    transportLost = true;
+  };
+  client.once('error', onTransportError);
+  client.once('close', onTransportClose);
+  client.once('end', onTransportClose);
   try {
-    // Shell detection and SFTP channel setup are independent network
-    // round-trips, so overlap them on the same SSH transport.
-    const [shell, sftp] = await Promise.all([probeShell(client), getSftp()]);
-    if (!shell) return undefined;
+    // Do not speculatively open SFTP against console appliances. Many expose
+    // only a plain shell channel and some disconnect the whole transport when
+    // an unsupported subsystem is requested.
+    const shell = await probeShell(client);
+    if (!shell) {
+      if (transportLost) throw new RemoteShellTransportLostError(transportError);
+      return undefined;
+    }
+    const sftp = await getSftp();
     const root = await installIntegration(sftp, shell);
     return await openExec(client, remoteShellCommand(shell, root), { pty, ...(env ? { env } : {}) });
   } catch {
+    if (transportLost) throw new RemoteShellTransportLostError(transportError);
     return undefined;
+  } finally {
+    client.off('error', onTransportError);
+    client.off('close', onTransportClose);
+    client.off('end', onTransportClose);
   }
 }
 

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -378,7 +378,13 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
       dialLease.release();
       return;
     }
-    sendControl(socket, { op: 'ready', connId: conn.id, host: conn.host, user: conn.user });
+    sendControl(socket, {
+      op: 'ready',
+      connId: conn.id,
+      host: conn.host,
+      user: conn.user,
+      sftpAvailable: conn.sftpAvailable,
+    });
     return;
   }
 
@@ -606,7 +612,13 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
       app.log.warn({ err, target: conn.metadataAlias }, 'could not record recent connection');
     }
   }
-  sendControl(socket, { op: 'ready', connId: conn.id, host: conn.host, user: conn.user });
+  sendControl(socket, {
+    op: 'ready',
+    connId: conn.id,
+    host: conn.host,
+    user: conn.user,
+    sftpAvailable: conn.sftpAvailable,
+  });
 }
 
 /** Attach a byte transport to the terminal socket with shared flow control. */

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -425,6 +425,8 @@ export interface OpenSshProfileMetadata {
   icon?: string;
   /** Muxus-only terminal highlighting for this OpenSSH alias. */
   keywordHighlights?: HostKeywordHighlightConfig;
+  /** Do not open SFTP channels or probe for remote Unix shell integration. */
+  disableSftp?: boolean;
   lastConnectedAt?: string;
   connectCount: number;
 }
@@ -435,6 +437,7 @@ export interface OpenSshMetadataPatch {
   color?: string | null;
   icon?: string | null;
   keywordHighlights?: HostKeywordHighlightConfig | null;
+  disableSftp?: boolean;
 }
 
 /**
@@ -766,6 +769,8 @@ export interface ConnectionInfo {
   user: string;
   /** Config alias when the target matches a Host block in ~/.ssh/config. */
   metadataAlias?: string;
+  /** False when this transport belongs to a host with SFTP disabled. */
+  sftpAvailable: boolean;
 }
 
 export interface ConnectionsResponse {

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -191,8 +191,8 @@ export type TerminalServerMessage =
       /** Set when this is an intermediate ProxyJump hop, not the final target. */
       hop?: string;
     }
-  /** Transport attached; SSH connIds also key follow-up SFTP/forward calls. */
-  | { op: 'ready'; connId: string; host?: string; user?: string }
+  /** Transport attached; SSH connIds also key follow-up SFTP/forward calls when available. */
+  | { op: 'ready'; connId: string; host?: string; user?: string; sftpAvailable?: boolean }
   /** Current durable-log state, emitted at start and after every live change. */
   | {
       op: 'logging-state';

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -287,6 +287,7 @@ describe('restoring imported serial hosts', () => {
           color: null,
           icon: null,
           keywordHighlights: null,
+          disableSftp: false,
         }),
       }),
     );

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -71,7 +71,25 @@ describe('SSH host editor draft', () => {
     expect(draft.requestTty).toBe('inherit');
     expect(draft.strictHostKeyChecking).toBe('inherit');
     expect(draft.identitiesOnly).toBe(true);
+    expect(draft.disableSftp).toBe(false);
     expect(draftToRequest(draft).options.proxyCommand).toBeUndefined();
+  });
+
+  it('loads the Muxus-only SFTP compatibility setting', () => {
+    const draft = draftFromEntry(
+      {
+        ...entry,
+        metadata: {
+          profileId: 'profile-cloud',
+          connectCount: 0,
+          disableSftp: true,
+        },
+      },
+      false,
+    );
+
+    expect(draft.disableSftp).toBe(true);
+    expect(draftToRequest(draft).options).not.toHaveProperty('disableSftp');
   });
 
   it('makes the specific-key promise independent of the SSH agent', () => {

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -29,6 +29,8 @@ writeFileSync(emptyConfig, '');
 interface ServerStats {
   connections: number;
   auths: number;
+  execs: number;
+  sftpRequests: number;
   shells: number;
 }
 
@@ -37,12 +39,21 @@ interface ServerStats {
  * per-connection shell cap (the MaxSessions failure mode), and rejected
  * exec/sftp probes so the manager falls back to plain shells.
  */
-function startServer(opts: { maxShellsPerConnection?: number } = {}): Promise<{
+function startServer(opts: {
+  maxShellsPerConnection?: number;
+  disconnectOnExec?: boolean;
+} = {}): Promise<{
   server: Server;
   port: number;
   stats: ServerStats;
 }> {
-  const stats: ServerStats = { connections: 0, auths: 0, shells: 0 };
+  const stats: ServerStats = {
+    connections: 0,
+    auths: 0,
+    execs: 0,
+    sftpRequests: 0,
+    shells: 0,
+  };
   const server = new Server({ hostKeys: [HOST_KEY] }, (conn) => {
     stats.connections += 1;
     let shells = 0;
@@ -62,11 +73,19 @@ function startServer(opts: { maxShellsPerConnection?: number } = {}): Promise<{
         // Empty probe output means "no integrated shell" — the manager then
         // opens a plain shell, which is what these tests exercise.
         session.on('exec', (acceptExec) => {
+          stats.execs += 1;
+          if (opts.disconnectOnExec) {
+            conn.end();
+            return;
+          }
           const stream = acceptExec();
           stream.exit(0);
           stream.end();
         });
-        session.on('sftp', (_acceptSftp, rejectSftp) => rejectSftp?.());
+        session.on('sftp', (_acceptSftp, rejectSftp) => {
+          stats.sftpRequests += 1;
+          rejectSftp?.();
+        });
         session.on('shell', (acceptShell, rejectShell) => {
           if (shells >= (opts.maxShellsPerConnection ?? Number.POSITIVE_INFINITY)) {
             rejectShell?.();
@@ -87,7 +106,10 @@ function startServer(opts: { maxShellsPerConnection?: number } = {}): Promise<{
 }
 
 let knownHostsCounter = 0;
-function makeManager(configFile = emptyConfig): SshConnectionManager {
+function makeManager(
+  configFile = emptyConfig,
+  disableSftpForHost?: (alias: string) => boolean,
+): SshConnectionManager {
   const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
   return new SshConnectionManager(log as never, {
     knownHosts: new KnownHostsStore(
@@ -95,6 +117,7 @@ function makeManager(configFile = emptyConfig): SshConnectionManager {
       path.join(tmp, 'no-global-known-hosts'),
     ),
     loadConfig: () => loadConfigDocument(configFile),
+    disableSftpForHost,
   });
 }
 
@@ -259,6 +282,115 @@ describe('SSH connection multiplexing', () => {
     expect(a.reused).toBe(false);
     expect(b.reused).toBe(false);
     expect(b.connection.id).not.toBe(a.connection.id);
+    expect(started.stats.connections).toBe(2);
+  }, 15_000);
+
+  it('opens a plain shell without probes when SFTP is disabled for the host', async () => {
+    const started = await startServer();
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-console-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host console',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+      ].join('\n'),
+    );
+    manager = makeManager(configFile, (alias) => alias === 'console');
+
+    const shell = await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(shell.lease.connection.sftpAvailable).toBe(false);
+    expect(started.stats).toMatchObject({ execs: 0, sftpRequests: 0, shells: 1 });
+    await expect(shell.lease.connection.sftp()).rejects.toThrow(
+      'SFTP is disabled for this host.',
+    );
+    expect(started.stats.sftpRequests).toBe(0);
+  }, 15_000);
+
+  it('automatically redials in plain-console mode when integration drops the transport', async () => {
+    const started = await startServer({ disconnectOnExec: true });
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-auto-console-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host console',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+      ].join('\n'),
+    );
+    manager = makeManager(configFile);
+
+    const first = await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(first.transport).toBe('new');
+    expect(first.lease.connection.sftpAvailable).toBe(false);
+    expect(started.stats).toMatchObject({ connections: 2, execs: 1, sftpRequests: 0, shells: 1 });
+
+    // The inference is remembered for this manager lifetime, so subsequent
+    // sessions reuse the compatible transport without probing again.
+    const second = await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+    expect(second.transport).toBe('shared');
+    expect(second.lease.connection.id).toBe(first.lease.connection.id);
+    expect(started.stats).toMatchObject({ connections: 2, execs: 1, sftpRequests: 0, shells: 2 });
+    await expect(second.lease.connection.sftp()).rejects.toThrow(
+      'SFTP is disabled for this host.',
+    );
+  }, 15_000);
+
+  it('does not share transports across different SFTP compatibility settings', async () => {
+    const started = await startServer();
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-sftp-isolation-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host regular console',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+      ].join('\n'),
+    );
+    manager = makeManager(configFile, (alias) => alias === 'console');
+
+    const regular = await manager.connectShell(
+      { kind: 'ssh', target: 'regular', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+    const consoleShell = await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(consoleShell.lease.connection.id).not.toBe(regular.lease.connection.id);
     expect(started.stats.connections).toBe(2);
   }, 15_000);
 });

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -43,6 +43,7 @@ describe('MuxusDatabase migrations', () => {
       { version: 16, name: 'password-vault-key-cleanup' },
       { version: 17, name: 'folder-settings' },
       { version: 18, name: 'lock-workspaces' },
+      { version: 19, name: 'host-disable-sftp' },
     ]);
   });
 
@@ -119,8 +120,8 @@ describe('MuxusDatabase migrations', () => {
 
     database = new MuxusDatabase(filename);
     expect(database.appliedMigrations().at(-1)).toEqual({
-      version: 18,
-      name: 'lock-workspaces',
+      version: 19,
+      name: 'host-disable-sftp',
     });
     expect(database.passwordVaultConfig()).toMatchObject({
       formatVersion: 2,
@@ -300,6 +301,7 @@ describe('hybrid OpenSSH metadata', () => {
       displayName: 'Production',
       group: 'Work',
       color: '#3b82f6',
+      disableSftp: true,
       keywordHighlights: {
         inheritGlobal: true,
         rules: [
@@ -321,6 +323,7 @@ describe('hybrid OpenSSH metadata', () => {
       displayName: 'Production',
       group: 'Work',
       color: '#3b82f6',
+      disableSftp: true,
       keywordHighlights: {
         inheritGlobal: true,
         rules: [expect.objectContaining({ keyword: 'ERROR' })],
@@ -328,6 +331,11 @@ describe('hybrid OpenSSH metadata', () => {
       connectCount: 1,
     });
     expect(database.openSshMetadata(['production']).get('production')).toEqual(connected);
+    expect(database.sftpDisabledForAlias('production')).toBe(true);
+    expect(database.sftpDisabledForAlias('missing')).toBe(false);
+
+    database.updateOpenSshMetadata('production', { disableSftp: false });
+    expect(database.sftpDisabledForAlias('production')).toBe(false);
   });
 
   it('moves hosts between case-insensitive groups and can clear organization', () => {

--- a/tests/unit/server/remote-shell-integration.test.ts
+++ b/tests/unit/server/remote-shell-integration.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
 import {
-  openIntegratedRemoteShell,
+  openRemoteShell,
   parseShellProbe,
   RemoteShellTransportLostError,
   remoteShellCommand,
@@ -81,7 +81,7 @@ describe('remote shell integration', () => {
       },
     };
 
-    const result = await openIntegratedRemoteShell(
+    const result = await openRemoteShell(
       stubClient(exec),
       async () => {
         setupOrder.push('sftp-start');
@@ -147,7 +147,7 @@ describe('remote shell integration', () => {
       writeFile: vi.fn(),
     };
 
-    const result = await openIntegratedRemoteShell(
+    const result = await openRemoteShell(
       stubClient(exec),
       async () => sftp as never,
       { term: 'xterm-256color', cols: 80, rows: 24 },
@@ -164,6 +164,7 @@ describe('remote shell integration', () => {
 
   it('does not request SFTP when the remote is not a supported Unix shell', async () => {
     const probeChannel = new StubChannel();
+    const plainChannel = new StubChannel();
     const getSftp = vi.fn();
     const exec = vi.fn(
       (
@@ -178,14 +179,22 @@ describe('remote shell integration', () => {
       },
     );
 
-    const result = await openIntegratedRemoteShell(
-      stubClient(exec),
+    const shell = vi.fn(
+      (
+        _pty: unknown,
+        _options: unknown,
+        callback: (error: Error | undefined, channel: StubChannel) => void,
+      ) => callback(undefined, plainChannel),
+    );
+    const result = await openRemoteShell(
+      Object.assign(stubClient(exec), { shell }),
       getSftp,
       { term: 'xterm-256color', cols: 80, rows: 24 },
     );
 
-    expect(result).toBeUndefined();
+    expect(result).toBe(plainChannel);
     expect(getSftp).not.toHaveBeenCalled();
+    expect(shell).toHaveBeenCalledOnce();
   });
 
   it('surfaces a transport lost during the optional shell probe', async () => {
@@ -205,7 +214,41 @@ describe('remote shell integration', () => {
     };
 
     await expect(
-      openIntegratedRemoteShell(
+      openRemoteShell(
+        client as never,
+        vi.fn(),
+        { term: 'xterm-256color', cols: 80, rows: 24 },
+      ),
+    ).rejects.toBeInstanceOf(RemoteShellTransportLostError);
+  });
+
+  it('keeps watching for transport loss while the plain fallback opens', async () => {
+    const client = new EventEmitter() as EventEmitter & {
+      exec: (
+        command: string,
+        callback: (error: Error | undefined, channel: StubChannel) => void,
+      ) => void;
+      shell: (
+        pty: unknown,
+        options: unknown,
+        callback: (error: Error | undefined, channel?: StubChannel) => void,
+      ) => void;
+    };
+    const probeChannel = new StubChannel();
+    client.exec = (_command, callback) => {
+      callback(undefined, probeChannel);
+      setImmediate(() => probeChannel.emit('close'));
+    };
+    client.shell = (_pty, _options, callback) => {
+      expect(client.listenerCount('end')).toBe(1);
+      setImmediate(() => {
+        client.emit('end');
+        callback(new Error('Not connected'));
+      });
+    };
+
+    await expect(
+      openRemoteShell(
         client as never,
         vi.fn(),
         { term: 'xterm-256color', cols: 80, rows: 24 },

--- a/tests/unit/server/remote-shell-integration.test.ts
+++ b/tests/unit/server/remote-shell-integration.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   openIntegratedRemoteShell,
   parseShellProbe,
+  RemoteShellTransportLostError,
   remoteShellCommand,
 } from '../../../server/src/ssh/remote-shell-integration.js';
 
@@ -10,6 +11,10 @@ class StubChannel extends EventEmitter {
   destroy(): this {
     return this;
   }
+}
+
+function stubClient(exec: unknown) {
+  return Object.assign(new EventEmitter(), { exec }) as never;
 }
 
 describe('remote shell integration', () => {
@@ -77,7 +82,7 @@ describe('remote shell integration', () => {
     };
 
     const result = await openIntegratedRemoteShell(
-      { exec } as never,
+      stubClient(exec),
       async () => {
         setupOrder.push('sftp-start');
         return sftp as never;
@@ -86,7 +91,7 @@ describe('remote shell integration', () => {
     );
 
     expect(result).toBe(terminalChannel);
-    expect(setupOrder.slice(0, 3)).toEqual(['probe-start', 'sftp-start', 'probe-finish']);
+    expect(setupOrder.slice(0, 3)).toEqual(['probe-start', 'probe-finish', 'sftp-start']);
     expect(commands[0]).toContain('"${SHELL-}" "${ZDOTDIR-}" "${HOME-}"');
     expect(commands[0]).not.toContain('\\${SHELL-}');
     expect(commands[1]).toMatch(
@@ -143,7 +148,7 @@ describe('remote shell integration', () => {
     };
 
     const result = await openIntegratedRemoteShell(
-      { exec } as never,
+      stubClient(exec),
       async () => sftp as never,
       { term: 'xterm-256color', cols: 80, rows: 24 },
     );
@@ -155,6 +160,57 @@ describe('remote shell integration', () => {
     expect(commands[1]).toMatch(
       /--rcfile '\/home\/u\/\.cache\/muxus\/shell-integration\/[a-f0-9]{12}\/bash-init\.bash'/,
     );
+  });
+
+  it('does not request SFTP when the remote is not a supported Unix shell', async () => {
+    const probeChannel = new StubChannel();
+    const getSftp = vi.fn();
+    const exec = vi.fn(
+      (
+        _command: string,
+        callback: (error: Error | undefined, channel: StubChannel) => void,
+      ) => {
+        callback(undefined, probeChannel);
+        setImmediate(() => {
+          probeChannel.emit('data', Buffer.from('console appliance\n'));
+          probeChannel.emit('close');
+        });
+      },
+    );
+
+    const result = await openIntegratedRemoteShell(
+      stubClient(exec),
+      getSftp,
+      { term: 'xterm-256color', cols: 80, rows: 24 },
+    );
+
+    expect(result).toBeUndefined();
+    expect(getSftp).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a transport lost during the optional shell probe', async () => {
+    const client = new EventEmitter() as EventEmitter & {
+      exec: (
+        command: string,
+        callback: (error: Error | undefined, channel: StubChannel) => void,
+      ) => void;
+    };
+    const probeChannel = new StubChannel();
+    client.exec = (_command, callback) => {
+      callback(undefined, probeChannel);
+      setImmediate(() => {
+        client.emit('error', new Error('remote protocol disconnect'));
+        probeChannel.emit('close');
+      });
+    };
+
+    await expect(
+      openIntegratedRemoteShell(
+        client as never,
+        vi.fn(),
+        { term: 'xterm-256color', cols: 80, rows: 24 },
+      ),
+    ).rejects.toBeInstanceOf(RemoteShellTransportLostError);
   });
 
   it('detects supported shells among startup output', () => {

--- a/tests/unit/server/ssh-routes.test.ts
+++ b/tests/unit/server/ssh-routes.test.ts
@@ -32,6 +32,18 @@ afterEach(async () => {
 const auth = () => ({ authorization: `Bearer ${TOKEN}` });
 
 describe('OpenSSH host keyword metadata', () => {
+  it('persists the per-host SFTP compatibility setting', async () => {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/ssh/config/hosts/production/metadata',
+      headers: auth(),
+      payload: { disableSftp: true },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ disableSftp: true });
+  });
+
   it('persists validated per-host highlighting without rewriting ssh_config', async () => {
     const response = await app.inject({
       method: 'PATCH',


### PR DESCRIPTION
## Summary

- reconnect automatically in plain-console mode when optional Unix shell integration disconnects an SSH transport
- avoid speculative SFTP requests and remember inferred console compatibility for the app session
- add a persistent per-host **Disable SFTP** override for known-sensitive console appliances
- hide SFTP controls when the active transport does not support SFTP
- preserve the compatibility setting through host metadata, backup, restore, and imported-host editing

## Root cause

Muxus previously started its remote shell probe and SFTP setup in parallel after authentication. Some console servers and network appliances terminate the entire SSH transport when they receive an unsupported exec or SFTP request. The subsequent shell request then failed with a misleading `Not connected` error.

The connection manager now distinguishes a transport lost during optional integration setup, redials once without probes or SFTP, and isolates compatibility transports from normal SFTP-enabled transports.

## Validation

- hostile SSH container: protocol disconnect reason 2 on the first exec probe, followed by a successful automatic plain-console reconnect
- repeated console connection reused the inferred compatible transport without another probe
- per-connection session cap used a dedicated overflow transport
- standard OpenSSH container retained working shell integration and SFTP
- `pnpm test`: 748 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
