### PR TITLE
Add window-wide numbered tab shortcuts

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,6 +16,29 @@
         height: 100%;
         margin: 0;
       }
+      .muxus-tab-icon,
+      .muxus-tab-number {
+        transition: opacity 120ms;
+      }
+      .muxus-tab-number {
+        position: absolute;
+        inset: 0;
+        font-size: 11px;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        line-height: 15px;
+        text-align: center;
+        opacity: 0;
+        pointer-events: none;
+      }
+      .muxus-tab-numbers-always .muxus-tab-number,
+      .muxus-tab-number-alt .muxus-tab-numbers-shortcut .muxus-tab-number {
+        opacity: 1;
+      }
+      .muxus-tab-numbers-always .muxus-tab-icon,
+      .muxus-tab-number-alt .muxus-tab-numbers-shortcut .muxus-tab-icon {
+        opacity: 0;
+      }
     </style>
   </head>
   <body>

--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -103,9 +103,13 @@ const initialKeys = collectStaticGraph(entry[0]);
 // Saved local-shell profiles are launchable directly from the sidebar, so the
 // profile preference shape and launch path join the initial graph (~2 KiB raw /
 // ~0.5 KiB gzip). The profile editor remains in the lazy settings dialog.
+//
+// Window-wide tab numbering belongs to the initial tab store and strips. Its
+// ordered-tab derivation, Alt reveal, inline badges and preference add ~1 KiB
+// raw / ~0.2 KiB gzip; the settings control stays lazy.
 check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 795_000,
-  gzip: 258_000,
+  raw: 797_000,
+  gzip: 259_000,
 });
 
 for (const feature of [

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -69,6 +69,7 @@ import {
   terminalSchemeIdForMode,
   usePrefsStore,
   type RightClickAction,
+  type TabNumberVisibility,
   type ThemeMode,
 } from '../state/prefs.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
@@ -723,12 +724,14 @@ function BehaviorSection() {
 /** Split behavior plus the entry point to the full shortcut editor. */
 function KeyboardSection() {
   const splitInheritsSession = usePrefsStore((s) => s.splitInheritsSession);
+  const tabNumberVisibility = usePrefsStore((s) => s.tabNumberVisibility);
   const set = usePrefsStore((s) => s.set);
   const setShortcutsOpen = useUiStore((s) => s.setShortcutsOpen);
   const keybindings = usePrefsStore((s) => s.keybindings);
   const customCount = Object.keys(keybindings).length;
   const splitChord = useChordLabel('pane.split.right');
   const focusChord = useChordLabel('pane.focus.right');
+  const numberedTabChord = useChordLabel('tab.select.1');
   const moveChord = useChordLabel('tab.to-pane.right');
   const zoomChord = useChordLabel('pane.zoom');
 
@@ -756,10 +759,30 @@ function KeyboardSection() {
         />
       </Box>
       <Box>
+        <SectionTitle>Tab numbers</SectionTitle>
+        <TextField
+          select
+          size="small"
+          label="Show tab numbers"
+          value={tabNumberVisibility}
+          onChange={(event) =>
+            set({ tabNumberVisibility: event.target.value as TabNumberVisibility })
+          }
+          sx={{ width: 320, maxWidth: '100%' }}
+        >
+          <MenuItem value="shortcut">While Alt is held</MenuItem>
+          <MenuItem value="always">Always</MenuItem>
+        </TextField>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          Tabs are numbered across the whole window and update when tabs or panes move.
+        </Typography>
+      </Box>
+      <Box>
         <SectionTitle>Layout keys</SectionTitle>
         <Stack spacing={0.75} sx={{ mb: 2 }}>
           <KeyboardSummaryRow label="Split the focused pane in any direction" chord={splitChord} />
           <KeyboardSummaryRow label="Move focus between panes" chord={focusChord} />
+          <KeyboardSummaryRow label="Jump to a window-wide numbered tab" chord={numberedTabChord} />
           <KeyboardSummaryRow label="Send the current tab to another pane" chord={moveChord} />
           <KeyboardSummaryRow label="Zoom a pane / restore the layout" chord={zoomChord} />
         </Stack>

--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -95,10 +95,12 @@ function PinIcon(props: SvgIconProps) {
 /** Browser-style terminal tab strip scoped to one split pane. */
 export function TabStrip({
   paneId,
+  tabNumberById,
   focused,
   zoomed,
 }: {
   paneId: string;
+  tabNumberById: ReadonlyMap<string, number>;
   focused: boolean;
   zoomed: boolean;
 }) {
@@ -277,6 +279,7 @@ export function TabStrip({
     >
       {tabs.map((tab) => {
         const active = tab.id === activeId;
+        const tabNumber = tabNumberById.get(tab.id);
         const hasUnreadOutput = unreadOutputIds.has(tab.id);
         const TabIcon =
           tab.profile === null
@@ -444,8 +447,12 @@ export function TabStrip({
               '&:hover .muxus-tab-close': { visibility: 'visible' },
             })}
           >
-            <Box component="span" sx={{ position: 'relative', display: 'flex', flexShrink: 0 }}>
+            <Box
+              component="span"
+              sx={{ position: 'relative', display: 'flex', width: 18, flexShrink: 0 }}
+            >
               <TabIcon
+                className="muxus-tab-icon"
                 sx={{
                   fontSize: 15,
                   color: hasUnreadOutput
@@ -455,6 +462,16 @@ export function TabStrip({
                       : 'text.secondary',
                 }}
               />
+              {tabNumber !== undefined ? (
+                <Box
+                  component="span"
+                  className="muxus-tab-number"
+                  aria-hidden
+                  title={`Tab ${tabNumber}`}
+                >
+                  {tabNumber}
+                </Box>
+              ) : null}
               {hasUnreadOutput ? (
                 <Box
                   component="span"

--- a/client/src/keymap/commands.ts
+++ b/client/src/keymap/commands.ts
@@ -95,14 +95,15 @@ function moveTabCommand(direction: PaneDirection): KeyCommand {
   };
 }
 
-function selectTabCommand(position: number): KeyCommand {
+function selectTabCommand(position: number, id = String(position)): KeyCommand {
   return {
-    id: `tab.select.${position}`,
+    id: `tab.select.${id}`,
     title: `Go to tab ${position}`,
     category: 'tabs',
     // Ctrl+2…Ctrl+8 are control characters (Ctrl+3 is Escape); leave them
     // to the terminal and take the Alt row that every terminal app uses.
     defaultChords: [`Alt+Digit${position}`, ...macOnly(`Mod+Digit${position}`)],
+    keywords: ['switch', 'jump', 'numbered tab', `tab ${position}`],
     palette: false,
     run: () => tabs().activateTabIndex(position - 1),
   };
@@ -260,14 +261,9 @@ export const KEY_COMMANDS: readonly KeyCommand[] = [
   selectTabCommand(6),
   selectTabCommand(7),
   selectTabCommand(8),
-  {
-    id: 'tab.select.last',
-    title: 'Go to last tab',
-    category: 'tabs',
-    defaultChords: ['Alt+Digit9', ...macOnly('Mod+Digit9')],
-    palette: false,
-    run: () => tabs().activateTabIndex('last'),
-  },
+  // Keep the legacy command id so existing custom bindings survive, while
+  // making 9 select the tab visibly labelled 9 instead of an unrelated last tab.
+  selectTabCommand(9, 'last'),
 
   // Terminal
   {

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -13,6 +13,7 @@ import Box from '@mui/material/Box';
 import { usePrefsStore } from '../state/prefs.js';
 import {
   useTabsStore,
+  tabsInOrder,
   type PaneLeaf,
   type PaneNode,
   type TerminalTab,
@@ -116,12 +117,17 @@ function PaneCanvas({
   const openEditor = useTabsStore((state) => state.openEditor);
   const activateEditor = useTabsStore((state) => state.activateEditor);
   const closeEditor = useTabsStore((state) => state.closeEditor);
+  const tabNumberVisibility = usePrefsStore((state) => state.tabNumberVisibility);
   const { panes, dividers } = useMemo(() => flattenPaneLayout(root), [root]);
   const paneById = useMemo(
     () => new Map(panes.map((entry) => [entry.pane.id, entry.pane])),
     [panes],
   );
   const occupiedPaneIds = useMemo(() => new Set(tabs.map((tab) => tab.paneId)), [tabs]);
+  const tabNumberById = useMemo(
+    () => new Map(tabsInOrder(root, tabs).map((tab, index) => [tab.id, index + 1])),
+    [root, tabs],
+  );
 
   /** Position every box from a pane tree — the live one, or a drag preview. */
   const applyLayout = useCallback(
@@ -150,11 +156,16 @@ function PaneCanvas({
   }, [applyLayout, root, tabs]);
 
   return (
-    <Box ref={containerRef} sx={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden' }}>
+    <Box
+      ref={containerRef}
+      className={`muxus-tab-numbers-${tabNumberVisibility}`}
+      sx={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden' }}
+    >
       {panes.map(({ pane }) => (
         <PaneChrome
           key={pane.id}
           pane={pane}
+          tabNumberById={tabNumberById}
           empty={!occupiedPaneIds.has(pane.id)}
           focused={pane.id === activePaneId}
           zoomed={pane.id === zoomedPaneId}
@@ -302,6 +313,7 @@ function positionDivider(
 
 function PaneChrome({
   pane,
+  tabNumberById,
   empty,
   focused,
   zoomed,
@@ -309,6 +321,7 @@ function PaneChrome({
   register,
 }: {
   pane: PaneLeaf;
+  tabNumberById: ReadonlyMap<string, number>;
   empty: boolean;
   focused: boolean;
   zoomed: boolean;
@@ -331,7 +344,12 @@ function PaneChrome({
         ...(zoomed ? { bgcolor: 'background.default' } : {}),
       }}
     >
-      <TabStrip paneId={pane.id} focused={focused} zoomed={zoomed} />
+      <TabStrip
+        paneId={pane.id}
+        tabNumberById={tabNumberById}
+        focused={focused}
+        zoomed={zoomed}
+      />
       {empty && (
         <Box sx={{ flex: 1, minHeight: 0 }}>
           <EmptyPane onAddHost={onAddHost} />

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -38,7 +38,15 @@ function isTypingTarget(target: EventTarget | null): boolean {
  * Electron bridge instead, and run the same commands.
  */
 export function installShortcuts(): () => void {
+  const updateTabNumberReveal = (event: KeyboardEvent) => {
+    if (!isModifierCode(event.code)) return;
+    document.documentElement.classList.toggle(
+      'muxus-tab-number-alt',
+      event.altKey,
+    );
+  };
   const onKeyDown = (event: KeyboardEvent) => {
+    updateTabNumberReveal(event);
     if (capturing || event.defaultPrevented || event.isComposing) return;
     if (isModifierCode(event.code) || isTypingTarget(event.target)) return;
     for (const command of commandsForEvent(event, usePrefsStore.getState().keybindings)) {
@@ -48,7 +56,10 @@ export function installShortcuts(): () => void {
       return;
     }
   };
+  const hideTabNumbers = () => document.documentElement.classList.remove('muxus-tab-number-alt');
   window.addEventListener('keydown', onKeyDown, true);
+  window.addEventListener('keyup', updateTabNumberReveal, true);
+  window.addEventListener('blur', hideTabNumbers);
 
   const unsubscribers = [
     window.muxusDesktop?.onCloseTab(() => {
@@ -64,6 +75,9 @@ export function installShortcuts(): () => void {
 
   return () => {
     window.removeEventListener('keydown', onKeyDown, true);
+    window.removeEventListener('keyup', updateTabNumberReveal, true);
+    window.removeEventListener('blur', hideTabNumbers);
+    hideTabNumbers();
     for (const unsub of unsubscribers) unsub?.();
   };
 }

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -8,6 +8,7 @@ import type { KeywordHighlightRule } from '@muxus/shared';
 export type ThemeMode = 'light' | 'dark' | 'os';
 export type EffectiveThemeMode = Exclude<ThemeMode, 'os'>;
 export type RightClickAction = 'copy-paste' | 'paste' | 'menu';
+export type TabNumberVisibility = 'shortcut' | 'always';
 
 /** Presentation of one sidebar folder. Folders are paths, not records, so
  *  their looks cannot hang off a host and live here instead. */
@@ -95,6 +96,8 @@ export interface PrefsState {
   interfaceZoom: number;
   /** Splitting a pane opens a second session on the same host. */
   splitInheritsSession: boolean;
+  /** When window-wide shortcut numbers are shown on terminal tabs. */
+  tabNumberVisibility: TabNumberVisibility;
   /**
    * Chords per command id, replacing that command's defaults. An empty array
    * unbinds the command; commands absent from the map keep their defaults.
@@ -134,6 +137,10 @@ function isThemeMode(value: unknown): value is ThemeMode {
   return value === 'light' || value === 'os' || value === 'dark';
 }
 
+function isTabNumberVisibility(value: unknown): value is TabNumberVisibility {
+  return value === 'shortcut' || value === 'always';
+}
+
 export function terminalSchemeIdForMode(
   prefs: Pick<PrefsState, 'lightTerminalScheme' | 'darkTerminalScheme'>,
   mode: EffectiveThemeMode,
@@ -150,6 +157,7 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
   };
   // A missing or invalid value falls through to the store's System default.
   if (!isThemeMode(state.themeMode)) delete state.themeMode;
+  if (!isTabNumberVisibility(state.tabNumberVisibility)) delete state.tabNumberVisibility;
   // v0 shipped the Muxus scheme as the default; stored copies of that
   // default follow the new one.
   let legacyTerminalScheme = state.terminalScheme;
@@ -281,6 +289,7 @@ export const usePrefsStore = create<PrefsState>()(
       restoreScrollback: true,
       interfaceZoom: 1,
       splitInheritsSession: true,
+      tabNumberVisibility: 'shortcut',
       keybindings: {},
       commandButtons: [],
       showCommandBar: true,
@@ -297,7 +306,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 9,
+      version: 10,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -127,8 +127,8 @@ interface TabsState {
   activate: (id: string) => void;
   focusPane: (paneId: string) => void;
   cycle: (backwards: boolean) => void;
-  /** Activate the nth tab of the focused pane, or its last one. */
-  activateTabIndex: (index: number | 'last') => boolean;
+  /** Activate the nth tab across the whole window in pane/strip order. */
+  activateTabIndex: (index: number) => boolean;
   /** Reorder the active tab inside its own pane. */
   moveTabWithinPane: (offset: -1 | 1) => boolean;
   /** Place one tab before or after another tab in the same pane and pin group. */
@@ -260,6 +260,22 @@ function replacePaneTabs(
 ): TerminalTab[] {
   let index = 0;
   return tabs.map((tab) => tab.paneId === paneId ? paneTabs[index++]! : tab);
+}
+
+/** Tabs in deterministic window-wide order: panes first, then each strip left-to-right. */
+export function tabsInOrder(
+  root: PaneNode,
+  tabs: readonly TerminalTab[],
+): TerminalTab[] {
+  const byPane = new Map<string, TerminalTab[]>();
+  for (const tab of tabs) {
+    const paneTabs = byPane.get(tab.paneId);
+    if (paneTabs) paneTabs.push(tab);
+    else byPane.set(tab.paneId, [tab]);
+  }
+  const ordered: TerminalTab[] = [];
+  for (const pane of panesInOrder(root)) ordered.push(...(byPane.get(pane.id) ?? []));
+  return ordered;
 }
 
 /** Insert a tab at an exact target, while keeping each pane's pinned group first. */
@@ -470,9 +486,8 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     }),
   activateTabIndex: (index) => {
     const state = get();
-    const paneTabs = state.tabs.filter((tab) => tab.paneId === state.activePaneId);
-    const target = index === 'last' ? paneTabs.at(-1) : paneTabs[index];
-    if (!target || target.id === state.activeId) return paneTabs.length > 0;
+    const target = tabsInOrder(state.root, state.tabs)[index];
+    if (!target || target.id === state.activeId) return !!target;
     state.activate(target.id);
     return true;
   },

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -97,8 +97,9 @@ restore or reconnect.
 ## Keyboard
 
 Controls whether **new splits continue the current session** (on by default; SSH reuses the
-live connection, and serial always asks), a summary of the layout keys, and access to the
-full shortcut editor.
+live connection, and serial always asks), whether window-wide tab numbers appear **while
+Alt is held** or **always**, a summary of the layout keys, and
+access to the full shortcut editor.
 
 <figure markdown="span">
   ![The keyboard shortcut sheet](../assets/screenshots/shortcuts.png#only-light){ .shadow }

--- a/docs/guide/tabs-and-panes.md
+++ b/docs/guide/tabs-and-panes.md
@@ -57,8 +57,10 @@ serial, or a remote editor.
 - **New tab**: ++ctrl+shift+t++, or the **+** in the strip.
 - **Close**: ++ctrl+shift+w++ (++cmd+w++ on macOS). Not ++ctrl+w++, which deletes a word in
   the shell.
-- **Switch**: ++alt+1++ … ++alt+9++ by position (++alt+9++ is always the last tab), or
-  ++ctrl+pgup++ / ++ctrl+pgdn++.
+- **Switch**: hold ++alt++ to reveal each tab's window-wide number, then use ++alt+1++ …
+  ++alt+9++ to activate that exact tab wherever it lives. **Settings → Keyboard** can keep
+  the numbers visible all the time. ++ctrl+pgup++ / ++ctrl+pgdn++ still cycle within the
+  focused pane.
 - **Reorder or move**: ++ctrl+shift+pgup++ / ++ctrl+shift+pgdn++ reorders in the current
   strip. Drag a tab to an exact position in this strip, another split, or another Muxus
   window. A cross-window drop hands off the live terminal and restores its scrollback.
@@ -71,6 +73,11 @@ serial, or a remote editor.
 
 Each tab shows a status dot: amber while connecting, green when connected, red when the
 transport is gone.
+
+Tab numbers follow depth-first split-tree order: at every split the left or top branch comes
+before the right or bottom branch, then tabs are numbered left-to-right inside each strip.
+Splitting, moving, reordering or closing tabs and panes recalculates the sequence immediately.
+Every tab displays its sequential number; the first nine have default single-digit shortcuts.
 
 ## Interaction between panes and tabs
 
@@ -87,7 +94,8 @@ transport is gone.
 Muxus takes as few keys from the shell as possible:
 
 - ++ctrl+w++ deletes a word, and ++ctrl+2++ … ++ctrl+8++ send their control characters.
-  Closing is therefore ++ctrl+shift+w++, and tabs use ++alt+1++ … ++alt+9++.
+  Closing is therefore ++ctrl+shift+w++, and window-wide tab selection uses
+  ++alt+1++ … ++alt+9++.
 - Chords follow the **character printed on the key cap**, so ++ctrl+shift+z++ is the key
   labelled `Z` on QWERTZ and AZERTY. Arrows and keys whose character a modifier mangles use
   their physical position.

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -44,8 +44,7 @@ resetting them.
 | Next / previous tab | ++ctrl+pgdn++, ++ctrl+pgup++ (also ++ctrl+shift+bracket-right++ / ++ctrl+shift+bracket-left++) |
 | Move tab left / right in the strip | ++ctrl+shift+pgup++, ++ctrl+shift+pgdn++ |
 | Move tab to pane left / right / up / down | ++alt+shift+left++, ++alt+shift+right++, ++alt+shift+up++, ++alt+shift+down++ |
-| Go to tab 1 … 8 | ++alt+1++ … ++alt+8++ |
-| Go to last tab | ++alt+9++ |
+| Go to window-wide tab 1 … 9 | ++alt+1++ … ++alt+9++ |
 
 ## Terminal
 
@@ -96,6 +95,8 @@ Monaco's own bindings apply inside the [remote editor](../guide/editor.md):
 
 - **The shell keeps its keys.** ++ctrl+w++ deletes a word and ++ctrl+2++ … ++ctrl+8++ send
   their control characters, so Muxus uses ++ctrl+shift+w++ and the ++alt++ number row.
+- **Numbered tabs are window-wide.** Hold ++alt++ to reveal the number on every tab;
+  ++alt+1++ … ++alt+9++ activate those exact tabs across all panes.
 - **Keys fall through when they do not apply.** ++alt+left++ moves focus only when a pane
   is to the left; otherwise the shell receives it.
 - **Chords follow the printed key cap.** ++ctrl+shift+z++ is the key labelled `Z` on QWERTZ

--- a/tests/unit/client/keymap.test.ts
+++ b/tests/unit/client/keymap.test.ts
@@ -151,6 +151,16 @@ describe('default bindings', () => {
       'tab.to-pane.right',
     ]);
   });
+
+  it('keeps numbered tab selection on the Alt row', () => {
+    expect(commandsForChord('Alt+Digit3').map((command) => command.id)).toEqual([
+      'tab.select.3',
+    ]);
+    expect(commandsForChord('Alt+Digit9').map((command) => command.id)).toEqual([
+      'tab.select.last',
+    ]);
+    expect(commandsForChord('Alt+Shift+Digit3')).toEqual([]);
+  });
 });
 
 describe('user overrides', () => {

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -44,6 +44,20 @@ describe('appearance preference', () => {
   });
 });
 
+describe('tab number visibility preference', () => {
+  it('defaults to revealing numbers while Alt is held', () => {
+    expect(usePrefsStore.getInitialState().tabNumberVisibility).toBe('shortcut');
+  });
+
+  it('keeps valid persisted values and drops invalid ones', () => {
+    expect(migratePrefsState({ tabNumberVisibility: 'always' }, 9)).toEqual({
+      tabNumberVisibility: 'always',
+    });
+    expect(migratePrefsState({ tabNumberVisibility: 'sometimes' }, 9)).toEqual({});
+    expect(migratePrefsState({ tabNumberVisibility: 'never' }, 9)).toEqual({});
+  });
+});
+
 describe('terminal color scheme preferences', () => {
   it('defaults new installations to matching light and dark schemes', () => {
     const initial = usePrefsStore.getInitialState();

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -699,6 +699,7 @@ describe('keyboard pane focus', () => {
     expect(useTabsStore.getState().cyclePane(false)).toBe(true);
     expect(useTabsStore.getState().activePaneId).toBe('pane-test');
   });
+
 });
 
 describe('moving tabs between panes', () => {
@@ -898,16 +899,19 @@ describe('moving tabs between panes', () => {
     ]);
   });
 
-  it('activates tabs by position within the focused pane', () => {
+  it('activates tabs by their window-wide pane and strip order', () => {
     const store = useTabsStore.getState();
-    const firstId = store.open({ kind: 'local' }, 'One');
-    store.open({ kind: 'local' }, 'Two');
-    const thirdId = store.open({ kind: 'local' }, 'Three');
+    const firstId = store.open({ kind: 'local' }, 'Left one');
+    store.open({ kind: 'local' }, 'Left two');
+    const rightPane = store.split('pane-test', 'right')!;
+    const thirdId = useTabsStore.getState().open({ kind: 'local' }, 'Right one');
+    useTabsStore.getState().open({ kind: 'local' }, 'Right two');
 
     expect(useTabsStore.getState().activateTabIndex(0)).toBe(true);
-    expect(useTabsStore.getState().activeId).toBe(firstId);
-    expect(useTabsStore.getState().activateTabIndex('last')).toBe(true);
-    expect(useTabsStore.getState().activeId).toBe(thirdId);
+    expect(useTabsStore.getState()).toMatchObject({ activePaneId: 'pane-test', activeId: firstId });
+    expect(useTabsStore.getState().activateTabIndex(2)).toBe(true);
+    expect(useTabsStore.getState()).toMatchObject({ activePaneId: rightPane, activeId: thirdId });
+    expect(useTabsStore.getState().activateTabIndex(4)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- number terminal tabs across the entire window using deterministic pane and strip order
- reveal tab numbers while Alt is held, with an Always option in Keyboard settings
- make Alt+1…9 activate the exact numbered tab across split panes
- document the behavior and cover ordering, shortcuts, preference migration, and bundle impact

## Why

Number shortcuts were scoped to the focused pane, so they could not directly reach tabs in other splits and offered no visible mapping.

## User impact

Holding Alt now replaces each tab icon with its window-wide number. Selecting a number activates that tab and moves focus to its pane. Numbers recalculate after split, move, reorder, or close operations.

## Validation

- `pnpm test` (782 passed, 3 skipped)
- `pnpm lint`
- `pnpm --filter @muxus/client build`
- `pnpm --filter @muxus/client check:bundle`
- `pnpm build-docs`

Closes #72