### PR TITLE
Add Windows ARM64 release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,20 +47,26 @@ jobs:
         run: pnpm check:bundle
 
   package-smoke:
-    name: Package (${{ matrix.os }})
+    name: Package (${{ matrix.name }})
     needs: validate
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            pack_args: ""
-          - os: macos-latest
+          - name: Linux x64
+            os: ubuntu-latest
+            pack_args: "--x64"
+          - name: macOS universal
+            os: macos-latest
             # Build universal like the release job so both per-arch
             # @napi-rs/keyring packages are exercised on every change.
             pack_args: "--universal"
-          - os: windows-latest
-            pack_args: ""
+          - name: Windows x64
+            os: windows-latest
+            pack_args: "--x64"
+          - name: Windows ARM64
+            os: windows-11-arm
+            pack_args: "--arm64"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -101,6 +107,24 @@ jobs:
 
       - name: Build unpacked desktop application
         run: pnpm --filter @muxus/electron pack:dir ${{ matrix.pack_args }}
+
+      - name: Verify Windows ARM64 native binaries
+        if: matrix.name == 'Windows ARM64'
+        shell: pwsh
+        run: |
+          $app = "electron/release/win-arm64-unpacked/resources/app.asar.unpacked/node_modules"
+          $binaries = @(
+            "$app/node-pty/prebuilds/win32-arm64/pty.node"
+            "$app/@serialport/bindings-cpp/prebuilds/win32-arm64/@serialport+bindings-cpp.armv8.node"
+          )
+          foreach ($binary in $binaries) {
+            if (-not (Test-Path -LiteralPath $binary)) {
+              throw "Windows ARM64 native binary not found: $binary"
+            }
+          }
+          if (-not (Get-ChildItem -Path "$app/@napi-rs/keyring-win32-arm64-msvc/*.node")) {
+            throw "Windows ARM64 keyring binary not found"
+          }
 
       - name: Verify universal keyring binaries
         if: runner.os == 'macOS'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,6 +28,12 @@ jobs:
             artifact_name: windows-exe-x64
             artifact_path: electron/release/*.exe
 
+          - name: Windows ARM64
+            os: windows-11-arm
+            build_args: --win nsis --arm64
+            artifact_name: windows-exe-arm64
+            artifact_path: electron/release/*.exe
+
           - name: macOS universal
             os: macos-latest
             build_args: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,11 @@ jobs:
             build_args: --win nsis --x64
             artifact_name: windows-x64
             artifact_path: electron/release/*.exe
+          - name: Windows ARM64
+            os: windows-11-arm
+            build_args: --win nsis --arm64
+            artifact_name: windows-arm64
+            artifact_path: electron/release/*.exe
           - name: macOS universal
             os: macos-latest
             # These overrides also backfill tags created before the universal

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ deb:
 	pnpm build && pnpm --filter @muxus/electron exec electron-builder --linux deb --x64
 
 win:
-	pnpm build && pnpm --filter @muxus/electron exec electron-builder --win --x64
+	pnpm build && pnpm --filter @muxus/electron exec electron-builder --win --x64 --arm64
 
 dmg:
 	pnpm build && pnpm --filter @muxus/electron exec electron-builder --mac dmg

--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -63,7 +63,7 @@ pnpm --filter @muxus/electron rebuild
 
 ```bash
 make deb    # Linux .deb
-make win    # Windows NSIS installer
+make win    # Windows NSIS installers (x64 and ARM64)
 make dmg    # macOS .dmg
 make all    # everything electron-builder is configured for
 ```

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -21,7 +21,7 @@ npmRebuild: true
 win:
   target:
     - target: nsis
-      arch: [x64]
+      arch: [x64, arm64]
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true


### PR DESCRIPTION
## Summary

- build Windows NSIS installers for both x64 and ARM64
- add native Windows ARM64 jobs to CI, manual packaging, and release workflows
- verify packaged ARM64 binaries for `node-pty`, serialport, and the OS keyring
- update the local Windows packaging target and development documentation

## Why

The existing Electron builder and GitHub Actions matrices only targeted Windows x64, so releases did not include an installer for Windows on ARM64. The new jobs run on GitHub's native `windows-11-arm` runner and publish a separately named ARM64 artifact.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test` (749 passed, 3 skipped)
- `pnpm check:bundle`
- `actionlint .github/workflows/ci.yml .github/workflows/package.yml .github/workflows/release.yml`
- YAML and release-matrix consistency checks
- `git diff --check`

Closes #59