### PR TITLE
Add saved local shell profiles

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -99,9 +99,13 @@ const initialKeys = collectStaticGraph(entry[0]);
 // distinguishing explicit saves from stale automatic saves and stopping retry
 // loops after a lock conflict. That first-paint guarantee adds ~2 KiB raw /
 // ~0.3 KiB gzip; the management dialog and its icons remain lazy.
+//
+// Saved local-shell profiles are launchable directly from the sidebar, so the
+// profile preference shape and launch path join the initial graph (~2 KiB raw /
+// ~0.5 KiB gzip). The profile editor remains in the lazy settings dialog.
 check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 793_000,
-  gzip: 257_000,
+  raw: 795_000,
+  gzip: 258_000,
 });
 
 for (const feature of [

--- a/client/src/components/LocalShellProfilesSection.tsx
+++ b/client/src/components/LocalShellProfilesSection.tsx
@@ -14,6 +14,7 @@ import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import { useAppInfo } from '../api/queries.js';
+import { parseLocalShellArgumentText } from '../local-shell-profile.js';
 import { confirmAction } from '../state/dialogs.js';
 import {
   usePrefsStore,
@@ -194,11 +195,7 @@ export function LocalShellProfilesSection() {
                       value={profile.args.join('\n')}
                       onChange={(event) =>
                         updateProfile(profile.id, {
-                          args: event.target.value
-                            .split(/\r?\n/)
-                            .filter((argument) => argument.length > 0)
-                            .slice(0, 64)
-                            .map((argument) => argument.slice(0, 4096)),
+                          args: parseLocalShellArgumentText(event.target.value),
                         })
                       }
                       placeholder={info?.platform === 'win32' ? '-d\nUbuntu' : '--login'}

--- a/client/src/components/LocalShellProfilesSection.tsx
+++ b/client/src/components/LocalShellProfilesSection.tsx
@@ -1,0 +1,243 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import IconButton from '@mui/material/IconButton';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import { useAppInfo } from '../api/queries.js';
+import { confirmAction } from '../state/dialogs.js';
+import {
+  usePrefsStore,
+  type LocalShellProfileConfig,
+} from '../state/prefs.js';
+
+export function LocalShellProfilesSection() {
+  const profiles = usePrefsStore((state) => state.localShellProfiles);
+  const defaultProfileId = usePrefsStore((state) => state.defaultLocalShellProfileId);
+  const localShell = usePrefsStore((state) => state.localShell);
+  const setPrefs = usePrefsStore((state) => state.set);
+  const { data: info } = useAppInfo();
+  const selectedDefault = profiles.some((profile) => profile.id === defaultProfileId)
+    ? defaultProfileId
+    : '';
+
+  const updateProfile = (id: string, patch: Partial<LocalShellProfileConfig>) => {
+    const current = usePrefsStore.getState();
+    setPrefs({
+      localShellProfiles: current.localShellProfiles.map((profile) =>
+        profile.id === id ? { ...profile, ...patch } : profile,
+      ),
+    });
+  };
+
+  const addProfile = () => {
+    const id = `local-${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${profiles.length}`}`;
+    const next: LocalShellProfileConfig = {
+      id,
+      name: `Shell ${profiles.length + 1}`,
+      shell: info?.defaultShell ?? '',
+      args: [],
+      cwd: '',
+      startupCommand: '',
+    };
+    setPrefs({
+      localShellProfiles: [...profiles, next],
+      defaultLocalShellProfileId: profiles.length === 0 ? id : defaultProfileId,
+    });
+  };
+
+  const removeProfile = (profile: LocalShellProfileConfig) => {
+    void confirmAction({
+      title: `Delete “${profile.name}”?`,
+      description:
+        'Existing tabs and saved workspaces keep their launch settings, but this profile will disappear from new-terminal choices.',
+      confirmLabel: 'Delete profile',
+      destructive: true,
+    }).then((confirmed) => {
+      if (!confirmed) return;
+      const current = usePrefsStore.getState();
+      current.set({
+        localShellProfiles: current.localShellProfiles.filter(
+          (candidate) => candidate.id !== profile.id,
+        ),
+        defaultLocalShellProfileId:
+          current.defaultLocalShellProfileId === profile.id
+            ? ''
+            : current.defaultLocalShellProfileId,
+      });
+    });
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+          Default local terminal
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          The default is used by the sidebar, the empty-pane shortcut, and the generic “New
+          local terminal” action. Every saved profile is also available in the quick launcher.
+        </Typography>
+        <Stack spacing={2} sx={{ maxWidth: 520 }}>
+          <FormControl fullWidth>
+            <InputLabel id="default-local-shell-label">Default profile</InputLabel>
+            <Select
+              labelId="default-local-shell-label"
+              label="Default profile"
+              value={selectedDefault}
+              onChange={(event) =>
+                setPrefs({ defaultLocalShellProfileId: event.target.value })
+              }
+            >
+              <MenuItem value="">Automatic / custom executable</MenuItem>
+              {profiles.map((profile) => (
+                <MenuItem key={profile.id} value={profile.id}>
+                  {profile.name.trim() || 'Unnamed shell'}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Automatic/custom executable"
+            value={localShell}
+            onChange={(event) => setPrefs({ localShell: event.target.value.slice(0, 4096) })}
+            placeholder="auto"
+            helperText={
+              info
+                ? `Used when no saved profile is selected; auto = ${info.defaultShell}`
+                : 'Used when no saved profile is selected; auto = your login shell'
+            }
+            fullWidth
+          />
+        </Stack>
+      </Box>
+
+      <Divider />
+
+      <Box>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 1 }}>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+              Saved shell profiles
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Use separate profiles for PowerShell, Command Prompt, WSL distributions, or
+              project-specific shells.
+            </Typography>
+          </Box>
+          <Button startIcon={<AddIcon />} variant="outlined" onClick={addProfile}>
+            Add profile
+          </Button>
+        </Stack>
+
+        {profiles.length === 0 ? (
+          <Paper variant="outlined" sx={{ p: 2.5, mt: 2, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              No saved profiles yet. The automatic shell continues to work as before.
+            </Typography>
+          </Paper>
+        ) : (
+          <Stack spacing={2} sx={{ mt: 2 }}>
+            {profiles.map((profile) => (
+              <Paper key={profile.id} variant="outlined" sx={{ p: 2 }}>
+                <Stack spacing={2}>
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+                    <TextField
+                      label="Profile name"
+                      value={profile.name}
+                      onChange={(event) =>
+                        updateProfile(profile.id, { name: event.target.value.slice(0, 200) })
+                      }
+                      error={!profile.name.trim()}
+                      helperText={!profile.name.trim() ? 'Enter a name.' : 'Shown in launch menus'}
+                      fullWidth
+                    />
+                    <Tooltip title="Delete profile">
+                      <IconButton
+                        aria-label={`Delete ${profile.name || 'shell profile'}`}
+                        color="error"
+                        onClick={() => removeProfile(profile)}
+                        sx={{ mt: 0.75 }}
+                      >
+                        <DeleteOutlineIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </Stack>
+                  <TextField
+                    label="Executable"
+                    value={profile.shell}
+                    onChange={(event) =>
+                      updateProfile(profile.id, { shell: event.target.value.slice(0, 4096) })
+                    }
+                    placeholder={info?.platform === 'win32' ? 'wsl.exe' : '/bin/zsh'}
+                    helperText="Executable name or absolute path; blank uses the system default"
+                    fullWidth
+                  />
+                  <Box
+                    sx={{
+                      display: 'grid',
+                      gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                      gap: 2,
+                    }}
+                  >
+                    <TextField
+                      label="Arguments"
+                      value={profile.args.join('\n')}
+                      onChange={(event) =>
+                        updateProfile(profile.id, {
+                          args: event.target.value
+                            .split(/\r?\n/)
+                            .filter((argument) => argument.length > 0)
+                            .slice(0, 64)
+                            .map((argument) => argument.slice(0, 4096)),
+                        })
+                      }
+                      placeholder={info?.platform === 'win32' ? '-d\nUbuntu' : '--login'}
+                      helperText="One argument per line; spaces stay inside that argument"
+                      minRows={2}
+                      multiline
+                      fullWidth
+                    />
+                    <TextField
+                      label="Starting directory"
+                      value={profile.cwd}
+                      onChange={(event) =>
+                        updateProfile(profile.id, { cwd: event.target.value.slice(0, 4096) })
+                      }
+                      placeholder={info?.homeDir}
+                      helperText="Blank starts in your home directory"
+                      fullWidth
+                    />
+                  </Box>
+                  <TextField
+                    label="Startup commands"
+                    value={profile.startupCommand}
+                    onChange={(event) =>
+                      updateProfile(profile.id, {
+                        startupCommand: event.target.value.slice(0, 32_768),
+                      })
+                    }
+                    placeholder="cd project"
+                    helperText="Entered automatically after the interactive shell starts; one command per line"
+                    minRows={2}
+                    multiline
+                    fullWidth
+                  />
+                </Stack>
+              </Paper>
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </Stack>
+  );
+}

--- a/client/src/components/QuickLauncherDialog.tsx
+++ b/client/src/components/QuickLauncherDialog.tsx
@@ -73,9 +73,10 @@ import {
   connectManagedHost,
   connectTarget,
   isQuickConnectTarget,
+  openLocalShellProfile,
   openLocalTerminal,
 } from '../session-actions.js';
-import type { CommandButton } from '../state/prefs.js';
+import type { CommandButton, LocalShellProfileConfig } from '../state/prefs.js';
 import { usePrefsStore } from '../state/prefs.js';
 import { useTabsStore, type TabStatus } from '../state/tabs.js';
 import { showErrorToast, showToast } from '../state/toast.js';
@@ -106,6 +107,7 @@ type LauncherResult = ResultBase &
     | { kind: 'command'; command: CommandButton }
     | { kind: 'tunnel'; tunnel: TunnelRecord; running?: ForwardInfo }
     | { kind: 'history'; session: SessionLogSummary; historyQuery: string }
+    | { kind: 'local-shell'; profile: LocalShellProfileConfig }
     | { kind: 'action'; action: LauncherAction }
     | { kind: 'keymap'; command: KeyCommand; chord?: string }
   );
@@ -134,6 +136,7 @@ export function QuickLauncherDialog() {
   const tabs = useTabsStore((state) => state.tabs);
   const activeId = useTabsStore((state) => state.activeId);
   const commands = usePrefsStore((state) => state.commandButtons);
+  const localShellProfiles = usePrefsStore((state) => state.localShellProfiles);
   const keybindings = usePrefsStore((state) => state.keybindings);
   const workspaces = useWorkspacesStore((state) => state.workspaces);
   const activeWorkspaceId = useWorkspacesStore((state) => state.activeId);
@@ -196,6 +199,7 @@ export function QuickLauncherDialog() {
         workspaces,
         activeWorkspaceId,
         commands,
+        localShellProfiles,
         tunnels,
         forwards,
         activeConnected: !!activeConnected,
@@ -205,6 +209,7 @@ export function QuickLauncherDialog() {
       activeId,
       activeWorkspaceId,
       commands,
+      localShellProfiles,
       forwards,
       savedHosts,
       sshHosts,
@@ -427,6 +432,10 @@ export function QuickLauncherDialog() {
         useUiStore
           .getState()
           .openHistory(result.historyQuery, result.session.id);
+        break;
+      case 'local-shell':
+        close();
+        openLocalShellProfile(result.profile);
         break;
       case 'action':
         runAction(result.action);
@@ -728,6 +737,7 @@ function buildCatalogResults({
   workspaces,
   activeWorkspaceId,
   commands,
+  localShellProfiles,
   tunnels,
   forwards,
   activeConnected,
@@ -739,6 +749,7 @@ function buildCatalogResults({
   workspaces: readonly WorkspaceSummary[];
   activeWorkspaceId?: string;
   commands: readonly CommandButton[];
+  localShellProfiles: readonly LocalShellProfileConfig[];
   tunnels: readonly TunnelRecord[];
   forwards: readonly ForwardInfo[];
   activeConnected: boolean;
@@ -855,6 +866,30 @@ function buildCatalogResults({
       priority: 130,
       showWhenEmpty: activeConnected && index < 5,
       disabledReason: activeConnected ? undefined : 'Connect a terminal to use this command',
+    });
+  }
+
+  for (const [index, profile] of localShellProfiles.entries()) {
+    const commandLine = [profile.shell || 'automatic shell', ...profile.args]
+      .filter(Boolean)
+      .join(' ');
+    results.push({
+      id: `local-shell:${profile.id}`,
+      kind: 'local-shell',
+      profile,
+      label: profile.name.trim() || 'Unnamed shell',
+      detail: `Local shell · ${commandLine}`,
+      keywords: [
+        'local',
+        'terminal',
+        'shell',
+        profile.shell,
+        ...profile.args,
+        profile.cwd,
+        profile.startupCommand,
+      ],
+      priority: 190,
+      showWhenEmpty: index < 5,
     });
   }
 
@@ -1069,6 +1104,9 @@ function ResultIcon({ result }: { result: LauncherResult }) {
     );
   }
   if (result.kind === 'history') return <HistoryOutlinedIcon {...props} />;
+  if (result.kind === 'local-shell') {
+    return <TerminalOutlinedIcon {...props} color="primary" />;
+  }
   if (result.kind === 'keymap') return <KeyboardOutlinedIcon {...props} />;
   if (result.action === 'settings') return <SettingsOutlinedIcon {...props} />;
   if (result.action === 'workspaces') return <WorkspacesOutlinedIcon {...props} />;
@@ -1098,9 +1136,11 @@ function ResultKindLabel({
   const label =
     result.kind === 'quick-connect'
       ? 'CONNECT'
-      : result.kind === 'editor'
-        ? 'FILE'
-        : result.kind.toUpperCase();
+      : result.kind === 'local-shell'
+        ? 'LOCAL'
+        : result.kind === 'editor'
+          ? 'FILE'
+          : result.kind.toUpperCase();
   return (
     <Typography
       variant="caption"

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -59,6 +59,7 @@ import {
   connectManagedHost,
   connectTarget,
   isQuickConnectTarget,
+  openLocalShellProfile,
   openLocalTerminal,
 } from '../session-actions.js';
 import {
@@ -105,6 +106,7 @@ export function SessionSidebar() {
   const setHostEditor = useUiStore((s) => s.setHostEditor);
   const setFolderDialog = useUiStore((s) => s.setFolderDialog);
   const sidebarWidth = usePrefsStore((state) => state.sidebarWidth);
+  const localShellProfiles = usePrefsStore((state) => state.localShellProfiles);
   const setPrefs = usePrefsStore((state) => state.set);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -132,6 +134,17 @@ export function SessionSidebar() {
   const needle = useDeferredValue(normalizedFilter);
   const hosts = config?.hosts ?? EMPTY_HOSTS;
   const profiles = savedData?.profiles ?? EMPTY_PROFILES;
+  const visibleLocalShellProfiles = useMemo(
+    () =>
+      localShellProfiles.filter((profile) => {
+        if (!needle) return true;
+        return [profile.name, profile.shell, ...profile.args, profile.cwd]
+          .join(' ')
+          .toLocaleLowerCase()
+          .includes(needle);
+      }),
+    [localShellProfiles, needle],
+  );
 
   const groups = useMemo(
     () => groupManagedHosts(hosts, profiles, config?.files ?? [], config?.path, needle),
@@ -536,6 +549,26 @@ export function SessionSidebar() {
               Local terminal
             </Box>
           </ListItemButton>
+          {visibleLocalShellProfiles.map((profile) => (
+            <Tooltip
+              key={profile.id}
+              title={[profile.shell || 'Automatic shell', ...profile.args].join(' ')}
+              placement="right"
+            >
+              <ListItemButton
+                component="li"
+                sx={[...fixedRowSx, { pl: 3 }]}
+                onMouseEnter={() => void loadTerminalViewImpl()}
+                onFocus={() => void loadTerminalViewImpl()}
+                onClick={() => openLocalShellProfile(profile)}
+              >
+                <TerminalIcon sx={{ fontSize: 15, flexShrink: 0, color: 'text.secondary' }} />
+                <Box component="span" sx={{ ...treeLabelSx, minWidth: 0 }}>
+                  {profile.name.trim() || 'Unnamed shell'}
+                </Box>
+              </ListItemButton>
+            </Tooltip>
+          ))}
           {quickConnectable && (
             <ListItemButton
               component="li"

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -30,6 +30,7 @@ import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
+import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import HighlightOutlinedIcon from '@mui/icons-material/HighlightOutlined';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
@@ -76,6 +77,7 @@ import {
 } from '../terminal/font-catalog.js';
 import { chordSx } from './chord-style.js';
 import { KeywordHighlightRulesEditor } from './KeywordHighlightRulesEditor.js';
+import { LocalShellProfilesSection } from './LocalShellProfilesSection.js';
 import { SessionLoggingPolicyFields } from './SessionLoggingPolicyFields.js';
 import { DataTransferSection } from './DataTransferSection.js';
 import { MobaXtermImportDialog } from './MobaXtermImportDialog.js';
@@ -85,6 +87,7 @@ import { SecureCrtImportDialog } from './SecureCrtImportDialog.js';
 type Section =
   | 'appearance'
   | 'terminal'
+  | 'local-shells'
   | 'logging'
   | 'highlighting'
   | 'behavior'
@@ -97,6 +100,7 @@ type Section =
 const SECTIONS: Array<{ id: Section; label: string; icon: React.ReactNode }> = [
   { id: 'appearance', label: 'Appearance', icon: <PaletteOutlinedIcon fontSize="small" /> },
   { id: 'terminal', label: 'Terminal', icon: <TerminalIcon fontSize="small" /> },
+  { id: 'local-shells', label: 'Local shells', icon: <CodeOutlinedIcon fontSize="small" /> },
   { id: 'logging', label: 'Session logging', icon: <HistoryOutlinedIcon fontSize="small" /> },
   { id: 'highlighting', label: 'Highlighting', icon: <HighlightOutlinedIcon fontSize="small" /> },
   { id: 'behavior', label: 'Behavior', icon: <TuneOutlinedIcon fontSize="small" /> },
@@ -190,6 +194,7 @@ export function SettingsDialog() {
           <Box sx={{ flex: 1, overflowY: 'auto', p: 3, pt: 2.5 }}>
             {section === 'appearance' && <AppearanceSection />}
             {section === 'terminal' && <TerminalSection />}
+            {section === 'local-shells' && <LocalShellProfilesSection />}
             {section === 'logging' && <SessionLoggingSection onDirtyChange={setLoggingDirty} />}
             {section === 'highlighting' && <HighlightingSection />}
             {section === 'behavior' && <BehaviorSection />}
@@ -607,22 +612,9 @@ function TerminalSection() {
 
 function BehaviorSection() {
   const prefs = usePrefsStore();
-  const { data: info } = useAppInfo();
 
   return (
     <Stack spacing={3}>
-      <Box>
-        <SectionTitle>Local terminal</SectionTitle>
-        <TextField
-          label="Shell"
-          value={prefs.localShell}
-          onChange={(e) => prefs.set({ localShell: e.target.value })}
-          placeholder="auto"
-          helperText={info ? `auto = ${info.defaultShell}` : 'auto = your login shell'}
-          sx={{ maxWidth: 420 }}
-          fullWidth
-        />
-      </Box>
       <Box>
         <SectionTitle>Tabs</SectionTitle>
         <FormControlLabel

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -24,7 +24,12 @@ import {
   MIN_SIDEBAR_WIDTH,
 } from './sidebar-width.js';
 import { MIN_SFTP_PANEL_WIDTH } from './sftp-panel-width.js';
-import { usePrefsStore, type FolderStyle, type PrefsState } from './state/prefs.js';
+import {
+  isLocalShellProfileArray,
+  usePrefsStore,
+  type FolderStyle,
+  type PrefsState,
+} from './state/prefs.js';
 import { isFolderIconId } from './components/sidebar/folder-icons.js';
 
 export const BACKUP_FORMAT = 'muxus-backup';
@@ -45,6 +50,8 @@ const PREFERENCE_KEYS = [
   'cursorBlink',
   'cursorStyle',
   'localShell',
+  'localShellProfiles',
+  'defaultLocalShellProfileId',
   'copyOnSelect',
   'allowOsc52ClipboardWrite',
   'rightClickAction',
@@ -637,6 +644,19 @@ export function sanitizePreferences(input: BackupPreferences): Partial<PrefsStat
   }
   if (typeof input.localShell === 'string' && input.localShell.length <= 4096) {
     output.localShell = input.localShell;
+  }
+  if (isLocalShellProfileArray(input.localShellProfiles)) {
+    output.localShellProfiles = input.localShellProfiles;
+  }
+  if (
+    typeof input.defaultLocalShellProfileId === 'string' &&
+    input.defaultLocalShellProfileId.length <= 200 &&
+    (!input.defaultLocalShellProfileId ||
+      output.localShellProfiles?.some(
+        (profile) => profile.id === input.defaultLocalShellProfileId,
+      ))
+  ) {
+    output.defaultLocalShellProfileId = input.defaultLocalShellProfileId;
   }
   if (typeof input.copyOnSelect === 'boolean') output.copyOnSelect = input.copyOnSelect;
   if (typeof input.allowOsc52ClipboardWrite === 'boolean') {

--- a/client/src/local-shell-profile.ts
+++ b/client/src/local-shell-profile.ts
@@ -1,0 +1,17 @@
+const MAX_LOCAL_SHELL_ARGUMENTS = 64;
+const MAX_LOCAL_SHELL_ARGUMENT_LENGTH = 4096;
+
+/** Preserve blank rows while the controlled arguments field is being edited. */
+export function parseLocalShellArgumentText(value: string): string[] {
+  return value
+    .split(/\r?\n/, MAX_LOCAL_SHELL_ARGUMENTS)
+    .map((argument) => argument.slice(0, MAX_LOCAL_SHELL_ARGUMENT_LENGTH));
+}
+
+/** Empty editor rows describe layout, not arguments passed to the executable. */
+export function localShellLaunchArguments(
+  arguments_: readonly string[],
+): string[] | undefined {
+  const compact = arguments_.filter((argument) => argument.length > 0);
+  return compact.length ? compact : undefined;
+}

--- a/client/src/quick-launcher.ts
+++ b/client/src/quick-launcher.ts
@@ -7,6 +7,7 @@ export type QuickLauncherKind =
   | 'command'
   | 'tunnel'
   | 'history'
+  | 'local-shell'
   | 'action'
   | 'keymap';
 

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -5,6 +5,7 @@ import type {
   SshHostEntry,
 } from '@muxus/shared';
 import type { ManagedHost } from './managed-hosts.js';
+import { localShellLaunchArguments } from './local-shell-profile.js';
 import { savedHostDisplayName } from './saved-hosts.js';
 import {
   usePrefsStore,
@@ -84,7 +85,7 @@ export function openLocalShellProfile(
   const profile: LocalProfile = {
     kind: 'local',
     shell: saved.shell.trim() || undefined,
-    args: saved.args.length ? saved.args : undefined,
+    args: localShellLaunchArguments(saved.args),
     cwd: saved.cwd.trim() || undefined,
     startupCommand: saved.startupCommand.trim() || undefined,
   };

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -6,7 +6,10 @@ import type {
 } from '@muxus/shared';
 import type { ManagedHost } from './managed-hosts.js';
 import { savedHostDisplayName } from './saved-hosts.js';
-import { usePrefsStore } from './state/prefs.js';
+import {
+  usePrefsStore,
+  type LocalShellProfileConfig,
+} from './state/prefs.js';
 import { useMultiExecStore } from './state/multi-exec.js';
 import { useTabsStore } from './state/tabs.js';
 import type { PaneDirection, SessionSetLayout } from './state/tabs.js';
@@ -61,17 +64,50 @@ function replaceActiveEmpty(
   return id && state.replaceEmpty(id, profile, title) ? id : undefined;
 }
 
-/** Open a new local terminal tab using the user's shell preference. */
-export function openLocalTerminal(replaceTabId?: string): string {
-  const { localShell } = usePrefsStore.getState();
+function launchLocalTerminal(
+  profile: LocalProfile,
+  title: string,
+  replaceTabId?: string,
+): string {
+  const key = JSON.stringify(profile);
+  return launchOnce(`local:${key}:${replaceTabId ?? ''}`, () => {
+    const replacedId = replaceActiveEmpty(profile, title, replaceTabId);
+    return replacedId ?? useTabsStore.getState().open(profile, title);
+  });
+}
+
+/** Open one explicitly selected saved local-shell configuration. */
+export function openLocalShellProfile(
+  saved: LocalShellProfileConfig,
+  replaceTabId?: string,
+): string {
   const profile: LocalProfile = {
     kind: 'local',
-    shell: localShell !== 'auto' && localShell.trim() ? localShell.trim() : undefined,
+    shell: saved.shell.trim() || undefined,
+    args: saved.args.length ? saved.args : undefined,
+    cwd: saved.cwd.trim() || undefined,
+    startupCommand: saved.startupCommand.trim() || undefined,
   };
-  return launchOnce(`local:${profile.shell ?? ''}:${replaceTabId ?? ''}`, () => {
-    const replacedId = replaceActiveEmpty(profile, 'Local', replaceTabId);
-    return replacedId ?? useTabsStore.getState().open(profile, 'Local');
-  });
+  return launchLocalTerminal(profile, saved.name.trim() || 'Local', replaceTabId);
+}
+
+/** Open the user's default local terminal. A named profile can replace the
+ * automatic shell without changing callers such as Ctrl+Shift+T or splits. */
+export function openLocalTerminal(replaceTabId?: string): string {
+  const { localShell, localShellProfiles, defaultLocalShellProfileId } =
+    usePrefsStore.getState();
+  const saved = localShellProfiles.find(
+    (profile) => profile.id === defaultLocalShellProfileId,
+  );
+  if (saved) return openLocalShellProfile(saved, replaceTabId);
+  return launchLocalTerminal(
+    {
+      kind: 'local',
+      shell: localShell !== 'auto' && localShell.trim() ? localShell.trim() : undefined,
+    },
+    'Local',
+    replaceTabId,
+  );
 }
 
 /** Open a blank tab that lets the user choose what kind of session to start. */

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -23,6 +23,17 @@ export interface CommandButton {
   sendEnter: boolean;
 }
 
+/** A reusable local terminal launch configuration. Arguments stay structured
+ * so paths and values containing spaces are never reparsed as a command line. */
+export interface LocalShellProfileConfig {
+  id: string;
+  name: string;
+  shell: string;
+  args: string[];
+  cwd: string;
+  startupCommand: string;
+}
+
 /** Bundled icon-only fallback covering Nerd Font and Powerline glyphs. */
 export const TERMINAL_SYMBOL_FONT = '"Pure Nerd Font"';
 
@@ -57,6 +68,10 @@ export interface PrefsState {
   cursorStyle: 'block' | 'underline' | 'bar';
   /** Local terminal shell; 'auto' lets the server pick the login shell. */
   localShell: string;
+  /** Named alternatives offered wherever a local terminal can be launched. */
+  localShellProfiles: LocalShellProfileConfig[];
+  /** Empty selects the legacy automatic/custom localShell preference. */
+  defaultLocalShellProfileId: string;
   /** Copy the selection to the clipboard as soon as it is made. */
   copyOnSelect: boolean;
   /** Let terminal applications replace the system clipboard via OSC 52. */
@@ -128,6 +143,18 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
   if (!isStringArray(state.sidebarEmptyFolders)) delete state.sidebarEmptyFolders;
   if (!isFolderStyleMap(state.sidebarFolderStyles)) delete state.sidebarFolderStyles;
   if (!isFolderOrderMap(state.sidebarFolderOrder)) delete state.sidebarFolderOrder;
+  const localShellProfiles = isLocalShellProfileArray(state.localShellProfiles)
+    ? state.localShellProfiles
+    : undefined;
+  if (!localShellProfiles) delete state.localShellProfiles;
+  if (typeof state.defaultLocalShellProfileId !== 'string') {
+    delete state.defaultLocalShellProfileId;
+  } else if (
+    state.defaultLocalShellProfileId &&
+    !localShellProfiles?.some((profile) => profile.id === state.defaultLocalShellProfileId)
+  ) {
+    state.defaultLocalShellProfileId = '';
+  }
   // The sidebar grew in v6 to fit its search box. A stored copy of the old
   // default was never a choice, so it follows; a dragged width is left alone.
   if (version < 6 && state.sidebarWidth === PREVIOUS_DEFAULT_SIDEBAR_WIDTH) {
@@ -163,6 +190,37 @@ function isFolderStyleMap(value: unknown): value is Record<string, FolderStyle> 
   );
 }
 
+export function isLocalShellProfileArray(value: unknown): value is LocalShellProfileConfig[] {
+  if (!Array.isArray(value) || value.length > 100) return false;
+  const ids = new Set<string>();
+  return value.every((entry) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) return false;
+    const profile = entry as Record<string, unknown>;
+    if (
+      typeof profile.id !== 'string' ||
+      !profile.id ||
+      profile.id.length > 200 ||
+      ids.has(profile.id) ||
+      typeof profile.name !== 'string' ||
+      !profile.name.trim() ||
+      profile.name.length > 200 ||
+      typeof profile.shell !== 'string' ||
+      profile.shell.length > 4096 ||
+      typeof profile.cwd !== 'string' ||
+      profile.cwd.length > 4096 ||
+      typeof profile.startupCommand !== 'string' ||
+      profile.startupCommand.length > 32_768 ||
+      !Array.isArray(profile.args) ||
+      profile.args.length > 64 ||
+      !profile.args.every((arg) => typeof arg === 'string' && arg.length <= 4096)
+    ) {
+      return false;
+    }
+    ids.add(profile.id);
+    return true;
+  });
+}
+
 export const usePrefsStore = create<PrefsState>()(
   persist(
     (set) => ({
@@ -177,6 +235,8 @@ export const usePrefsStore = create<PrefsState>()(
       cursorBlink: true,
       cursorStyle: 'block',
       localShell: 'auto',
+      localShellProfiles: [],
+      defaultLocalShellProfileId: '',
       copyOnSelect: false,
       allowOsc52ClipboardWrite: true,
       rightClickAction: 'copy-paste',
@@ -205,7 +265,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 6,
+      version: 7,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/client/src/window-management.ts
+++ b/client/src/window-management.ts
@@ -39,8 +39,13 @@ export function isAppWindowLaunch(value: unknown): value is AppWindowLaunch {
 function isSessionProfile(profile: Record<string, unknown>): boolean {
   if (profile.kind === 'local') {
     return (
-      (profile.shell === undefined || typeof profile.shell === 'string') &&
-      (profile.cwd === undefined || typeof profile.cwd === 'string')
+      optionalBoundedString(profile.shell, 4096) &&
+      optionalBoundedString(profile.cwd, 4096) &&
+      optionalBoundedString(profile.startupCommand, 32_768) &&
+      (profile.args === undefined ||
+        (Array.isArray(profile.args) &&
+          profile.args.length <= 64 &&
+          profile.args.every((arg) => typeof arg === 'string' && arg.length <= 4096)))
     );
   }
   if (profile.kind === 'ssh') {
@@ -71,6 +76,10 @@ function isSessionProfile(profile: Record<string, unknown>): boolean {
     (profile.flowControl === undefined ||
       ['none', 'hardware', 'software'].includes(profile.flowControl as string))
   );
+}
+
+function optionalBoundedString(value: unknown, maxLength: number): boolean {
+  return value === undefined || (typeof value === 'string' && value.length <= maxLength);
 }
 
 function validPort(value: unknown): boolean {

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -11,7 +11,7 @@ because storage policy should not change under a running recorder.
 <figure markdown="span">
   ![The settings dialog](../assets/screenshots/settings.png#only-light){ .shadow }
   ![The settings dialog](../assets/screenshots/settings-dark.png#only-dark){ .shadow }
-  <figcaption>Nine sections, listed on the left. The footer states when changes apply.</figcaption>
+  <figcaption>Eleven sections, listed on the left. The footer states when changes apply.</figcaption>
 </figure>
 
 ## Appearance
@@ -40,7 +40,21 @@ because storage policy should not change under a running recorder.
   Zellij, and the **multiline paste confirmation**. OSC 52 reads remain blocked so a
   terminal program cannot retrieve the local clipboard.
 - **Scrollback lines** kept per terminal.
-- **Local shell**: the shell a local terminal starts; `auto` uses the login shell.
+
+## Local shells
+
+The automatic local terminal keeps the previous behaviour: `auto` uses the login shell,
+or an executable can override it. Saved profiles make several local environments available
+at once. Each profile has a display name, executable, structured argument list, starting
+directory and optional startup commands.
+
+Arguments are entered one per line, so a value containing spaces stays one argument. For
+example, a Windows profile with executable `wsl.exe` and arguments `-d` and `Ubuntu`
+opens that distribution; another profile can select Debian, PowerShell or `cmd.exe`.
+Profiles appear below **Local terminal** in the sidebar and in the quick launcher. One can
+be selected as the default used by the sidebar, empty-pane shortcut and generic local
+terminal action. Startup commands are entered into the interactive shell whenever the
+profile starts, including when it is restored in a workspace.
 
 ## Session logging
 

--- a/docs/guide/terminal.md
+++ b/docs/guide/terminal.md
@@ -54,6 +54,14 @@ blink, clipboard behaviour and scrollback length are in
 [Settings → Terminal](settings.md#terminal). Changes apply to every open terminal
 immediately.
 
+## Local shell profiles
+
+[Settings → Local shells](settings.md#local-shells) can save several local launch
+configurations side by side—for example PowerShell, Command Prompt and individual WSL
+distributions. A profile can supply executable arguments, a starting directory and commands
+to run when its interactive shell starts. Saved profiles are launchable from both the hosts
+sidebar and the quick launcher.
+
 ### Per-tab zoom
 
 ++ctrl+plus++, ++ctrl+minus++ and ++ctrl+0++, or ++ctrl+wheel++, change the font size of

--- a/server/src/local/pty-manager.ts
+++ b/server/src/local/pty-manager.ts
@@ -61,3 +61,22 @@ export function localStartupInput(command: string | undefined): string | undefin
   if (!trimmed) return undefined;
   return `${trimmed.replace(/\r?\n/g, '\r')}\r`;
 }
+
+// Terminal control bytes are the protocol delimiters these expressions parse.
+// oxlint-disable-next-line no-control-regex
+const SHELL_PROMPT_OSC = /\x1b\](?:133|633);A(?:;[^\x07\x1b]*)?(?:\x07|\x1b\\)/;
+// oxlint-disable-next-line no-control-regex
+const ANSI_OSC = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+// oxlint-disable-next-line no-control-regex
+const ANSI_CSI = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const COMMON_PROMPT_END = /(?:[$#>]|❯|➜)\s*$/u;
+
+/** Detect the first interactive prompt without feeding startup text into shell
+ * initialization. OSC 133/633 is authoritative; the visible fallback covers
+ * default cmd, PowerShell, POSIX, fish, and common themed prompts. */
+export function localShellPromptReady(output: string): boolean {
+  if (SHELL_PROMPT_OSC.test(output)) return true;
+  const visible = output.replace(ANSI_OSC, '').replace(ANSI_CSI, '');
+  const line = visible.split(/[\r\n]/).at(-1) ?? '';
+  return COMMON_PROMPT_END.test(line);
+}

--- a/server/src/local/pty-manager.ts
+++ b/server/src/local/pty-manager.ts
@@ -27,6 +27,7 @@ export interface LocalPty {
 export function spawnLocalPty(profile: LocalProfile, cols: number, rows: number): LocalPty {
   const shell = profile.shell?.trim() || defaultShell();
   const integration = shellIntegration(shell, process.env);
+  const args = localPtyArgs(profile, integration.args);
   const env: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (!HOST_TERMINAL_ENV.test(key)) env[key] = value;
@@ -36,7 +37,7 @@ export function spawnLocalPty(profile: LocalProfile, cols: number, rows: number)
   // Muxus renders 24-bit color; advertise it independently of terminfo.
   env.COLORTERM = 'truecolor';
   env.TERM_PROGRAM = 'muxus';
-  const spawned = pty.spawn(shell, integration.args, {
+  const spawned = pty.spawn(shell, args, {
     name: DEFAULT_TERM,
     cols,
     rows,
@@ -44,4 +45,19 @@ export function spawnLocalPty(profile: LocalProfile, cols: number, rows: number)
     env,
   });
   return { pty: spawned, shell };
+}
+
+export function localPtyArgs(
+  profile: LocalProfile,
+  integrationArgs: readonly string[],
+): string[] {
+  return [...integrationArgs, ...(profile.args ?? [])];
+}
+
+/** Normalize a saved startup action to terminal input. A PTY Enter is CR on
+ * every supported platform; embedded newlines become separate Enter presses. */
+export function localStartupInput(command: string | undefined): string | undefined {
+  const trimmed = command?.trim();
+  if (!trimmed) return undefined;
+  return `${trimmed.replace(/\r?\n/g, '\r')}\r`;
 }

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -6,7 +6,7 @@ import type { TerminalServerMessage } from '@muxus/shared';
 import { terminalClientMessageSchema, type TerminalClientMessage } from '@muxus/shared/ws-protocol';
 import type { AppContext } from '../app.js';
 import type { ConnectIo } from '../ssh/connection-manager.js';
-import { spawnLocalPty, DEFAULT_TERM } from '../local/pty-manager.js';
+import { localStartupInput, spawnLocalPty, DEFAULT_TERM } from '../local/pty-manager.js';
 import { SerialTransport } from '../serial/serial-transport.js';
 import { TelnetTransport } from '../telnet/telnet-transport.js';
 import type { TerminalTransport } from '../transports/terminal-transport.js';
@@ -432,6 +432,8 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
     });
     socket.on('close', () => pty.kill());
     sendControl(socket, { op: 'ready', connId: `local-${process.pid}` });
+    const startupInput = localStartupInput(profile.startupCommand);
+    if (startupInput) pty.write(startupInput);
     return;
   }
 

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -6,7 +6,12 @@ import type { TerminalServerMessage } from '@muxus/shared';
 import { terminalClientMessageSchema, type TerminalClientMessage } from '@muxus/shared/ws-protocol';
 import type { AppContext } from '../app.js';
 import type { ConnectIo } from '../ssh/connection-manager.js';
-import { localStartupInput, spawnLocalPty, DEFAULT_TERM } from '../local/pty-manager.js';
+import {
+  localShellPromptReady,
+  localStartupInput,
+  spawnLocalPty,
+  DEFAULT_TERM,
+} from '../local/pty-manager.js';
 import { SerialTransport } from '../serial/serial-transport.js';
 import { TelnetTransport } from '../telnet/telnet-transport.js';
 import type { TerminalTransport } from '../transports/terminal-transport.js';
@@ -416,6 +421,8 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
 
   if (profile.kind === 'local') {
     const { pty } = spawnLocalPty(profile, cols, rows);
+    let startupInput = localStartupInput(profile.startupCommand);
+    let startupOutput = '';
     writeInput = (data) => pty.write(data.toString('utf8'));
     control.onMessage = (msg) => {
       if (handleLoggingControl(msg)) return;
@@ -424,6 +431,15 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
     pty.onData((data) => {
       recorder?.output(data);
       if (socket.readyState === socket.OPEN) socket.send(Buffer.from(data, 'utf8'), { binary: true });
+      if (startupInput) {
+        startupOutput = `${startupOutput}${data}`.slice(-8192);
+        if (localShellPromptReady(startupOutput)) {
+          const input = startupInput;
+          startupInput = undefined;
+          startupOutput = '';
+          pty.write(input);
+        }
+      }
     });
     pty.onExit(({ exitCode }) => {
       recorder?.end('completed');
@@ -432,8 +448,6 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
     });
     socket.on('close', () => pty.kill());
     sendControl(socket, { op: 'ready', connId: `local-${process.pid}` });
-    const startupInput = localStartupInput(profile.startupCommand);
-    if (startupInput) pty.write(startupInput);
     return;
   }
 

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -23,8 +23,12 @@ export function terminalWebSocketProtocols(token: string): string[] {
 export const localProfileSchema = z.object({
   kind: z.literal('local'),
   /** Login shell override; empty/absent picks the server's default. */
-  shell: z.string().optional(),
-  cwd: z.string().optional(),
+  shell: z.string().max(4096).optional(),
+  /** Arguments passed to the shell executable without command-line re-parsing. */
+  args: z.array(z.string().max(4096)).max(64).optional(),
+  cwd: z.string().max(4096).optional(),
+  /** Text entered after the interactive shell starts, followed by Enter. */
+  startupCommand: z.string().max(32_768).optional(),
 });
 
 export const sshProfileSchema = z.object({

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -23,6 +23,8 @@ beforeEach(() => {
     notifyOnNewVersion: true,
     showCommandBar: true,
     backgroundColor: '',
+    localShellProfiles: [],
+    defaultLocalShellProfileId: '',
   });
 });
 
@@ -155,6 +157,58 @@ describe('backing up preferences', () => {
     expect(document.data.preferences.notifyOnNewVersion).toBe(false);
     expect(document.data.preferences.backgroundColor).toBe('#102030');
     expect(document.data.preferences.showCommandBar).toBe(false);
+  });
+
+  it('includes saved local shell profiles and their default selection', async () => {
+    usePrefsStore.setState({
+      localShellProfiles: [
+        {
+          id: 'ubuntu',
+          name: 'Ubuntu',
+          shell: 'wsl.exe',
+          args: ['-d', 'Ubuntu'],
+          cwd: 'C:\\work',
+          startupCommand: 'cd project',
+        },
+      ],
+      defaultLocalShellProfileId: 'ubuntu',
+    });
+    mockBackupSnapshot();
+
+    const document = await createBackupDocument();
+
+    expect(document.data.preferences.localShellProfiles).toHaveLength(1);
+    expect(document.data.preferences.defaultLocalShellProfileId).toBe('ubuntu');
+  });
+});
+
+describe('restoring local shell profiles', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+  const ubuntu = {
+    id: 'ubuntu',
+    name: 'Ubuntu',
+    shell: 'wsl.exe',
+    args: ['-d', 'Ubuntu'],
+    cwd: 'C:\\work',
+    startupCommand: 'cd project',
+  };
+
+  it('restores bounded profiles and their default selection', () => {
+    expect(
+      sanitizePreferences(
+        prefs({ localShellProfiles: [ubuntu], defaultLocalShellProfileId: 'ubuntu' }),
+      ),
+    ).toMatchObject({
+      localShellProfiles: [ubuntu],
+      defaultLocalShellProfileId: 'ubuntu',
+    });
+  });
+
+  it('drops malformed profiles rather than importing them', () => {
+    expect(
+      sanitizePreferences(prefs({ localShellProfiles: [{ ...ubuntu, args: '-d Ubuntu' }] }))
+        .localShellProfiles,
+    ).toBeUndefined();
   });
 });
 

--- a/tests/unit/client/local-shell-profile.test.ts
+++ b/tests/unit/client/local-shell-profile.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  localShellLaunchArguments,
+  parseLocalShellArgumentText,
+} from '../../../client/src/local-shell-profile.js';
+
+describe('local shell profile arguments', () => {
+  it('preserves trailing and intermediate blank rows while editing', () => {
+    expect(parseLocalShellArgumentText('-d\n')).toEqual(['-d', '']);
+    expect(parseLocalShellArgumentText('-d\n\nUbuntu')).toEqual(['-d', '', 'Ubuntu']);
+  });
+
+  it('discards blank editor rows only when launching', () => {
+    expect(localShellLaunchArguments(['-d', '', 'Ubuntu', ''])).toEqual([
+      '-d',
+      'Ubuntu',
+    ]);
+    expect(localShellLaunchArguments([''])).toBeUndefined();
+  });
+});

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -9,9 +9,19 @@ import {
 import { DEFAULT_SIDEBAR_WIDTH } from '../../../client/src/sidebar-width.js';
 import {
   MONO_FONT_FALLBACK,
+  isLocalShellProfileArray,
   migratePrefsState,
   terminalFontStack,
 } from '../../../client/src/state/prefs.js';
+
+const ubuntuProfile = {
+  id: 'ubuntu',
+  name: 'Ubuntu',
+  shell: 'wsl.exe',
+  args: ['-d', 'Ubuntu'],
+  cwd: 'C:\\work',
+  startupCommand: 'cd project',
+};
 
 describe('terminalFontStack', () => {
   it('always includes the bundled Nerd Font symbol fallback', () => {
@@ -93,6 +103,25 @@ describe('migratePrefsState', () => {
     expect(migratePrefsState({ terminalScheme: 'muxus', termName: 'xterm-kitty' }, 0)).toEqual({
       terminalScheme: 'vscode-dark',
     });
+  });
+});
+
+describe('local shell profile preferences', () => {
+  it('keeps complete profiles and rejects duplicate IDs', () => {
+    expect(isLocalShellProfileArray([ubuntuProfile])).toBe(true);
+    expect(isLocalShellProfileArray([ubuntuProfile, { ...ubuntuProfile }])).toBe(false);
+  });
+
+  it('drops malformed persisted profiles without changing other preferences', () => {
+    expect(
+      migratePrefsState(
+        {
+          monoFontSize: 16,
+          localShellProfiles: [{ ...ubuntuProfile, args: '-d Ubuntu' }],
+        },
+        6,
+      ),
+    ).toEqual({ monoFontSize: 16 });
   });
 });
 

--- a/tests/unit/client/session-launch-guard.test.ts
+++ b/tests/unit/client/session-launch-guard.test.ts
@@ -3,6 +3,7 @@ import type { SavedHostProfile } from '@muxus/shared';
 import {
   connectSavedHost,
   connectTarget,
+  openLocalShellProfile,
   openLocalTerminal,
 } from '../../../client/src/session-actions.js';
 import { usePrefsStore } from '../../../client/src/state/prefs.js';
@@ -44,7 +45,11 @@ beforeEach(() => {
     activeId: null,
     zoomedPaneId: null,
   });
-  usePrefsStore.setState({ localShell: 'auto' });
+  usePrefsStore.setState({
+    localShell: 'auto',
+    localShellProfiles: [],
+    defaultLocalShellProfileId: '',
+  });
   // Start each test outside the window left behind by the previous one.
   settleGuard();
 });
@@ -101,6 +106,59 @@ describe('repeat launch guard', () => {
 
     expect(second).toBe(first);
     expect(useTabsStore.getState().tabs).toHaveLength(1);
+  });
+
+  it('opens the selected saved local shell with arguments and startup actions', () => {
+    const saved = {
+      id: 'ubuntu',
+      name: 'Ubuntu',
+      shell: 'wsl.exe',
+      args: ['-d', 'Ubuntu'],
+      cwd: 'C:\\work',
+      startupCommand: 'cd project\nnpm run dev',
+    };
+
+    const id = openLocalShellProfile(saved);
+
+    expect(useTabsStore.getState().tabs).toContainEqual(
+      expect.objectContaining({
+        id,
+        title: 'Ubuntu',
+        profile: {
+          kind: 'local',
+          shell: 'wsl.exe',
+          args: ['-d', 'Ubuntu'],
+          cwd: 'C:\\work',
+          startupCommand: 'cd project\nnpm run dev',
+        },
+      }),
+    );
+  });
+
+  it('uses the configured default saved local shell', () => {
+    usePrefsStore.setState({
+      localShellProfiles: [
+        {
+          id: 'powershell',
+          name: 'PowerShell',
+          shell: 'pwsh.exe',
+          args: ['-NoLogo'],
+          cwd: '',
+          startupCommand: '',
+        },
+      ],
+      defaultLocalShellProfileId: 'powershell',
+    });
+
+    const id = openLocalTerminal();
+
+    expect(useTabsStore.getState().tabs).toContainEqual(
+      expect.objectContaining({
+        id,
+        title: 'PowerShell',
+        profile: { kind: 'local', shell: 'pwsh.exe', args: ['-NoLogo'] },
+      }),
+    );
   });
 
   it('reopens a host whose fresh tab was closed inside the window', () => {

--- a/tests/unit/client/window-management.test.ts
+++ b/tests/unit/client/window-management.test.ts
@@ -57,6 +57,22 @@ describe('secondary window launch payloads', () => {
     expect(decodeAppWindowLaunch(encodeAppWindowLaunch(serial))).toEqual(serial);
   });
 
+  it('round-trips a configured local shell launch', () => {
+    const launch: AppWindowLaunch = {
+      kind: 'session',
+      title: 'Ubuntu',
+      profile: {
+        kind: 'local',
+        shell: 'wsl.exe',
+        args: ['-d', 'Ubuntu'],
+        cwd: 'C:\\work',
+        startupCommand: 'cd project',
+      },
+    };
+
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(launch))).toEqual(launch);
+  });
+
   it('rejects malformed or unsupported payloads', () => {
     expect(isAppWindowLaunch({ kind: 'session', title: 'Missing profile' })).toBe(false);
     expect(
@@ -72,6 +88,13 @@ describe('secondary window launch payloads', () => {
       }),
     ).toBe(false);
     expect(isAppWindowLaunch({ kind: 'sftp', connId: '', title: 'Empty connection' })).toBe(false);
+    expect(
+      isAppWindowLaunch({
+        kind: 'session',
+        title: 'Invalid local shell',
+        profile: { kind: 'local', args: ['valid', 42] },
+      }),
+    ).toBe(false);
     expect(decodeAppWindowLaunch('not-base64-json')).toBeUndefined();
   });
 });

--- a/tests/unit/server/pty-manager.test.ts
+++ b/tests/unit/server/pty-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   localPtyArgs,
+  localShellPromptReady,
   localStartupInput,
 } from '../../../server/src/local/pty-manager.js';
 
@@ -20,5 +21,14 @@ describe('local shell profiles', () => {
     );
     expect(localStartupInput('  ')).toBeUndefined();
     expect(localStartupInput(undefined)).toBeUndefined();
+  });
+
+  it('waits for an integrated or visible interactive prompt', () => {
+    expect(localShellPromptReady('Loading profile...\r\n')).toBe(false);
+    expect(localShellPromptReady('Password: ')).toBe(false);
+    expect(localShellPromptReady('\x1b]133;A\x07')).toBe(true);
+    expect(localShellPromptReady('\x1b]633;A;Prompt\x1b\\')).toBe(true);
+    expect(localShellPromptReady('\x1b[32muser@host\x1b[0m $ ')).toBe(true);
+    expect(localShellPromptReady('PS C:\\work> ')).toBe(true);
   });
 });

--- a/tests/unit/server/pty-manager.test.ts
+++ b/tests/unit/server/pty-manager.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  localPtyArgs,
+  localStartupInput,
+} from '../../../server/src/local/pty-manager.js';
+
+describe('local shell profiles', () => {
+  it('keeps shell integration arguments and appends configured arguments', () => {
+    expect(
+      localPtyArgs(
+        { kind: 'local', shell: 'wsl.exe', args: ['-d', 'Ubuntu'] },
+        ['--integration'],
+      ),
+    ).toEqual(['--integration', '-d', 'Ubuntu']);
+  });
+
+  it('turns multiline startup commands into PTY Enter presses', () => {
+    expect(localStartupInput('  cd project\nnpm run dev  ')).toBe(
+      'cd project\rnpm run dev\r',
+    );
+    expect(localStartupInput('  ')).toBeUndefined();
+    expect(localStartupInput(undefined)).toBeUndefined();
+  });
+});

--- a/tests/unit/shared/ws-protocol.test.ts
+++ b/tests/unit/shared/ws-protocol.test.ts
@@ -17,6 +17,39 @@ describe('sessionProfileSchema', () => {
     expect(sessionProfileSchema.safeParse({ kind: 'local' }).success).toBe(true);
   });
 
+  it('accepts structured local shell arguments and startup commands', () => {
+    expect(
+      sessionProfileSchema.parse({
+        kind: 'local',
+        shell: 'wsl.exe',
+        args: ['-d', 'Ubuntu'],
+        cwd: 'C:\\work',
+        startupCommand: 'cd project\nnpm run dev',
+      }),
+    ).toEqual({
+      kind: 'local',
+      shell: 'wsl.exe',
+      args: ['-d', 'Ubuntu'],
+      cwd: 'C:\\work',
+      startupCommand: 'cd project\nnpm run dev',
+    });
+  });
+
+  it('bounds local shell launch data', () => {
+    expect(
+      sessionProfileSchema.safeParse({
+        kind: 'local',
+        args: Array.from({ length: 65 }, () => 'arg'),
+      }).success,
+    ).toBe(false);
+    expect(
+      sessionProfileSchema.safeParse({
+        kind: 'local',
+        startupCommand: 'x'.repeat(32_769),
+      }).success,
+    ).toBe(false);
+  });
+
   it('accepts a full ssh profile', () => {
     const parsed = sessionProfileSchema.safeParse({
       kind: 'ssh',


### PR DESCRIPTION
## Summary

- add named local shell profiles with an executable, structured arguments, starting directory, and startup commands
- expose saved profiles in the sidebar and quick launcher, with an optional default profile for existing local-terminal actions
- preserve profiles in preferences, backups, secondary-window launches, and workspaces
- document the workflow and add protocol, persistence, launch, and PTY coverage

## Why

Muxus could open multiple local terminal tabs, but every new tab used one global shell executable and there was no way to pass structured arguments. On Windows this prevented convenient switching between PowerShell, Command Prompt, and individual WSL distributions.

This adds reusable launch configurations while keeping the existing automatic shell behavior as the fallback.

Closes #63

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 761 passed, 3 skipped