### PR TITLE
Support separate terminal themes for light and dark modes

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -26,6 +26,7 @@ import Tooltip from '@mui/material/Tooltip';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -64,7 +65,12 @@ import {
   interfaceZoomLabel,
 } from '../interface-zoom.js';
 import { useChordLabel } from '../keymap/hints.js';
-import { usePrefsStore, type RightClickAction, type ThemeMode } from '../state/prefs.js';
+import {
+  terminalSchemeIdForMode,
+  usePrefsStore,
+  type RightClickAction,
+  type ThemeMode,
+} from '../state/prefs.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
 import { showErrorToast, showToast } from '../state/toast.js';
 import { confirmAction } from '../state/dialogs.js';
@@ -241,6 +247,7 @@ function SectionTitle({ children }: { children: string }) {
 
 function AppearanceSection() {
   const prefs = usePrefsStore();
+  const effectiveThemeMode = useTheme().palette.mode;
   const [installedFontFamilies, setInstalledFontFamilies] = useState<readonly string[]>();
   const [fontCatalogLoading, setFontCatalogLoading] = useState(
     () => window.muxusDesktop?.listLocalFontFamilies !== undefined,
@@ -268,7 +275,9 @@ function AppearanceSection() {
   );
   const zoomInChord = useChordLabel('terminal.zoom-in');
   const zoomOutChord = useChordLabel('terminal.zoom-out');
-  const schemeTheme = terminalScheme(prefs.terminalScheme).theme;
+  const schemeTheme = terminalScheme(
+    terminalSchemeIdForMode(prefs, effectiveThemeMode),
+  ).theme;
   const schemeForeground = schemeTheme.foreground ?? '#cccccc';
   const schemeBackground = schemeTheme.background ?? '#1e1e1e';
 
@@ -320,27 +329,21 @@ function AppearanceSection() {
         </Typography>
       </Box>
       <Box>
-        <SectionTitle>Terminal color scheme</SectionTitle>
-        <FormControl sx={{ width: '100%', maxWidth: 420 }}>
-          <InputLabel id="terminal-color-scheme-label">Color scheme</InputLabel>
-          <Select
-            labelId="terminal-color-scheme-label"
-            value={prefs.terminalScheme}
-            label="Color scheme"
-            onChange={(event) => prefs.set({ terminalScheme: event.target.value })}
-            renderValue={(schemeId) => <SchemeLabel scheme={terminalScheme(schemeId)} showMode />}
-            MenuProps={{ slotProps: { paper: { sx: { maxHeight: 390 } } } }}
-          >
-            {TERMINAL_SCHEME_GROUPS.flatMap((group) => [
-              <ListSubheader key={group.label}>{group.label}</ListSubheader>,
-              ...group.schemes.map((scheme) => (
-                <MenuItem key={scheme.id} value={scheme.id}>
-                  <SchemeLabel scheme={scheme} />
-                </MenuItem>
-              )),
-            ])}
-          </Select>
-        </FormControl>
+        <SectionTitle>Terminal color schemes</SectionTitle>
+        <Stack spacing={2} sx={{ width: '100%', maxWidth: 420 }}>
+          <TerminalSchemeSelect
+            id="light-terminal-theme"
+            label="Light terminal theme"
+            value={prefs.lightTerminalScheme}
+            onChange={(lightTerminalScheme) => prefs.set({ lightTerminalScheme })}
+          />
+          <TerminalSchemeSelect
+            id="dark-terminal-theme"
+            label="Dark terminal theme"
+            value={prefs.darkTerminalScheme}
+            onChange={(darkTerminalScheme) => prefs.set({ darkTerminalScheme })}
+          />
+        </Stack>
         <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mt: 2 }}>
           <Typography variant="body2" color="text.secondary">
             Background color
@@ -470,6 +473,42 @@ function AppearanceSection() {
         </Stack>
       </Box>
     </Stack>
+  );
+}
+
+function TerminalSchemeSelect({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const labelId = `${id}-label`;
+  return (
+    <FormControl fullWidth>
+      <InputLabel id={labelId}>{label}</InputLabel>
+      <Select
+        labelId={labelId}
+        value={value}
+        label={label}
+        onChange={(event) => onChange(event.target.value)}
+        renderValue={(schemeId) => <SchemeLabel scheme={terminalScheme(schemeId)} showMode />}
+        MenuProps={{ slotProps: { paper: { sx: { maxHeight: 390 } } } }}
+      >
+        {TERMINAL_SCHEME_GROUPS.flatMap((group) => [
+          <ListSubheader key={group.label}>{group.label}</ListSubheader>,
+          ...group.schemes.map((scheme) => (
+            <MenuItem key={scheme.id} value={scheme.id}>
+              <SchemeLabel scheme={scheme} />
+            </MenuItem>
+          )),
+        ])}
+      </Select>
+    </FormControl>
   );
 }
 

--- a/client/src/components/TerminalView.tsx
+++ b/client/src/components/TerminalView.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense } from 'react';
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
 import type { SessionTab } from '../state/tabs.js';
-import { usePrefsStore } from '../state/prefs.js';
+import { terminalSchemeIdForMode, usePrefsStore } from '../state/prefs.js';
 import { terminalScheme, themeWithColorOverrides } from '../terminal/palette.js';
 import { loadTerminalViewImpl } from '../lazy-features.js';
 
@@ -9,7 +10,8 @@ const TerminalViewImpl = lazy(loadTerminalViewImpl);
 
 /** Thin Suspense wrapper so xterm and its terminal addons stay off the first paint. */
 export function TerminalView({ tab, active }: { tab: SessionTab; active: boolean }) {
-  const schemeId = usePrefsStore((s) => s.terminalScheme);
+  const mode = useTheme().palette.mode;
+  const schemeId = usePrefsStore((prefs) => terminalSchemeIdForMode(prefs, mode));
   const backgroundColor = usePrefsStore((s) => s.backgroundColor);
   const background = themeWithColorOverrides(
     terminalScheme(schemeId).theme,

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -38,7 +38,12 @@ import { copyToClipboard, readFromClipboard } from '../clipboard.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
 import { showToast } from '../state/toast.js';
 import { broadcastTerminalInput } from '../state/multi-exec.js';
-import { TERMINAL_SYMBOL_FONT, terminalFontStack, usePrefsStore } from '../state/prefs.js';
+import {
+  TERMINAL_SYMBOL_FONT,
+  terminalFontStack,
+  terminalSchemeIdForMode,
+  usePrefsStore,
+} from '../state/prefs.js';
 import { useTabsStore, type SessionTab } from '../state/tabs.js';
 import {
   TERMINAL_MINIMUM_CONTRAST_RATIO,
@@ -160,7 +165,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const cursorBlink = usePrefsStore((s) => s.cursorBlink);
   const cursorStyle = usePrefsStore((s) => s.cursorStyle);
   const scrollback = usePrefsStore((s) => s.scrollback);
-  const schemeId = usePrefsStore((s) => s.terminalScheme);
+  const schemeId = usePrefsStore((prefs) =>
+    terminalSchemeIdForMode(prefs, theme.palette.mode),
+  );
   const fontColor = usePrefsStore((s) => s.fontColor);
   const backgroundColor = usePrefsStore((s) => s.backgroundColor);
   const globalKeywordHighlights = usePrefsStore((s) => s.keywordHighlights);
@@ -304,7 +311,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       // ImageAddon uses a bottom layer for negative-z Kitty placements.
       allowTransparency: true,
       theme: themeWithColorOverrides(
-        terminalScheme(prefs.terminalScheme).theme,
+        terminalScheme(terminalSchemeIdForMode(prefs, theme.palette.mode)).theme,
         prefs.fontColor,
         prefs.backgroundColor,
       ),

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -43,7 +43,8 @@ const PREFERENCE_KEYS = [
   'monoFontSize',
   'fontFamily',
   'lineHeight',
-  'terminalScheme',
+  'lightTerminalScheme',
+  'darkTerminalScheme',
   'fontColor',
   'backgroundColor',
   'scrollback',
@@ -608,7 +609,9 @@ function portableTunnelInput(tunnel: TunnelRecord): Omit<TunnelRecord, 'createdA
  * structure is validated there, individual values here. Anything that fails
  * is dropped rather than rejecting the whole backup.
  */
-export function sanitizePreferences(input: BackupPreferences): Partial<PrefsState> {
+export function sanitizePreferences(
+  input: BackupPreferences & { terminalScheme?: unknown },
+): Partial<PrefsState> {
   const output: Partial<PrefsState> = {};
   if (['light', 'dark', 'os'].includes(input.themeMode)) {
     output.themeMode = input.themeMode;
@@ -620,11 +623,18 @@ export function sanitizePreferences(input: BackupPreferences): Partial<PrefsStat
     output.fontFamily = input.fontFamily;
   }
   if (finiteRange(input.lineHeight, 1, 1.6)) output.lineHeight = input.lineHeight;
-  if (
-    typeof input.terminalScheme === 'string' &&
-    input.terminalScheme.length <= 100
-  ) {
-    output.terminalScheme = input.terminalScheme;
+  const legacyTerminalScheme = validTerminalSchemePreference(input.terminalScheme)
+    ? input.terminalScheme
+    : undefined;
+  if (validTerminalSchemePreference(input.lightTerminalScheme)) {
+    output.lightTerminalScheme = input.lightTerminalScheme;
+  } else if (legacyTerminalScheme !== undefined) {
+    output.lightTerminalScheme = legacyTerminalScheme;
+  }
+  if (validTerminalSchemePreference(input.darkTerminalScheme)) {
+    output.darkTerminalScheme = input.darkTerminalScheme;
+  } else if (legacyTerminalScheme !== undefined) {
+    output.darkTerminalScheme = legacyTerminalScheme;
   }
   if (input.fontColor === '' || validHexColor(input.fontColor)) {
     output.fontColor = input.fontColor;
@@ -719,6 +729,10 @@ export function sanitizePreferences(input: BackupPreferences): Partial<PrefsStat
     output.sidebarFolderOrder = input.sidebarFolderOrder;
   }
   return output;
+}
+
+function validTerminalSchemePreference(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= 100;
 }
 
 function validFolderOrder(value: unknown): value is Record<string, string[]> {

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -6,6 +6,7 @@ import { muxusStateStorage } from './persist-storage.js';
 import type { KeywordHighlightRule } from '@muxus/shared';
 
 export type ThemeMode = 'light' | 'dark' | 'os';
+export type EffectiveThemeMode = Exclude<ThemeMode, 'os'>;
 export type RightClickAction = 'copy-paste' | 'paste' | 'menu';
 
 /** Presentation of one sidebar folder. Folders are paths, not records, so
@@ -56,8 +57,10 @@ export interface PrefsState {
   fontFamily: string;
   /** Terminal line height multiplier (1.0 = font metrics). */
   lineHeight: number;
-  /** Terminal color scheme id (see terminal/palette.ts). */
-  terminalScheme: string;
+  /** Terminal color scheme id used while the effective application theme is light. */
+  lightTerminalScheme: string;
+  /** Terminal color scheme id used while the effective application theme is dark. */
+  darkTerminalScheme: string;
   /** Terminal text color; empty follows the color scheme's foreground. */
   fontColor: string;
   /** Terminal background color; empty follows the color scheme's background. */
@@ -131,15 +134,40 @@ function isThemeMode(value: unknown): value is ThemeMode {
   return value === 'light' || value === 'os' || value === 'dark';
 }
 
+export function terminalSchemeIdForMode(
+  prefs: Pick<PrefsState, 'lightTerminalScheme' | 'darkTerminalScheme'>,
+  mode: EffectiveThemeMode,
+): string {
+  return mode === 'light' ? prefs.lightTerminalScheme : prefs.darkTerminalScheme;
+}
+
 /** Upgrade persisted preferences without mutating the storage snapshot. */
 export function migratePrefsState(persisted: unknown, version: number): unknown {
   if (persisted === null || typeof persisted !== 'object') return persisted;
-  const state = { ...persisted } as Partial<PrefsState> & { termName?: unknown };
+  const state = { ...persisted } as Partial<PrefsState> & {
+    terminalScheme?: unknown;
+    termName?: unknown;
+  };
   // A missing or invalid value falls through to the store's System default.
   if (!isThemeMode(state.themeMode)) delete state.themeMode;
   // v0 shipped the Muxus scheme as the default; stored copies of that
   // default follow the new one.
-  if (version === 0 && state.terminalScheme === 'muxus') state.terminalScheme = 'vscode-dark';
+  let legacyTerminalScheme = state.terminalScheme;
+  if (version === 0 && legacyTerminalScheme === 'muxus') {
+    legacyTerminalScheme = 'vscode-dark';
+  }
+  // v9 split the single scheme preference by effective appearance. Copying
+  // the old value to both modes preserves the terminal users saw before the
+  // upgrade; they can then choose a different scheme for either mode.
+  if (version < 9 && typeof legacyTerminalScheme === 'string') {
+    if (typeof state.lightTerminalScheme !== 'string') {
+      state.lightTerminalScheme = legacyTerminalScheme;
+    }
+    if (typeof state.darkTerminalScheme !== 'string') {
+      state.darkTerminalScheme = legacyTerminalScheme;
+    }
+  }
+  delete state.terminalScheme;
   // TERM is fixed by the server now; remove the retired client override.
   delete state.termName;
   // Folder presentation arrived in v5. A restored or hand-edited snapshot can
@@ -233,7 +261,8 @@ export const usePrefsStore = create<PrefsState>()(
       monoFontSize: 14,
       fontFamily: 'JetBrains Mono',
       lineHeight: 1.0,
-      terminalScheme: 'vscode-dark',
+      lightTerminalScheme: 'vscode-light',
+      darkTerminalScheme: 'vscode-dark',
       fontColor: '',
       backgroundColor: '',
       scrollback: 10_000,
@@ -268,7 +297,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 8,
+      version: 9,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -19,8 +19,10 @@ because storage policy should not change under a running recorder.
 - **Application theme**: light, dark, or follow the system.
 - **Interface scale**: the size of the whole window. Terminal text has a separate zoom
   (++ctrl+shift+equal++ / ++ctrl+shift+minus++ / ++ctrl+wheel++).
-- **Terminal colour scheme**: fifteen schemes, grouped into light and dark sets, with
-  optional text and background colour overrides.
+- **Light terminal theme** and **Dark terminal theme**: separate colour schemes that
+  follow the effective application appearance, including system appearance changes.
+  Fifteen schemes are grouped into light and dark sets, with optional shared text and
+  background colour overrides.
 - **Font**: family, size and line height. The desktop selector includes JetBrains Mono,
   which is bundled, plus the font families installed for the current operating-system
   user. Nerd Font symbols remain an automatic bundled fallback.

--- a/hack/capture.mjs
+++ b/hack/capture.mjs
@@ -30,7 +30,8 @@ const BASE_PREFS = {
   monoFontSize: 14,
   fontFamily: 'JetBrains Mono',
   lineHeight: 1.1,
-  terminalScheme: THEME === 'dark' ? 'vscode-dark' : 'github-light',
+  lightTerminalScheme: 'github-light',
+  darkTerminalScheme: 'vscode-dark',
   sidebarWidth: 250,
   commandButtons: [],
   keywordHighlights: [],
@@ -69,7 +70,7 @@ async function open(prefs = {}, seed) {
       ? route.fulfill({ json: { workspace: null } })
       : route.continue(),
   );
-  const state = JSON.stringify({ state: { ...BASE_PREFS, ...prefs }, version: 6 });
+  const state = JSON.stringify({ state: { ...BASE_PREFS, ...prefs }, version: 9 });
   await page.addInitScript((value) => localStorage.setItem('muxus-prefs', value), state);
   await page.goto(`${env.url}/?token=${env.token}`, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector('[aria-label="Add host"]');

--- a/hack/record.mjs
+++ b/hack/record.mjs
@@ -45,7 +45,8 @@ const PREFS = {
   monoFontSize: 14,
   fontFamily: 'JetBrains Mono',
   lineHeight: 1.1,
-  terminalScheme: THEME === 'dark' ? 'vscode-dark' : 'github-light',
+  lightTerminalScheme: 'github-light',
+  darkTerminalScheme: 'vscode-dark',
   sidebarWidth: 250,
   commandButtons: [],
   keywordHighlights: [],
@@ -184,7 +185,7 @@ await page.route('**/api/workspaces/startup', (route) =>
 );
 await page.addInitScript(
   (value) => localStorage.setItem('muxus-prefs', value),
-  JSON.stringify({ state: PREFS, version: 6 }),
+  JSON.stringify({ state: PREFS, version: 9 }),
 );
 await page.addInitScript(overlay);
 await purgeWorkspaces();

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -23,6 +23,8 @@ beforeEach(() => {
     notifyOnNewVersion: true,
     showCommandBar: true,
     backgroundColor: '',
+    lightTerminalScheme: 'vscode-light',
+    darkTerminalScheme: 'vscode-dark',
     localShellProfiles: [],
     defaultLocalShellProfileId: '',
   });
@@ -149,6 +151,8 @@ describe('backing up preferences', () => {
       notifyOnNewVersion: false,
       showCommandBar: false,
       backgroundColor: '#102030',
+      lightTerminalScheme: 'paper',
+      darkTerminalScheme: 'dracula',
     });
     mockBackupSnapshot();
 
@@ -157,6 +161,8 @@ describe('backing up preferences', () => {
     expect(document.data.preferences.notifyOnNewVersion).toBe(false);
     expect(document.data.preferences.backgroundColor).toBe('#102030');
     expect(document.data.preferences.showCommandBar).toBe(false);
+    expect(document.data.preferences.lightTerminalScheme).toBe('paper');
+    expect(document.data.preferences.darkTerminalScheme).toBe('dracula');
   });
 
   it('includes saved local shell profiles and their default selection', async () => {
@@ -179,6 +185,36 @@ describe('backing up preferences', () => {
 
     expect(document.data.preferences.localShellProfiles).toHaveLength(1);
     expect(document.data.preferences.defaultLocalShellProfileId).toBe('ubuntu');
+  });
+});
+
+describe('restoring terminal color scheme preferences', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores separate light and dark selections', () => {
+    expect(
+      sanitizePreferences(
+        prefs({ lightTerminalScheme: 'paper', darkTerminalScheme: 'dracula' }),
+      ),
+    ).toMatchObject({
+      lightTerminalScheme: 'paper',
+      darkTerminalScheme: 'dracula',
+    });
+  });
+
+  it('restores a legacy single selection into both appearances', () => {
+    expect(sanitizePreferences(prefs({ terminalScheme: 'nord' }))).toMatchObject({
+      lightTerminalScheme: 'nord',
+      darkTerminalScheme: 'nord',
+    });
+  });
+
+  it('drops malformed selections', () => {
+    const restored = sanitizePreferences(
+      prefs({ lightTerminalScheme: 42, darkTerminalScheme: 'x'.repeat(101) }),
+    );
+    expect(restored.lightTerminalScheme).toBeUndefined();
+    expect(restored.darkTerminalScheme).toBeUndefined();
   });
 });
 

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -12,6 +12,7 @@ import {
   isLocalShellProfileArray,
   migratePrefsState,
   terminalFontStack,
+  terminalSchemeIdForMode,
   usePrefsStore,
 } from '../../../client/src/state/prefs.js';
 
@@ -39,6 +40,43 @@ describe('appearance preference', () => {
   it('falls back to System when a persisted preference is invalid', () => {
     expect(migratePrefsState({ themeMode: 'sepia', monoFontSize: 16 }, 7)).toEqual({
       monoFontSize: 16,
+    });
+  });
+});
+
+describe('terminal color scheme preferences', () => {
+  it('defaults new installations to matching light and dark schemes', () => {
+    const initial = usePrefsStore.getInitialState();
+    expect(initial.lightTerminalScheme).toBe('vscode-light');
+    expect(initial.darkTerminalScheme).toBe('vscode-dark');
+  });
+
+  it('selects the scheme for the effective appearance', () => {
+    const prefs = { lightTerminalScheme: 'paper', darkTerminalScheme: 'dracula' };
+    expect(terminalSchemeIdForMode(prefs, 'light')).toBe('paper');
+    expect(terminalSchemeIdForMode(prefs, 'dark')).toBe('dracula');
+  });
+
+  it('migrates a single saved scheme into both appearances', () => {
+    expect(migratePrefsState({ terminalScheme: 'nord' }, 8)).toEqual({
+      lightTerminalScheme: 'nord',
+      darkTerminalScheme: 'nord',
+    });
+  });
+
+  it('keeps split selections when reprocessing an older snapshot', () => {
+    expect(
+      migratePrefsState(
+        {
+          terminalScheme: 'nord',
+          lightTerminalScheme: 'paper',
+          darkTerminalScheme: 'dracula',
+        },
+        8,
+      ),
+    ).toEqual({
+      lightTerminalScheme: 'paper',
+      darkTerminalScheme: 'dracula',
     });
   });
 });
@@ -121,7 +159,8 @@ describe('migratePrefsState', () => {
 
   it('still applies the original color-scheme migration', () => {
     expect(migratePrefsState({ terminalScheme: 'muxus', termName: 'xterm-kitty' }, 0)).toEqual({
-      terminalScheme: 'vscode-dark',
+      lightTerminalScheme: 'vscode-dark',
+      darkTerminalScheme: 'vscode-dark',
     });
   });
 });


### PR DESCRIPTION
## Summary

- add separate Light terminal theme and Dark terminal theme preferences
- apply the matching scheme to existing and newly opened terminals when the effective appearance changes
- migrate the legacy single-scheme preference into both modes and include both selections in backup and restore
- update documentation and demo capture fixtures

## Why

The terminal scheme was stored independently from the application appearance, so switching between light and dark modes could leave terminals with poor contrast. The terminal now derives its active scheme from the effective application mode, including operating-system appearance changes while System mode is selected.

## Validation

- `pnpm build`
- `pnpm lint`
- client and test TypeScript checks
- 775 tests passed, 3 skipped
- browser checks for manual appearance switching, System mode switching, and existing/new terminals

Closes #68