### PR TITLE
Add configurable split pane focus indicators

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -107,8 +107,12 @@ const initialKeys = collectStaticGraph(entry[0]);
 // Window-wide tab numbering belongs to the initial tab store and strips. Its
 // ordered-tab derivation, Alt reveal, inline badges and preference add ~1 KiB
 // raw / ~0.2 KiB gzip; the settings control stays lazy.
+//
+// Split-pane focus highlighting also runs in the initial pane canvas so focus
+// and active multi-exec targets update immediately. Its preference reads and
+// pane-target derivation add less than 1 KiB raw; the settings UI stays lazy.
 check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 797_000,
+  raw: 798_000,
   gzip: 259_000,
 });
 

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -66,6 +66,9 @@ import {
 } from '../interface-zoom.js';
 import { useChordLabel } from '../keymap/hints.js';
 import {
+  MAX_INACTIVE_PANE_DIM_STRENGTH,
+  MIN_INACTIVE_PANE_DIM_STRENGTH,
+  clampInactivePaneDimStrength,
   terminalSchemeIdForMode,
   usePrefsStore,
   type RightClickAction,
@@ -377,6 +380,52 @@ function AppearanceSection() {
               Following the color scheme
             </Typography>
           )}
+        </Stack>
+      </Box>
+      <Box>
+        <SectionTitle>Split pane focus</SectionTitle>
+        <Stack spacing={1.25} sx={{ maxWidth: 440 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={prefs.dimInactivePanes}
+                onChange={(event) => prefs.set({ dimInactivePanes: event.target.checked })}
+              />
+            }
+            label={<Typography variant="body2">Dim inactive panes</Typography>}
+          />
+          <Box sx={{ pl: 4.5, maxWidth: 360 }}>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              Dimming strength —{' '}
+              {Math.round(
+                clampInactivePaneDimStrength(prefs.inactivePaneDimStrength) * 100,
+              )}
+              %
+            </Typography>
+            <Slider
+              aria-label="Inactive pane dimming strength"
+              size="small"
+              min={MIN_INACTIVE_PANE_DIM_STRENGTH * 100}
+              max={MAX_INACTIVE_PANE_DIM_STRENGTH * 100}
+              step={5}
+              value={clampInactivePaneDimStrength(prefs.inactivePaneDimStrength) * 100}
+              disabled={!prefs.dimInactivePanes}
+              onChange={(_event, value) =>
+                prefs.set({ inactivePaneDimStrength: (value as number) / 100 })
+              }
+            />
+          </Box>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={prefs.activePaneBorder}
+                onChange={(event) => prefs.set({ activePaneBorder: event.target.checked })}
+              />
+            }
+            label={<Typography variant="body2">Show a thin accent outline</Typography>}
+          />
         </Stack>
       </Box>
       <Box>

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -25,6 +25,8 @@ import {
 } from './sidebar-width.js';
 import { MIN_SFTP_PANEL_WIDTH } from './sftp-panel-width.js';
 import {
+  MAX_INACTIVE_PANE_DIM_STRENGTH,
+  MIN_INACTIVE_PANE_DIM_STRENGTH,
   isLocalShellProfileArray,
   usePrefsStore,
   type FolderStyle,
@@ -47,6 +49,9 @@ const PREFERENCE_KEYS = [
   'darkTerminalScheme',
   'fontColor',
   'backgroundColor',
+  'activePaneBorder',
+  'dimInactivePanes',
+  'inactivePaneDimStrength',
   'scrollback',
   'cursorBlink',
   'cursorStyle',
@@ -641,6 +646,21 @@ export function sanitizePreferences(
   }
   if (input.backgroundColor === '' || validHexColor(input.backgroundColor)) {
     output.backgroundColor = input.backgroundColor;
+  }
+  if (typeof input.activePaneBorder === 'boolean') {
+    output.activePaneBorder = input.activePaneBorder;
+  }
+  if (typeof input.dimInactivePanes === 'boolean') {
+    output.dimInactivePanes = input.dimInactivePanes;
+  }
+  if (
+    finiteRange(
+      input.inactivePaneDimStrength,
+      MIN_INACTIVE_PANE_DIM_STRENGTH,
+      MAX_INACTIVE_PANE_DIM_STRENGTH,
+    )
+  ) {
+    output.inactivePaneDimStrength = input.inactivePaneDimStrength;
   }
   if (
     Number.isInteger(input.scrollback) &&

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -132,10 +132,13 @@ function PaneCanvas({
   );
   const occupiedPaneIds = useMemo(() => new Set(tabs.map((tab) => tab.paneId)), [tabs]);
   const highlightedPaneIds = useMemo(() => {
-    const paneIds = multiExecPaneIds(tabs, multiExecTargetIds);
+    const paneIds = multiExecPaneIds(
+      panes.map(({ pane }) => pane),
+      multiExecTargetIds,
+    );
     paneIds.add(activePaneId);
     return paneIds;
-  }, [activePaneId, multiExecTargetIds, tabs]);
+  }, [activePaneId, multiExecTargetIds, panes]);
   const tabNumberById = useMemo(
     () => new Map(tabsInOrder(root, tabs).map((tab, index) => [tab.id, index + 1])),
     [root, tabs],

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -10,7 +10,9 @@ import {
   type RefObject,
 } from 'react';
 import Box from '@mui/material/Box';
-import { usePrefsStore } from '../state/prefs.js';
+import { alpha } from '@mui/material/styles';
+import { paneFocusOpacity, usePrefsStore } from '../state/prefs.js';
+import { multiExecPaneIds, useMultiExecStore } from '../state/multi-exec.js';
 import {
   useTabsStore,
   tabsInOrder,
@@ -112,18 +114,28 @@ function PaneCanvas({
   const paneRefs = useRef(new Map<string, HTMLDivElement>());
   const tabRefs = useRef(new Map<string, HTMLDivElement>());
   const dividerRefs = useRef(new Map<string, HTMLHRElement>());
+  const activePaneBorderRefs = useRef(new Map<string, HTMLDivElement>());
   const focusPane = useTabsStore((state) => state.focusPane);
   const resizeSplit = useTabsStore((state) => state.resizeSplit);
   const openEditor = useTabsStore((state) => state.openEditor);
   const activateEditor = useTabsStore((state) => state.activateEditor);
   const closeEditor = useTabsStore((state) => state.closeEditor);
   const tabNumberVisibility = usePrefsStore((state) => state.tabNumberVisibility);
+  const activePaneBorder = usePrefsStore((state) => state.activePaneBorder);
+  const dimInactivePanes = usePrefsStore((state) => state.dimInactivePanes);
+  const inactivePaneDimStrength = usePrefsStore((state) => state.inactivePaneDimStrength);
+  const multiExecTargetIds = useMultiExecStore((state) => state.selectedIds);
   const { panes, dividers } = useMemo(() => flattenPaneLayout(root), [root]);
   const paneById = useMemo(
     () => new Map(panes.map((entry) => [entry.pane.id, entry.pane])),
     [panes],
   );
   const occupiedPaneIds = useMemo(() => new Set(tabs.map((tab) => tab.paneId)), [tabs]);
+  const highlightedPaneIds = useMemo(() => {
+    const paneIds = multiExecPaneIds(tabs, multiExecTargetIds);
+    paneIds.add(activePaneId);
+    return paneIds;
+  }, [activePaneId, multiExecTargetIds, tabs]);
   const tabNumberById = useMemo(
     () => new Map(tabsInOrder(root, tabs).map((tab, index) => [tab.id, index + 1])),
     [root, tabs],
@@ -147,13 +159,17 @@ function PaneCanvas({
         const element = dividerRefs.current.get(divider.splitId);
         if (element) positionDivider(element, divider.direction, divider.bounds, divider.ratio);
       }
+      for (const [paneId, element] of activePaneBorderRefs.current) {
+        const rect = rects.get(paneId);
+        if (rect) positionBox(element, rect, false, 0);
+      }
     },
     [zoomedPaneId],
   );
 
   useLayoutEffect(() => {
     applyLayout(root);
-  }, [applyLayout, root, tabs]);
+  }, [activePaneBorder, applyLayout, highlightedPaneIds, root, tabs]);
 
   return (
     <Box
@@ -168,6 +184,11 @@ function PaneCanvas({
           tabNumberById={tabNumberById}
           empty={!occupiedPaneIds.has(pane.id)}
           focused={pane.id === activePaneId}
+          opacity={paneFocusOpacity(
+            highlightedPaneIds.has(pane.id),
+            dimInactivePanes,
+            inactivePaneDimStrength,
+          )}
           zoomed={pane.id === zoomedPaneId}
           onAddHost={onAddHost}
           register={(element) => registerBox(paneRefs.current, pane.id, element)}
@@ -182,6 +203,8 @@ function PaneCanvas({
             key={tab.id}
             ref={(element: HTMLDivElement | null) => registerBox(tabRefs.current, tab.id, element)}
             data-pane-id={tab.paneId}
+            data-pane-focused={pane.id === activePaneId ? 'true' : 'false'}
+            data-pane-highlighted={highlightedPaneIds.has(pane.id) ? 'true' : 'false'}
             onPointerDown={() => focusPane(tab.paneId)}
             sx={{
               position: 'absolute',
@@ -189,6 +212,11 @@ function PaneCanvas({
               minHeight: 0,
               overflow: 'hidden',
               display: visible ? 'flex' : 'none',
+              opacity: paneFocusOpacity(
+                highlightedPaneIds.has(pane.id),
+                dimInactivePanes,
+                inactivePaneDimStrength,
+              ),
               ...(pane.id === zoomedPaneId ? { bgcolor: 'background.default' } : {}),
             }}
           >
@@ -242,6 +270,28 @@ function PaneCanvas({
           </Box>
         );
       })}
+      {activePaneBorder && panes.length > 1 && !zoomedPaneId
+        ? panes
+            .filter(({ pane }) => highlightedPaneIds.has(pane.id))
+            .map(({ pane }) => (
+              <Box
+                key={pane.id}
+                ref={(element: HTMLDivElement | null) =>
+                  registerBox(activePaneBorderRefs.current, pane.id, element)
+                }
+                aria-hidden
+                data-active-pane-border="true"
+                data-pane-id={pane.id}
+                sx={{
+                  position: 'absolute',
+                  pointerEvents: 'none',
+                  zIndex: 4,
+                  boxShadow: (theme) =>
+                    `inset 0 0 0 1px ${alpha(theme.palette.primary.main, 0.8)}`,
+                }}
+              />
+            ))
+        : null}
       {!zoomedPaneId &&
         dividers.map((divider) => (
           <SplitDivider
@@ -316,6 +366,7 @@ function PaneChrome({
   tabNumberById,
   empty,
   focused,
+  opacity,
   zoomed,
   onAddHost,
   register,
@@ -324,6 +375,7 @@ function PaneChrome({
   tabNumberById: ReadonlyMap<string, number>;
   empty: boolean;
   focused: boolean;
+  opacity: number;
   zoomed: boolean;
   onAddHost: () => void;
   register: (element: HTMLDivElement | null) => void;
@@ -334,6 +386,7 @@ function PaneChrome({
     <Box
       ref={register}
       onPointerDown={() => focusPane(pane.id)}
+      data-pane-focused={focused ? 'true' : 'false'}
       sx={{
         position: 'absolute',
         minWidth: 0,
@@ -341,6 +394,7 @@ function PaneChrome({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+        opacity,
         ...(zoomed ? { bgcolor: 'background.default' } : {}),
       }}
     >

--- a/client/src/state/multi-exec.ts
+++ b/client/src/state/multi-exec.ts
@@ -26,6 +26,16 @@ function unique(tabIds: readonly string[]): string[] {
   return [...new Set(tabIds)];
 }
 
+/** Panes whose terminals currently participate in mirrored input. */
+export function multiExecPaneIds(
+  tabs: readonly { id: string; paneId: string }[],
+  selectedIds: readonly string[],
+): Set<string> {
+  if (selectedIds.length < 2) return new Set();
+  const selected = new Set(selectedIds);
+  return new Set(tabs.filter((tab) => selected.has(tab.id)).map((tab) => tab.paneId));
+}
+
 /**
  * A selection change that also remembers any set large enough to mirror, so
  * switching multi-execution off and on again lands on the same terminals.

--- a/client/src/state/multi-exec.ts
+++ b/client/src/state/multi-exec.ts
@@ -26,14 +26,18 @@ function unique(tabIds: readonly string[]): string[] {
   return [...new Set(tabIds)];
 }
 
-/** Panes whose terminals currently participate in mirrored input. */
+/** Visible panes whose active terminals currently participate in mirrored input. */
 export function multiExecPaneIds(
-  tabs: readonly { id: string; paneId: string }[],
+  panes: readonly { id: string; activeTabId: string | null }[],
   selectedIds: readonly string[],
 ): Set<string> {
   if (selectedIds.length < 2) return new Set();
   const selected = new Set(selectedIds);
-  return new Set(tabs.filter((tab) => selected.has(tab.id)).map((tab) => tab.paneId));
+  return new Set(
+    panes
+      .filter((pane) => pane.activeTabId && selected.has(pane.activeTabId))
+      .map((pane) => pane.id),
+  );
 }
 
 /**

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -10,6 +10,28 @@ export type EffectiveThemeMode = Exclude<ThemeMode, 'os'>;
 export type RightClickAction = 'copy-paste' | 'paste' | 'menu';
 export type TabNumberVisibility = 'shortcut' | 'always';
 
+export const DEFAULT_INACTIVE_PANE_DIM_STRENGTH = 0.15;
+export const MIN_INACTIVE_PANE_DIM_STRENGTH = 0.1;
+export const MAX_INACTIVE_PANE_DIM_STRENGTH = 0.6;
+
+/** Keep hand-edited or older persisted values from making a pane illegible. */
+export function clampInactivePaneDimStrength(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_INACTIVE_PANE_DIM_STRENGTH;
+  return Math.min(
+    MAX_INACTIVE_PANE_DIM_STRENGTH,
+    Math.max(MIN_INACTIVE_PANE_DIM_STRENGTH, value),
+  );
+}
+
+/** Presentation-only opacity for one pane; terminal buffers remain untouched. */
+export function paneFocusOpacity(
+  emphasized: boolean,
+  dimInactivePanes: boolean,
+  dimStrength: number,
+): number {
+  return emphasized || !dimInactivePanes ? 1 : 1 - clampInactivePaneDimStrength(dimStrength);
+}
+
 /** Presentation of one sidebar folder. Folders are paths, not records, so
  *  their looks cannot hang off a host and live here instead. */
 export interface FolderStyle {
@@ -98,6 +120,12 @@ export interface PrefsState {
   splitInheritsSession: boolean;
   /** When window-wide shortcut numbers are shown on terminal tabs. */
   tabNumberVisibility: TabNumberVisibility;
+  /** Draw a theme-accented border around focused and multi-exec panes in a split layout. */
+  activePaneBorder: boolean;
+  /** Reduce the presentation opacity of panes that do not receive keyboard input. */
+  dimInactivePanes: boolean;
+  /** Fraction removed from inactive-pane opacity while dimming is enabled. */
+  inactivePaneDimStrength: number;
   /**
    * Chords per command id, replacing that command's defaults. An empty array
    * unbinds the command; commands absent from the map keep their defaults.
@@ -158,6 +186,16 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
   // A missing or invalid value falls through to the store's System default.
   if (!isThemeMode(state.themeMode)) delete state.themeMode;
   if (!isTabNumberVisibility(state.tabNumberVisibility)) delete state.tabNumberVisibility;
+  if (typeof state.activePaneBorder !== 'boolean') delete state.activePaneBorder;
+  if (typeof state.dimInactivePanes !== 'boolean') delete state.dimInactivePanes;
+  if (
+    typeof state.inactivePaneDimStrength !== 'number' ||
+    !Number.isFinite(state.inactivePaneDimStrength) ||
+    state.inactivePaneDimStrength < MIN_INACTIVE_PANE_DIM_STRENGTH ||
+    state.inactivePaneDimStrength > MAX_INACTIVE_PANE_DIM_STRENGTH
+  ) {
+    delete state.inactivePaneDimStrength;
+  }
   // v0 shipped the Muxus scheme as the default; stored copies of that
   // default follow the new one.
   let legacyTerminalScheme = state.terminalScheme;
@@ -290,6 +328,9 @@ export const usePrefsStore = create<PrefsState>()(
       interfaceZoom: 1,
       splitInheritsSession: true,
       tabNumberVisibility: 'shortcut',
+      activePaneBorder: false,
+      dimInactivePanes: false,
+      inactivePaneDimStrength: DEFAULT_INACTIVE_PANE_DIM_STRENGTH,
       keybindings: {},
       commandButtons: [],
       showCommandBar: true,
@@ -306,7 +347,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 10,
+      version: 11,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -19,6 +19,9 @@ because storage policy should not change under a running recorder.
 - **Application theme**: light, dark, or follow the system.
 - **Interface scale**: the size of the whole window. Terminal text has a separate zoom
   (++ctrl+shift+equal++ / ++ctrl+shift+minus++ / ++ctrl+wheel++).
+- **Split pane focus**: dim inactive panes or add a thin theme-aware outline. Both are off by
+  default; dimming starts at 15% and is adjustable. Multi-exec panes stay emphasized. These
+  effects are presentation-only and do not alter terminal colours or output.
 - **Light terminal theme** and **Dark terminal theme**: separate colour schemes that
   follow the effective application appearance, including system appearance changes.
   Fifteen schemes are grouped into light and dark sets, with optional shared text and

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -25,6 +25,9 @@ beforeEach(() => {
     backgroundColor: '',
     lightTerminalScheme: 'vscode-light',
     darkTerminalScheme: 'vscode-dark',
+    activePaneBorder: false,
+    dimInactivePanes: false,
+    inactivePaneDimStrength: 0.15,
     localShellProfiles: [],
     defaultLocalShellProfileId: '',
   });
@@ -153,6 +156,9 @@ describe('backing up preferences', () => {
       backgroundColor: '#102030',
       lightTerminalScheme: 'paper',
       darkTerminalScheme: 'dracula',
+      activePaneBorder: false,
+      dimInactivePanes: true,
+      inactivePaneDimStrength: 0.35,
     });
     mockBackupSnapshot();
 
@@ -163,6 +169,9 @@ describe('backing up preferences', () => {
     expect(document.data.preferences.showCommandBar).toBe(false);
     expect(document.data.preferences.lightTerminalScheme).toBe('paper');
     expect(document.data.preferences.darkTerminalScheme).toBe('dracula');
+    expect(document.data.preferences.activePaneBorder).toBe(false);
+    expect(document.data.preferences.dimInactivePanes).toBe(true);
+    expect(document.data.preferences.inactivePaneDimStrength).toBe(0.35);
   });
 
   it('includes saved local shell profiles and their default selection', async () => {
@@ -215,6 +224,31 @@ describe('restoring terminal color scheme preferences', () => {
     );
     expect(restored.lightTerminalScheme).toBeUndefined();
     expect(restored.darkTerminalScheme).toBeUndefined();
+  });
+});
+
+describe('restoring split pane focus preferences', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores the two indicators and dimming strength independently', () => {
+    expect(
+      sanitizePreferences(
+        prefs({ activePaneBorder: false, dimInactivePanes: true, inactivePaneDimStrength: 0.35 }),
+      ),
+    ).toMatchObject({
+      activePaneBorder: false,
+      dimInactivePanes: true,
+      inactivePaneDimStrength: 0.35,
+    });
+  });
+
+  it('drops malformed or unreadable dimming choices', () => {
+    const restored = sanitizePreferences(
+      prefs({ activePaneBorder: 'yes', dimInactivePanes: 'yes', inactivePaneDimStrength: 0.9 }),
+    );
+    expect(restored.activePaneBorder).toBeUndefined();
+    expect(restored.dimInactivePanes).toBeUndefined();
+    expect(restored.inactivePaneDimStrength).toBeUndefined();
   });
 });
 

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { toggleMultiExec } from '../../../client/src/session-actions.js';
 import {
   broadcastTerminalInput,
+  multiExecPaneIds,
   useMultiExecStore,
 } from '../../../client/src/state/multi-exec.js';
 import { useTabsStore } from '../../../client/src/state/tabs.js';
@@ -54,6 +55,20 @@ function connectTab(title: string): string {
 }
 
 describe('multi-execution routing', () => {
+  it('identifies every pane participating in active mirrored input', () => {
+    const tabs = [
+      { id: 'tab-a', paneId: 'pane-left' },
+      { id: 'tab-b', paneId: 'pane-right' },
+      { id: 'tab-c', paneId: 'pane-right' },
+    ];
+
+    expect([...multiExecPaneIds(tabs, ['tab-a'])]).toEqual([]);
+    expect([...multiExecPaneIds(tabs, ['tab-a', 'tab-c'])]).toEqual([
+      'pane-left',
+      'pane-right',
+    ]);
+  });
+
   it('mirrors source input only to the other selected terminals', () => {
     const sends = [vi.fn(() => true), vi.fn(() => true), vi.fn(() => true)];
     const unregister = [

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -55,18 +55,15 @@ function connectTab(title: string): string {
 }
 
 describe('multi-execution routing', () => {
-  it('identifies every pane participating in active mirrored input', () => {
-    const tabs = [
-      { id: 'tab-a', paneId: 'pane-left' },
-      { id: 'tab-b', paneId: 'pane-right' },
-      { id: 'tab-c', paneId: 'pane-right' },
+  it('identifies panes whose visible tabs participate in active mirrored input', () => {
+    const panes = [
+      { id: 'pane-left', activeTabId: 'tab-a' },
+      { id: 'pane-right', activeTabId: 'tab-b' },
     ];
 
-    expect([...multiExecPaneIds(tabs, ['tab-a'])]).toEqual([]);
-    expect([...multiExecPaneIds(tabs, ['tab-a', 'tab-c'])]).toEqual([
-      'pane-left',
-      'pane-right',
-    ]);
+    expect([...multiExecPaneIds(panes, ['tab-a'])]).toEqual([]);
+    expect([...multiExecPaneIds(panes, ['tab-a', 'tab-c'])]).toEqual(['pane-left']);
+    expect([...multiExecPaneIds(panes, ['tab-a', 'tab-b'])]).toEqual(['pane-left', 'pane-right']);
   });
 
   it('mirrors source input only to the other selected terminals', () => {

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -8,9 +8,12 @@ import {
 } from '../../../client/src/interface-zoom.js';
 import { DEFAULT_SIDEBAR_WIDTH } from '../../../client/src/sidebar-width.js';
 import {
+  DEFAULT_INACTIVE_PANE_DIM_STRENGTH,
   MONO_FONT_FALLBACK,
+  clampInactivePaneDimStrength,
   isLocalShellProfileArray,
   migratePrefsState,
+  paneFocusOpacity,
   terminalFontStack,
   terminalSchemeIdForMode,
   usePrefsStore,
@@ -41,6 +44,38 @@ describe('appearance preference', () => {
     expect(migratePrefsState({ themeMode: 'sepia', monoFontSize: 16 }, 7)).toEqual({
       monoFontSize: 16,
     });
+  });
+});
+
+describe('split pane focus preferences', () => {
+  it('leaves both indicators off by default with dimming set to 15%', () => {
+    const initial = usePrefsStore.getInitialState();
+    expect(initial.activePaneBorder).toBe(false);
+    expect(initial.dimInactivePanes).toBe(false);
+    expect(initial.inactivePaneDimStrength).toBe(DEFAULT_INACTIVE_PANE_DIM_STRENGTH);
+  });
+
+  it('keeps valid choices and drops malformed persisted values', () => {
+    expect(
+      migratePrefsState(
+        { activePaneBorder: false, dimInactivePanes: true, inactivePaneDimStrength: 0.4 },
+        10,
+      ),
+    ).toEqual({ activePaneBorder: false, dimInactivePanes: true, inactivePaneDimStrength: 0.4 });
+    expect(
+      migratePrefsState(
+        { activePaneBorder: 'yes', dimInactivePanes: 1, inactivePaneDimStrength: 0.95 },
+        10,
+      ),
+    ).toEqual({});
+  });
+
+  it('dims only inactive panes and bounds presentation opacity', () => {
+    expect(paneFocusOpacity(true, true, 0.4)).toBe(1);
+    expect(paneFocusOpacity(false, false, 0.4)).toBe(1);
+    expect(paneFocusOpacity(false, true, 0.4)).toBe(0.6);
+    expect(clampInactivePaneDimStrength(Number.NaN)).toBe(DEFAULT_INACTIVE_PANE_DIM_STRENGTH);
+    expect(paneFocusOpacity(false, true, 1)).toBe(0.4);
   });
 });
 


### PR DESCRIPTION
## Summary

- add independent controls for inactive-pane dimming and a thin theme-aware focus outline
- keep the focused pane and panes participating in active multi-execution emphasized
- persist, validate, back up, and restore the new preferences
- leave both indicators disabled by default, with dimming preset to 15% when enabled

## Why

Split layouts can make the keyboard target difficult to identify, especially with several terminal panes. These presentation-only indicators improve focus visibility without changing terminal colors, copied text, or captured output.

## Validation

- `pnpm test` (788 passed, 3 skipped)
- `pnpm --filter @muxus/client typecheck`
- `pnpm exec oxlint ... --deny-warnings`

Closes #71