### PR TITLE
Improve appearance mode selector

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -127,6 +127,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = (e: MediaQueryListEvent) => setOsTheme(e.matches ? 'dark' : 'light');
+    setOsTheme(mq.matches ? 'dark' : 'light');
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, []);

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -287,11 +287,11 @@ function AppearanceSection() {
           <ToggleButton value="light" sx={{ px: 2 }}>
             Light
           </ToggleButton>
-          <ToggleButton value="dark" sx={{ px: 2 }}>
-            Dark
-          </ToggleButton>
           <ToggleButton value="os" sx={{ px: 2 }}>
             System
+          </ToggleButton>
+          <ToggleButton value="dark" sx={{ px: 2 }}>
+            Dark
           </ToggleButton>
         </ToggleButtonGroup>
       </Box>

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, type ReactNode, useState } from 'react';
 import AppBar from '@mui/material/AppBar';
 import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
@@ -44,7 +44,7 @@ import { layout } from '../theme.js';
 import { useChordLabel } from '../keymap/hints.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
 import { showToast } from '../state/toast.js';
-import { usePrefsStore } from '../state/prefs.js';
+import { usePrefsStore, type ThemeMode } from '../state/prefs.js';
 import { useTabsStore } from '../state/tabs.js';
 import { useUiStore } from '../state/ui.js';
 import { useWorkspacesStore } from '../state/workspaces.js';
@@ -61,9 +61,18 @@ import {
   loadSftpPanel,
 } from '../lazy-features.js';
 
+const APPEARANCE_OPTIONS: readonly {
+  mode: ThemeMode;
+  label: string;
+  icon: ReactNode;
+}[] = [
+  { mode: 'light', label: 'Light', icon: <LightModeOutlinedIcon fontSize="small" /> },
+  { mode: 'os', label: 'System', icon: <BrightnessAutoOutlinedIcon fontSize="small" /> },
+  { mode: 'dark', label: 'Dark', icon: <DarkModeOutlinedIcon fontSize="small" /> },
+];
+
 export const TopBar = memo(function TopBar() {
   const mode = usePrefsStore((s) => s.themeMode);
-  const toggleTheme = usePrefsStore((s) => s.toggleTheme);
   const sidebarCollapsed = usePrefsStore((s) => s.sidebarCollapsed);
   const setPrefs = usePrefsStore((s) => s.set);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
@@ -83,6 +92,7 @@ export const TopBar = memo(function TopBar() {
   const sshReady = !!activeTab?.connId && activeTab.sftpAvailable !== false;
   const terminalReady = !!activeTab?.profile;
   const [terminalMenu, setTerminalMenu] = useState<HTMLElement | null>(null);
+  const [appearanceMenu, setAppearanceMenu] = useState<HTMLElement | null>(null);
   const sidebarChord = useChordLabel('app.sidebar');
   const findChord = useChordLabel('terminal.find');
   const selectAllChord = useChordLabel('terminal.select-all');
@@ -95,6 +105,7 @@ export const TopBar = memo(function TopBar() {
 
   const handle = () => terminalHandle(activeTab?.id);
   const closeMenu = () => setTerminalMenu(null);
+  const currentAppearance = APPEARANCE_OPTIONS.find((option) => option.mode === mode)!;
 
   return (
     <AppBar position="static" color="transparent" sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -203,9 +214,16 @@ export const TopBar = memo(function TopBar() {
             <HistoryOutlinedIcon fontSize="small" />
           </IconButton>
         </Tooltip>
-        <Tooltip title={mode === 'light' ? 'Switch to dark mode' : mode === 'dark' ? 'Follow system theme' : 'Switch to light mode'}>
-          <IconButton size="small" aria-label="Toggle theme" onClick={toggleTheme}>
-            {mode === 'light' ? <DarkModeOutlinedIcon fontSize="small" /> : mode === 'dark' ? <BrightnessAutoOutlinedIcon fontSize="small" /> : <LightModeOutlinedIcon fontSize="small" />}
+        <Tooltip title={`Appearance: ${currentAppearance.label}`}>
+          <IconButton
+            size="small"
+            aria-label={`Appearance: ${currentAppearance.label}`}
+            aria-controls={appearanceMenu ? 'appearance-menu' : undefined}
+            aria-expanded={appearanceMenu ? 'true' : undefined}
+            aria-haspopup="menu"
+            onClick={(event) => setAppearanceMenu(event.currentTarget)}
+          >
+            {currentAppearance.icon}
           </IconButton>
         </Tooltip>
         <Tooltip title="Keyboard shortcuts">
@@ -231,6 +249,27 @@ export const TopBar = memo(function TopBar() {
           </IconButton>
         </Tooltip>
       </Toolbar>
+
+      <Menu
+        id="appearance-menu"
+        open={!!appearanceMenu}
+        anchorEl={appearanceMenu}
+        onClose={() => setAppearanceMenu(null)}
+      >
+        {APPEARANCE_OPTIONS.map((option) => (
+          <MenuItem
+            key={option.mode}
+            selected={option.mode === mode}
+            onClick={() => {
+              setPrefs({ themeMode: option.mode });
+              setAppearanceMenu(null);
+            }}
+          >
+            <ListItemIcon>{option.icon}</ListItemIcon>
+            <ListItemText>{option.label}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
 
       <Menu open={!!terminalMenu} anchorEl={terminalMenu} onClose={closeMenu}>
         <MenuItem

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -61,15 +61,12 @@ import {
   loadSftpPanel,
 } from '../lazy-features.js';
 
-const APPEARANCE_OPTIONS: readonly {
-  mode: ThemeMode;
-  label: string;
-  icon: ReactNode;
-}[] = [
+const APPEARANCE_OPTIONS = [
   { mode: 'light', label: 'Light', icon: <LightModeOutlinedIcon fontSize="small" /> },
   { mode: 'os', label: 'System', icon: <BrightnessAutoOutlinedIcon fontSize="small" /> },
   { mode: 'dark', label: 'Dark', icon: <DarkModeOutlinedIcon fontSize="small" /> },
-];
+] as const satisfies readonly { mode: ThemeMode; label: string; icon: ReactNode }[];
+const SYSTEM_APPEARANCE = APPEARANCE_OPTIONS[1];
 
 export const TopBar = memo(function TopBar() {
   const mode = usePrefsStore((s) => s.themeMode);
@@ -105,7 +102,8 @@ export const TopBar = memo(function TopBar() {
 
   const handle = () => terminalHandle(activeTab?.id);
   const closeMenu = () => setTerminalMenu(null);
-  const currentAppearance = APPEARANCE_OPTIONS.find((option) => option.mode === mode)!;
+  const currentAppearance =
+    APPEARANCE_OPTIONS.find((option) => option.mode === mode) ?? SYSTEM_APPEARANCE;
 
   return (
     <AppBar position="static" color="transparent" sx={{ borderBottom: 1, borderColor: 'divider' }}>

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -124,8 +124,7 @@ export interface PrefsState {
   sftpPanelWidth: number;
   /** Verbose diagnostic logging plus access to the log viewer and export. */
   debugMode: boolean;
-  toggleTheme: () => void;
-  set: (patch: Partial<Omit<PrefsState, 'set' | 'toggleTheme'>>) => void;
+  set: (patch: Partial<Omit<PrefsState, 'set'>>) => void;
 }
 
 /** Upgrade persisted preferences without mutating the storage snapshot. */
@@ -259,8 +258,6 @@ export const usePrefsStore = create<PrefsState>()(
       sidebarEmptyFolders: [],
       sftpPanelWidth: DEFAULT_SFTP_PANEL_WIDTH,
       debugMode: false,
-      toggleTheme: () =>
-        set((s) => ({ themeMode: s.themeMode === 'light' ? 'dark' : s.themeMode === 'dark' ? 'os' : 'light' })),
       set: (patch) => set(patch),
     }),
     {

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -127,10 +127,16 @@ export interface PrefsState {
   set: (patch: Partial<Omit<PrefsState, 'set'>>) => void;
 }
 
+function isThemeMode(value: unknown): value is ThemeMode {
+  return value === 'light' || value === 'os' || value === 'dark';
+}
+
 /** Upgrade persisted preferences without mutating the storage snapshot. */
 export function migratePrefsState(persisted: unknown, version: number): unknown {
   if (persisted === null || typeof persisted !== 'object') return persisted;
   const state = { ...persisted } as Partial<PrefsState> & { termName?: unknown };
+  // A missing or invalid value falls through to the store's System default.
+  if (!isThemeMode(state.themeMode)) delete state.themeMode;
   // v0 shipped the Muxus scheme as the default; stored copies of that
   // default follow the new one.
   if (version === 0 && state.terminalScheme === 'muxus') state.terminalScheme = 'vscode-dark';
@@ -262,7 +268,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 7,
+      version: 8,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -12,6 +12,7 @@ import {
   isLocalShellProfileArray,
   migratePrefsState,
   terminalFontStack,
+  usePrefsStore,
 } from '../../../client/src/state/prefs.js';
 
 const ubuntuProfile = {
@@ -22,6 +23,19 @@ const ubuntuProfile = {
   cwd: 'C:\\work',
   startupCommand: 'cd project',
 };
+
+describe('appearance preference', () => {
+  it('defaults new installations to the system appearance', () => {
+    expect(usePrefsStore.getInitialState().themeMode).toBe('os');
+  });
+
+  it.each(['light', 'dark'] as const)(
+    'retains an existing explicit %s preference during migration',
+    (themeMode) => {
+      expect(migratePrefsState({ themeMode }, 0)).toMatchObject({ themeMode });
+    },
+  );
+});
 
 describe('terminalFontStack', () => {
   it('always includes the bundled Nerd Font symbol fallback', () => {

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -35,6 +35,12 @@ describe('appearance preference', () => {
       expect(migratePrefsState({ themeMode }, 0)).toMatchObject({ themeMode });
     },
   );
+
+  it('falls back to System when a persisted preference is invalid', () => {
+    expect(migratePrefsState({ themeMode: 'sepia', monoFontSize: 16 }, 7)).toEqual({
+      monoFontSize: 16,
+    });
+  });
 });
 
 describe('terminalFontStack', () => {


### PR DESCRIPTION
## Summary

- replace the cyclic appearance action with a Light/System/Dark selector in the header
- show the active preference through the header icon, tooltip, accessible label, and selected menu item
- order the Settings choices as Light, System, and Dark
- resynchronize System mode when the OS media query listener is attached
- add regression coverage for the System default and preserving explicit Light/Dark choices

## Why

The previous header button described and displayed the next action instead of the active appearance preference. That made the current state ambiguous and hid the available three-way choice.

## Impact

New installations continue to default to System mode, explicit Light and Dark preferences remain persisted, and users can now see and select any appearance mode directly from either the header or Settings.

## Validation

- `pnpm --filter @muxus/tests test -- tests/unit/client/prefs.test.ts` (94 files passed, 767 tests passed)
- `pnpm --filter @muxus/client typecheck`
- `pnpm lint`
- `pnpm --filter @muxus/client build`
- `git diff --check`

Closes #67