### PR TITLE
Add SFTP actions to host and tab context menus

### DIFF
--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -24,6 +24,7 @@ import CloseFullscreenOutlinedIcon from '@mui/icons-material/CloseFullscreenOutl
 import CloseIcon from '@mui/icons-material/Close';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import GridViewOutlinedIcon from '@mui/icons-material/GridViewOutlined';
 import HorizontalSplitOutlinedIcon from '@mui/icons-material/HorizontalSplitOutlined';
 import LinkOffOutlinedIcon from '@mui/icons-material/LinkOffOutlined';
@@ -178,6 +179,10 @@ export function TabStrip({
 
   const openMenu = (tab: TerminalTab, position: { top: number; left: number }) => setMenu({ position, tab });
   const menuTab = menu ? allTabs.find((t) => t.id === menu.tab.id) : undefined;
+  const menuTabSupportsSftp =
+    menuTab?.profile?.kind === 'ssh' &&
+    (menuTab.status === 'connecting' || menuTab.status === 'connected') &&
+    menuTab.sftpAvailable !== false;
   const canSplitMenuTab = !!menuTab && allTabs.some(
     (tab) => tab.paneId === menuTab.paneId && tab.id !== menuTab.id,
   );
@@ -796,6 +801,19 @@ export function TabStrip({
           </ListItemIcon>
           <ListItemText>Open in new window</ListItemText>
         </MenuItem>
+        {menuTabSupportsSftp ? (
+          <MenuItem
+            onClick={() => {
+              update(menuTab.id, { sftpOpen: true });
+              setMenu(null);
+            }}
+          >
+            <ListItemIcon>
+              <FolderOutlinedIcon fontSize="small" />
+            </ListItemIcon>
+            Open SFTP file browser
+          </MenuItem>
+        ) : null}
         <Divider />
         <MenuItem
           disabled={!canSplitMenuTab}

--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -805,6 +805,7 @@ export function TabStrip({
           <MenuItem
             onClick={() => {
               update(menuTab.id, { sftpOpen: true });
+              activate(menuTab.id);
               setMenu(null);
             }}
           >

--- a/client/src/components/sidebar/HostContextMenu.tsx
+++ b/client/src/components/sidebar/HostContextMenu.tsx
@@ -6,6 +6,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import DriveFileMoveOutlinedIcon from '@mui/icons-material/DriveFileMoveOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import LibraryAddOutlinedIcon from '@mui/icons-material/LibraryAddOutlined';
@@ -13,7 +14,10 @@ import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
 import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
 import { copyToClipboard } from '../../clipboard.js';
-import { managedHostCopyCommand, type ManagedHost } from '../../managed-hosts.js';
+import {
+  managedHostCopyCommand,
+  type ManagedHost,
+} from '../../managed-hosts.js';
 import {
   connectManagedHost,
   openManagedHostInNewWindow,
@@ -22,10 +26,15 @@ import {
   loadFolderDialog,
   loadHostEditorDialog,
   loadHostOrganizationDialog,
+  loadSftpPanel,
   loadTerminalViewImpl,
 } from '../../lazy-features.js';
 import { showToast } from '../../state/toast.js';
 import { useUiStore } from '../../state/ui.js';
+import {
+  managedHostSupportsSftp,
+  openManagedHostSftp,
+} from './host-sftp-action.js';
 
 export interface HostMenuState {
   anchor: HTMLElement;
@@ -88,6 +97,24 @@ export function HostContextMenu({
         </ListItemIcon>
         Open in new window
       </MenuItem>
+      {menu && managedHostSupportsSftp(menu.host) ? (
+        <MenuItem
+          onMouseEnter={() => {
+            void loadTerminalViewImpl();
+            void loadSftpPanel();
+          }}
+          onFocus={() => {
+            void loadTerminalViewImpl();
+            void loadSftpPanel();
+          }}
+          onClick={run(openManagedHostSftp)}
+        >
+          <ListItemIcon>
+            <FolderOpenOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          Open SFTP file browser
+        </MenuItem>
+      ) : null}
       <MenuItem disabled={!canMoveUp} onClick={run(() => onMove(-1))}>
         <ListItemIcon>
           <KeyboardArrowUpIcon fontSize="small" />

--- a/client/src/components/sidebar/host-sftp-action.ts
+++ b/client/src/components/sidebar/host-sftp-action.ts
@@ -1,0 +1,38 @@
+import type { ManagedHost } from '../../managed-hosts.js';
+import { connectHost } from '../../session-actions.js';
+import { useTabsStore } from '../../state/tabs.js';
+
+/** Whether the host context menu may offer the SSH-backed file browser. */
+export function managedHostSupportsSftp(
+  host: ManagedHost,
+): host is Extract<ManagedHost, { kind: 'ssh' }> {
+  return host.kind === 'ssh' && host.entry.metadata?.disableSftp !== true;
+}
+
+/**
+ * Reveal the file browser on a usable tab for this host. Prefer a tab whose
+ * SSH transport is already ready, then one still connecting; only dial a new
+ * session when there is nothing suitable to reuse.
+ */
+export function openManagedHostSftp(host: ManagedHost): string | undefined {
+  if (!managedHostSupportsSftp(host)) return undefined;
+
+  const state = useTabsStore.getState();
+  const matching = state.tabs.filter(
+    (tab) =>
+      tab.profile?.kind === 'ssh' &&
+      tab.profile.target === host.entry.alias &&
+      (tab.status === 'connecting' || tab.status === 'connected') &&
+      tab.sftpAvailable !== false,
+  );
+  const reusable =
+    matching.find((tab) => tab.id === state.activeId && !!tab.connId) ??
+    matching.find((tab) => !!tab.connId) ??
+    matching.find((tab) => tab.id === state.activeId) ??
+    matching[0];
+  const id = reusable?.id ?? connectHost(host.entry);
+  const next = useTabsStore.getState();
+  next.update(id, { sftpOpen: true });
+  next.activate(id);
+  return id;
+}

--- a/tests/unit/client/managed-hosts.test.ts
+++ b/tests/unit/client/managed-hosts.test.ts
@@ -6,6 +6,7 @@ import {
   managedHostKey,
   managedHostRef,
 } from '../../../client/src/managed-hosts.js';
+import { managedHostSupportsSftp } from '../../../client/src/components/sidebar/host-sftp-action.js';
 
 const ROOT = '/home/test/.ssh/config';
 
@@ -142,5 +143,19 @@ describe('managed host identity and clipboard actions', () => {
       label: 'Copy device path',
       text: 'COM3',
     });
+  });
+
+  it('offers SFTP only for SSH hosts where it is not explicitly disabled', () => {
+    const disabled = sshHost('console');
+    disabled.metadata = {
+      profileId: 'ssh-console',
+      connectCount: 0,
+      disableSftp: true,
+    };
+
+    expect(managedHostSupportsSftp(ssh)).toBe(true);
+    expect(managedHostSupportsSftp({ kind: 'ssh', entry: disabled })).toBe(false);
+    expect(managedHostSupportsSftp(telnet)).toBe(false);
+    expect(managedHostSupportsSftp(serial)).toBe(false);
   });
 });

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -3,6 +3,10 @@ import {
   requestClosePane,
   splitActivePane,
 } from '../../../client/src/session-actions.js';
+import {
+  managedHostSupportsSftp,
+  openManagedHostSftp,
+} from '../../../client/src/components/sidebar/host-sftp-action.js';
 import { useDialogStore } from '../../../client/src/state/dialogs.js';
 import { usePrefsStore } from '../../../client/src/state/prefs.js';
 import { useTabsStore } from '../../../client/src/state/tabs.js';
@@ -171,6 +175,84 @@ describe('blank session tabs', () => {
         status: 'connecting',
       }),
     ]);
+  });
+});
+
+describe('host SFTP action', () => {
+  const host = {
+    kind: 'ssh' as const,
+    entry: {
+      alias: 'router',
+      aliases: ['router'],
+      file: '/home/test/.ssh/config',
+      options: {},
+      resolved: {
+        hostname: 'router.example.test',
+        port: 22,
+        identityFiles: [],
+        certificateFiles: [],
+        identitiesOnly: false,
+        forwardAgent: false,
+        proxyJump: [],
+        forwards: [],
+        passwordOnly: false,
+      },
+    },
+  };
+
+  it('connects with the file browser ready to open', () => {
+    const id = openManagedHostSftp(host);
+
+    expect(useTabsStore.getState()).toMatchObject({
+      activeId: id,
+      tabs: [
+        {
+          id,
+          profile: { kind: 'ssh', target: 'router' },
+          status: 'connecting',
+          sftpOpen: true,
+        },
+      ],
+    });
+  });
+
+  it('reuses and activates an existing suitable connection', () => {
+    const existingId = useTabsStore
+      .getState()
+      .open({ kind: 'ssh', target: 'router' }, 'Router');
+    useTabsStore.getState().update(existingId, {
+      status: 'connected',
+      connId: 'connection-1',
+      sftpAvailable: true,
+    });
+    useTabsStore.getState().open({ kind: 'local' }, 'Local');
+
+    expect(openManagedHostSftp(host)).toBe(existingId);
+    expect(useTabsStore.getState()).toMatchObject({
+      activeId: existingId,
+      tabs: [
+        { id: existingId, sftpOpen: true },
+        { profile: { kind: 'local' } },
+      ],
+    });
+  });
+
+  it('does nothing when SFTP is explicitly disabled', () => {
+    const disabled = {
+      ...host,
+      entry: {
+        ...host.entry,
+        metadata: {
+          profileId: 'ssh-router',
+          connectCount: 0,
+          disableSftp: true,
+        },
+      },
+    };
+
+    expect(managedHostSupportsSftp(disabled)).toBe(false);
+    expect(openManagedHostSftp(disabled)).toBeUndefined();
+    expect(useTabsStore.getState().tabs).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- add an **Open SFTP file browser** action to eligible SSH host context menus
- reuse a suitable connected or connecting tab when available, otherwise start the host with its SFTP browser open
- hide the action for Telnet, serial, and explicitly SFTP-disabled hosts
- add the same action to eligible SSH tab context menus while preserving the existing in-session and detached-window workflows

## Validation

- `pnpm test`
- `pnpm lint`
- client and test TypeScript checks
- production client build
- bundle budget check

Closes #69