### PR TITLE
Add reusable syntax highlighting profiles

### DIFF
--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -111,9 +111,14 @@ const initialKeys = collectStaticGraph(entry[0]);
 // Split-pane focus highlighting also runs in the initial pane canvas so focus
 // and active multi-exec targets update immediately. Its preference reads and
 // pane-target derivation add less than 1 KiB raw; the settings UI stays lazy.
+//
+// Reusable keyword-highlighting profiles are persisted preferences. Their
+// bounded shape validator therefore joins the startup preference migration
+// (~1.5 KiB raw / ~0.3 KiB gzip); profile editing and transfer UI stay in the
+// lazy settings chunk, and terminal resolution stays in the terminal chunk.
 check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 798_000,
-  gzip: 259_000,
+  raw: 800_000,
+  gzip: 259_500,
 });
 
 for (const feature of [

--- a/client/src/components/HighlightProfilesSection.tsx
+++ b/client/src/components/HighlightProfilesSection.tsx
@@ -1,0 +1,238 @@
+import { useRef, useState, type ChangeEvent } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined';
+import type { KeywordHighlightProfile } from '@muxus/shared';
+import { newPreferenceId } from '../command-buttons.js';
+import {
+  MAX_HIGHLIGHT_PROFILE_FILE_BYTES,
+  createHighlightProfileDocument,
+  mergeHighlightProfiles,
+  parseHighlightProfileDocument,
+} from '../highlight-profiles.js';
+import { exportFilename, saveTextFile } from '../save-file.js';
+import { confirmAction } from '../state/dialogs.js';
+import { usePrefsStore } from '../state/prefs.js';
+import { showErrorToast, showToast } from '../state/toast.js';
+import { KeywordHighlightRulesEditor } from './KeywordHighlightRulesEditor.js';
+
+export function HighlightProfilesSection() {
+  const globalRules = usePrefsStore((state) => state.keywordHighlights);
+  const profiles = usePrefsStore((state) => state.keywordHighlightProfiles);
+  const setPrefs = usePrefsStore((state) => state.set);
+  const importInput = useRef<HTMLInputElement>(null);
+  const [selectedId, setSelectedId] = useState('');
+  const selectedProfile =
+    profiles.find((profile) => profile.id === selectedId) ?? profiles[0];
+
+  const updateProfile = (
+    id: string,
+    patch: Partial<Pick<KeywordHighlightProfile, 'name' | 'rules'>>,
+  ) => {
+    const current = usePrefsStore.getState().keywordHighlightProfiles;
+    setPrefs({
+      keywordHighlightProfiles: current.map((profile) =>
+        profile.id === id ? { ...profile, ...patch } : profile,
+      ),
+    });
+  };
+
+  const addProfile = () => {
+    const current = usePrefsStore.getState().keywordHighlightProfiles;
+    const profile: KeywordHighlightProfile = {
+      id: newPreferenceId('highlight-profile'),
+      name: unusedProfileName(current),
+      rules: [],
+    };
+    setPrefs({ keywordHighlightProfiles: [...current, profile] });
+    setSelectedId(profile.id);
+  };
+
+  const deleteProfile = (profile: KeywordHighlightProfile) => {
+    void confirmAction({
+      title: `Delete ${profile.name}?`,
+      description:
+        'Hosts assigned to this profile will stop receiving its shared rules. Their own rules are not changed.',
+      confirmLabel: 'Delete profile',
+      destructive: true,
+    }).then((confirmed) => {
+      if (!confirmed) return;
+      const current = usePrefsStore.getState().keywordHighlightProfiles;
+      usePrefsStore.getState().set({
+        keywordHighlightProfiles: current.filter((candidate) => candidate.id !== profile.id),
+      });
+      setSelectedId('');
+    });
+  };
+
+  const exportProfile = (profile: KeywordHighlightProfile) => {
+    try {
+      const document = createHighlightProfileDocument([profile]);
+      saveTextFile(
+        exportFilename(`${profile.name} highlighting profile`, 'muxus-highlight.json'),
+        `${JSON.stringify(document, null, 2)}\n`,
+        'application/json',
+      );
+      showToast('success', `Exported ${profile.name}.`);
+    } catch (error) {
+      showErrorToast(error);
+    }
+  };
+
+  const importProfiles = async (file: File) => {
+    if (file.size > MAX_HIGHLIGHT_PROFILE_FILE_BYTES) {
+      showToast('error', 'That highlighting profile file is too large.');
+      return;
+    }
+    try {
+      const document = parseHighlightProfileDocument(await file.text());
+      const current = usePrefsStore.getState().keywordHighlightProfiles;
+      usePrefsStore.getState().set({
+        keywordHighlightProfiles: mergeHighlightProfiles(current, document.profiles),
+      });
+      setSelectedId(document.profiles[0]?.id ?? '');
+      showToast(
+        'success',
+        `Imported ${document.profiles.length} highlighting profile${document.profiles.length === 1 ? '' : 's'}. Matching IDs were updated.`,
+      );
+    } catch (error) {
+      showErrorToast(error);
+    }
+  };
+
+  const chooseImport = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (file) void importProfiles(file);
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+          Global keyword highlighting
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          These literal keywords are highlighted in every terminal. A host can include
+          these rules and add its assigned profile and own rules, or replace the global
+          set entirely.
+        </Typography>
+        <KeywordHighlightRulesEditor
+          rules={globalRules}
+          onChange={(keywordHighlights) => setPrefs({ keywordHighlights })}
+        />
+      </Box>
+
+      <Divider />
+
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+          Reusable profiles
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 2 }}>
+          Define a platform-specific rule set once, assign it in any host editor, and
+          export it to share with another Muxus installation.
+        </Typography>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          sx={{ alignItems: { sm: 'center' } }}
+        >
+          <TextField
+            select
+            size="small"
+            label="Profile"
+            value={selectedProfile?.id ?? ''}
+            onChange={(event) => setSelectedId(event.target.value)}
+            sx={{ minWidth: 240, flex: 1 }}
+          >
+            {profiles.length === 0 ? (
+              <MenuItem value="" disabled>
+                No profiles yet
+              </MenuItem>
+            ) : null}
+            {profiles.map((profile) => (
+              <MenuItem key={profile.id} value={profile.id}>
+                {profile.name} ({profile.rules.length})
+              </MenuItem>
+            ))}
+          </TextField>
+          <Button startIcon={<AddIcon />} onClick={addProfile}>
+            New
+          </Button>
+          <Button startIcon={<UploadFileOutlinedIcon />} onClick={() => importInput.current?.click()}>
+            Import
+          </Button>
+          <input
+            ref={importInput}
+            hidden
+            type="file"
+            accept=".muxus-highlight,.json,.muxus-highlight.json,application/json"
+            onChange={chooseImport}
+          />
+        </Stack>
+      </Box>
+
+      {selectedProfile ? (
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            label="Profile name"
+            value={selectedProfile.name}
+            onChange={(event) =>
+              updateProfile(selectedProfile.id, { name: event.target.value })
+            }
+            onBlur={() => {
+              if (!selectedProfile.name.trim()) {
+                updateProfile(selectedProfile.id, { name: 'Untitled profile' });
+              }
+            }}
+            slotProps={{ htmlInput: { maxLength: 200 } }}
+          />
+          <KeywordHighlightRulesEditor
+            rules={selectedProfile.rules}
+            onChange={(rules) => updateProfile(selectedProfile.id, { rules })}
+            emptyMessage="No rules in this profile yet."
+          />
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+            <Button
+              variant="outlined"
+              startIcon={<DownloadOutlinedIcon />}
+              disabled={!selectedProfile.name.trim()}
+              onClick={() => exportProfile(selectedProfile)}
+            >
+              Export profile
+            </Button>
+            <Button
+              color="error"
+              startIcon={<DeleteOutlineIcon />}
+              onClick={() => deleteProfile(selectedProfile)}
+            >
+              Delete profile
+            </Button>
+          </Stack>
+        </Stack>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          Create or import a profile to reuse highlighting rules across hosts.
+        </Typography>
+      )}
+    </Stack>
+  );
+}
+
+function unusedProfileName(profiles: readonly KeywordHighlightProfile[]): string {
+  const names = new Set(profiles.map((profile) => profile.name.toLocaleLowerCase()));
+  if (!names.has('new profile')) return 'New profile';
+  let suffix = 2;
+  while (names.has(`new profile ${suffix}`)) suffix++;
+  return `New profile ${suffix}`;
+}

--- a/client/src/components/HighlightProfilesSection.tsx
+++ b/client/src/components/HighlightProfilesSection.tsx
@@ -14,6 +14,7 @@ import type { KeywordHighlightProfile } from '@muxus/shared';
 import { newPreferenceId } from '../command-buttons.js';
 import {
   MAX_HIGHLIGHT_PROFILE_FILE_BYTES,
+  MAX_KEYWORD_HIGHLIGHT_PROFILES,
   createHighlightProfileDocument,
   mergeHighlightProfiles,
   parseHighlightProfileDocument,
@@ -47,6 +48,13 @@ export function HighlightProfilesSection() {
 
   const addProfile = () => {
     const current = usePrefsStore.getState().keywordHighlightProfiles;
+    if (current.length >= MAX_KEYWORD_HIGHLIGHT_PROFILES) {
+      showToast(
+        'error',
+        `Muxus supports up to ${MAX_KEYWORD_HIGHLIGHT_PROFILES} highlighting profiles. Delete one before creating another.`,
+      );
+      return;
+    }
     const profile: KeywordHighlightProfile = {
       id: newPreferenceId('highlight-profile'),
       name: unusedProfileName(current),
@@ -165,7 +173,11 @@ export function HighlightProfilesSection() {
               </MenuItem>
             ))}
           </TextField>
-          <Button startIcon={<AddIcon />} onClick={addProfile}>
+          <Button
+            startIcon={<AddIcon />}
+            disabled={profiles.length >= MAX_KEYWORD_HIGHLIGHT_PROFILES}
+            onClick={addProfile}
+          >
             New
           </Button>
           <Button startIcon={<UploadFileOutlinedIcon />} onClick={() => importInput.current?.click()}>

--- a/client/src/components/HostEditorDialog.tsx
+++ b/client/src/components/HostEditorDialog.tsx
@@ -213,7 +213,11 @@ function SshHostEditorContent({
         color: draft.color ?? null,
         disableSftp: draft.disableSftp,
         keywordHighlights:
-          highlights.inheritGlobal && highlights.rules.length === 0 ? null : highlights,
+          highlights.inheritGlobal &&
+          !highlights.profileId &&
+          highlights.rules.length === 0
+            ? null
+            : highlights,
       },
     });
   });
@@ -274,7 +278,14 @@ function SshHostEditorContent({
     },
     { value: 'forwards', label: 'Port forwarding', icon: <SwapHorizOutlinedIcon fontSize="small" />, count: draft.forwards.length },
     { value: 'logging', label: 'Session logging', icon: <HistoryOutlinedIcon fontSize="small" /> },
-    { value: 'highlighting', label: 'Highlighting', icon: <HighlightOutlinedIcon fontSize="small" />, count: draft.keywordHighlights.rules.length },
+    {
+      value: 'highlighting',
+      label: 'Highlighting',
+      icon: <HighlightOutlinedIcon fontSize="small" />,
+      count:
+        draft.keywordHighlights.rules.length +
+        (draft.keywordHighlights.profileId ? 1 : 0),
+    },
     {
       value: 'advanced',
       label: 'Advanced',

--- a/client/src/components/NativeHostEditorContent.tsx
+++ b/client/src/components/NativeHostEditorContent.tsx
@@ -148,7 +148,9 @@ export function NativeHostEditorContent({
       value: 'highlighting',
       label: 'Highlighting',
       icon: <HighlightOutlinedIcon fontSize="small" />,
-      count: draft.keywordHighlights.rules.length,
+      count:
+        draft.keywordHighlights.rules.length +
+        (draft.keywordHighlights.profileId ? 1 : 0),
     },
   ];
 

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -86,7 +86,7 @@ import {
   terminalFontIsAvailable,
 } from '../terminal/font-catalog.js';
 import { chordSx } from './chord-style.js';
-import { KeywordHighlightRulesEditor } from './KeywordHighlightRulesEditor.js';
+import { HighlightProfilesSection } from './HighlightProfilesSection.js';
 import { LocalShellProfilesSection } from './LocalShellProfilesSection.js';
 import { SessionLoggingPolicyFields } from './SessionLoggingPolicyFields.js';
 import { DataTransferSection } from './DataTransferSection.js';
@@ -206,7 +206,7 @@ export function SettingsDialog() {
             {section === 'terminal' && <TerminalSection />}
             {section === 'local-shells' && <LocalShellProfilesSection />}
             {section === 'logging' && <SessionLoggingSection onDirtyChange={setLoggingDirty} />}
-            {section === 'highlighting' && <HighlightingSection />}
+            {section === 'highlighting' && <HighlightProfilesSection />}
             {section === 'behavior' && <BehaviorSection />}
             {section === 'keyboard' && <KeyboardSection />}
             {section === 'passwords' && <PasswordVaultSection />}
@@ -1126,26 +1126,6 @@ function HistoryStorageSettings({ onDirtyChange }: { onDirtyChange: (dirty: bool
         >
           Save history storage
         </Button>
-      </Box>
-    </Stack>
-  );
-}
-
-function HighlightingSection() {
-  const rules = usePrefsStore((state) => state.keywordHighlights);
-  const setPrefs = usePrefsStore((state) => state.set);
-  return (
-    <Stack spacing={1.5}>
-      <Box>
-        <SectionTitle>Global keyword highlighting</SectionTitle>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          These literal keywords are highlighted in every terminal. A host can include these rules
-          and add its own, or replace them entirely.
-        </Typography>
-        <KeywordHighlightRulesEditor
-          rules={rules}
-          onChange={(keywordHighlights) => setPrefs({ keywordHighlights })}
-        />
       </Box>
     </Stack>
   );

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -171,6 +171,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const fontColor = usePrefsStore((s) => s.fontColor);
   const backgroundColor = usePrefsStore((s) => s.backgroundColor);
   const globalKeywordHighlights = usePrefsStore((s) => s.keywordHighlights);
+  const keywordHighlightProfiles = usePrefsStore((s) => s.keywordHighlightProfiles);
   const scheme = terminalScheme(schemeId);
   const terminalTheme = useMemo(
     () => themeWithColorOverrides(scheme.theme, fontColor, backgroundColor),
@@ -193,8 +194,17 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       ?.keywordHighlights;
   }, [sshConfig, savedHosts, savedProfileId, tab.profile]);
   const keywordHighlights = useMemo(
-    () => resolveKeywordHighlights(globalKeywordHighlights, hostKeywordHighlights),
-    [globalKeywordHighlights, hostKeywordHighlights],
+    () =>
+      resolveKeywordHighlights(
+        globalKeywordHighlights,
+        hostKeywordHighlights,
+        hostKeywordHighlights?.profileId
+          ? keywordHighlightProfiles.find(
+              (profile) => profile.id === hostKeywordHighlights.profileId,
+            )?.rules
+          : undefined,
+      ),
+    [globalKeywordHighlights, hostKeywordHighlights, keywordHighlightProfiles],
   );
 
   const searchOptions = useMemo<ISearchOptions>(

--- a/client/src/components/host-editor/HighlightingSection.tsx
+++ b/client/src/components/host-editor/HighlightingSection.tsx
@@ -1,9 +1,13 @@
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import type { HostKeywordHighlightConfig } from '@muxus/shared';
+import { usePrefsStore } from '../../state/prefs.js';
 import { KeywordHighlightRulesEditor } from '../KeywordHighlightRulesEditor.js';
 
 export function HighlightingSection({
@@ -15,6 +19,11 @@ export function HighlightingSection({
   onChange: (config: HostKeywordHighlightConfig) => void;
   description?: string;
 }) {
+  const profiles = usePrefsStore((state) => state.keywordHighlightProfiles);
+  const selectedProfile = config.profileId
+    ? profiles.find((profile) => profile.id === config.profileId)
+    : undefined;
+
   return (
     <Stack spacing={2}>
       <Box>
@@ -25,6 +34,41 @@ export function HighlightingSection({
           {description}
         </Typography>
       </Box>
+      <TextField
+        select
+        fullWidth
+        label="Highlighting profile"
+        value={config.profileId ?? ''}
+        onChange={(event) =>
+          onChange({
+            ...config,
+            profileId: event.target.value || undefined,
+          })
+        }
+        helperText={
+          selectedProfile
+            ? `${selectedProfile.rules.length} shared rule${selectedProfile.rules.length === 1 ? '' : 's'}; edit it in Settings → Highlighting.`
+            : 'Optional named rule set shared by several hosts.'
+        }
+      >
+        <MenuItem value="">No reusable profile</MenuItem>
+        {config.profileId && !selectedProfile ? (
+          <MenuItem value={config.profileId}>
+            Missing profile ({config.profileId})
+          </MenuItem>
+        ) : null}
+        {profiles.map((profile) => (
+          <MenuItem key={profile.id} value={profile.id}>
+            {profile.name}
+          </MenuItem>
+        ))}
+      </TextField>
+      {config.profileId && !selectedProfile ? (
+        <Alert severity="warning" variant="outlined">
+          This host references a profile that is not installed. Import it again or choose
+          another profile.
+        </Alert>
+      ) : null}
       <FormControlLabel
         control={
           <Switch
@@ -39,7 +83,7 @@ export function HighlightingSection({
           <Box>
             <Typography variant="body2">Include global highlighting rules</Typography>
             <Typography variant="caption" color="text.secondary">
-              Turn this off when this host should use only the rules below.
+              Turn this off when this host should use only its profile and host rules.
             </Typography>
           </Box>
         }
@@ -47,7 +91,7 @@ export function HighlightingSection({
       <KeywordHighlightRulesEditor
         rules={config.rules}
         onChange={(rules) => onChange({ ...config, rules })}
-        emptyMessage="No host-specific keyword rules yet."
+        emptyMessage="No additional host-specific keyword rules."
       />
     </Stack>
   );

--- a/client/src/components/host-editor/native-draft.ts
+++ b/client/src/components/host-editor/native-draft.ts
@@ -115,7 +115,9 @@ export function nativeDraftMetadataPatch(draft: NativeHostDraft): OpenSshMetadat
     group: draft.group.trim() || null,
     color: draft.color ?? null,
     keywordHighlights:
-      highlights.inheritGlobal && highlights.rules.length === 0 ? null : highlights,
+      highlights.inheritGlobal && !highlights.profileId && highlights.rules.length === 0
+        ? null
+        : highlights,
   };
 }
 

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -18,6 +18,7 @@ import type {
 } from '@muxus/shared';
 import { apiFetch } from './api/http.js';
 import { fetchHostPreview } from './api/ssh-config.js';
+import { isKeywordHighlightProfileArray } from './highlight-profiles.js';
 import { saveTextFile } from './save-file.js';
 import {
   MAX_SIDEBAR_WIDTH,
@@ -67,6 +68,7 @@ const PREFERENCE_KEYS = [
   'commandButtons',
   'showCommandBar',
   'keywordHighlights',
+  'keywordHighlightProfiles',
   'sidebarCollapsed',
   'sidebarWidth',
   'sidebarCollapsedFolders',
@@ -720,6 +722,9 @@ export function sanitizePreferences(
     input.keywordHighlights.every(validKeywordHighlight)
   ) {
     output.keywordHighlights = input.keywordHighlights;
+  }
+  if (isKeywordHighlightProfileArray(input.keywordHighlightProfiles)) {
+    output.keywordHighlightProfiles = input.keywordHighlightProfiles;
   }
   if (typeof input.sidebarCollapsed === 'boolean') {
     output.sidebarCollapsed = input.sidebarCollapsed;

--- a/client/src/highlight-profiles.ts
+++ b/client/src/highlight-profiles.ts
@@ -1,0 +1,143 @@
+import type { KeywordHighlightProfile, KeywordHighlightRule } from '@muxus/shared';
+
+export const HIGHLIGHT_PROFILE_FORMAT = 'muxus-keyword-highlighting-profiles';
+export const HIGHLIGHT_PROFILE_VERSION = 1;
+export const MAX_HIGHLIGHT_PROFILE_FILE_BYTES = 2 * 1024 * 1024;
+
+export interface HighlightProfileDocument {
+  format: typeof HIGHLIGHT_PROFILE_FORMAT;
+  version: typeof HIGHLIGHT_PROFILE_VERSION;
+  createdAt: string;
+  profiles: KeywordHighlightProfile[];
+}
+
+/** Build the portable file shared by the highlighting settings import/export UI. */
+export function createHighlightProfileDocument(
+  profiles: readonly KeywordHighlightProfile[],
+): HighlightProfileDocument {
+  if (!isKeywordHighlightProfileArray(profiles) || profiles.length === 0) {
+    throw new Error('Select at least one valid highlighting profile to export.');
+  }
+  return {
+    format: HIGHLIGHT_PROFILE_FORMAT,
+    version: HIGHLIGHT_PROFILE_VERSION,
+    createdAt: new Date().toISOString(),
+    profiles: profiles.map(copyProfile),
+  };
+}
+
+/** Parse an untrusted, standalone highlighting-profile file. */
+export function parseHighlightProfileDocument(text: string): HighlightProfileDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('This highlighting profile file is not valid JSON.');
+  }
+  if (!isRecord(parsed) || parsed.format !== HIGHLIGHT_PROFILE_FORMAT) {
+    throw new Error('This is not a Muxus highlighting profile file.');
+  }
+  if (parsed.version !== HIGHLIGHT_PROFILE_VERSION) {
+    throw new Error(
+      typeof parsed.version === 'number'
+        ? `Highlighting profile version ${parsed.version} is not supported.`
+        : 'This file is missing a supported highlighting profile version.',
+    );
+  }
+  if (
+    typeof parsed.createdAt !== 'string' ||
+    Number.isNaN(Date.parse(parsed.createdAt)) ||
+    !isKeywordHighlightProfileArray(parsed.profiles) ||
+    parsed.profiles.length === 0
+  ) {
+    throw new Error('The highlighting profile file is incomplete or invalid.');
+  }
+  return {
+    format: HIGHLIGHT_PROFILE_FORMAT,
+    version: HIGHLIGHT_PROFILE_VERSION,
+    createdAt: parsed.createdAt,
+    profiles: parsed.profiles.map(copyProfile),
+  };
+}
+
+/** Replace matching IDs and retain unrelated profiles during an import. */
+export function mergeHighlightProfiles(
+  current: readonly KeywordHighlightProfile[],
+  imported: readonly KeywordHighlightProfile[],
+): KeywordHighlightProfile[] {
+  const byId = new Map(current.map((profile) => [profile.id, profile]));
+  for (const profile of imported) byId.set(profile.id, profile);
+  return [...byId.values()];
+}
+
+export function isKeywordHighlightProfileArray(
+  value: unknown,
+): value is KeywordHighlightProfile[] {
+  if (!Array.isArray(value) || value.length > 100) return false;
+  const profileIds = new Set<string>();
+  return value.every((entry) => {
+    if (!isRecord(entry)) return false;
+    if (
+      !boundedString(entry.id, 200) ||
+      profileIds.has(entry.id) ||
+      !boundedString(entry.name, 200) ||
+      !entry.name.trim() ||
+      !Array.isArray(entry.rules) ||
+      entry.rules.length > 100
+    ) {
+      return false;
+    }
+    const ruleIds = new Set<string>();
+    if (
+      !entry.rules.every((rule) => {
+        if (!validKeywordHighlightRule(rule) || ruleIds.has(rule.id)) return false;
+        ruleIds.add(rule.id);
+        return true;
+      })
+    ) {
+      return false;
+    }
+    profileIds.add(entry.id);
+    return true;
+  });
+}
+
+export function validKeywordHighlightRule(value: unknown): value is KeywordHighlightRule {
+  return (
+    isRecord(value) &&
+    boundedString(value.id, 100) &&
+    boundedString(value.keyword, 500) &&
+    validHexColor(value.foreground) &&
+    (value.background === undefined || validHexColor(value.background)) &&
+    typeof value.caseSensitive === 'boolean' &&
+    typeof value.wholeWord === 'boolean'
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function boundedString(value: unknown, max: number): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= max;
+}
+
+function validHexColor(value: unknown): value is string {
+  return typeof value === 'string' && /^#[0-9a-f]{6}$/i.test(value);
+}
+
+/** Strip unknown JSON fields instead of carrying them into preferences and later exports. */
+function copyProfile(profile: KeywordHighlightProfile): KeywordHighlightProfile {
+  return {
+    id: profile.id,
+    name: profile.name,
+    rules: profile.rules.map((rule) => ({
+      id: rule.id,
+      keyword: rule.keyword,
+      foreground: rule.foreground,
+      ...(rule.background === undefined ? {} : { background: rule.background }),
+      caseSensitive: rule.caseSensitive,
+      wholeWord: rule.wholeWord,
+    })),
+  };
+}

--- a/client/src/highlight-profiles.ts
+++ b/client/src/highlight-profiles.ts
@@ -3,6 +3,7 @@ import type { KeywordHighlightProfile, KeywordHighlightRule } from '@muxus/share
 export const HIGHLIGHT_PROFILE_FORMAT = 'muxus-keyword-highlighting-profiles';
 export const HIGHLIGHT_PROFILE_VERSION = 1;
 export const MAX_HIGHLIGHT_PROFILE_FILE_BYTES = 2 * 1024 * 1024;
+export const MAX_KEYWORD_HIGHLIGHT_PROFILES = 100;
 
 export interface HighlightProfileDocument {
   format: typeof HIGHLIGHT_PROFILE_FORMAT;
@@ -67,13 +68,22 @@ export function mergeHighlightProfiles(
 ): KeywordHighlightProfile[] {
   const byId = new Map(current.map((profile) => [profile.id, profile]));
   for (const profile of imported) byId.set(profile.id, profile);
-  return [...byId.values()];
+  if (byId.size > MAX_KEYWORD_HIGHLIGHT_PROFILES) {
+    throw new Error(
+      `This import would exceed the limit of ${MAX_KEYWORD_HIGHLIGHT_PROFILES} highlighting profiles. Delete an existing profile and try again.`,
+    );
+  }
+  const merged = [...byId.values()];
+  if (!isKeywordHighlightProfileArray(merged)) {
+    throw new Error('The merged highlighting profiles are invalid.');
+  }
+  return merged;
 }
 
 export function isKeywordHighlightProfileArray(
   value: unknown,
 ): value is KeywordHighlightProfile[] {
-  if (!Array.isArray(value) || value.length > 100) return false;
+  if (!Array.isArray(value) || value.length > MAX_KEYWORD_HIGHLIGHT_PROFILES) return false;
   const profileIds = new Set<string>();
   return value.every((entry) => {
     if (!isRecord(entry)) return false;

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -3,7 +3,8 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 import { DEFAULT_SIDEBAR_WIDTH } from '../sidebar-width.js';
 import { DEFAULT_SFTP_PANEL_WIDTH } from '../sftp-panel-width.js';
 import { muxusStateStorage } from './persist-storage.js';
-import type { KeywordHighlightRule } from '@muxus/shared';
+import { isKeywordHighlightProfileArray } from '../highlight-profiles.js';
+import type { KeywordHighlightProfile, KeywordHighlightRule } from '@muxus/shared';
 
 export type ThemeMode = 'light' | 'dark' | 'os';
 export type EffectiveThemeMode = Exclude<ThemeMode, 'os'>;
@@ -137,6 +138,8 @@ export interface PrefsState {
   showCommandBar: boolean;
   /** Rules applied to every terminal; hosts may add to or replace these. */
   keywordHighlights: KeywordHighlightRule[];
+  /** Named rule sets referenced by saved-host highlighting metadata. */
+  keywordHighlightProfiles: KeywordHighlightProfile[];
   /** Whether the whole hosts sidebar is hidden — not to be confused with
    *  sidebarCollapsedFolders, which collapses individual folders inside it. */
   sidebarCollapsed: boolean;
@@ -233,6 +236,9 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
     !localShellProfiles?.some((profile) => profile.id === state.defaultLocalShellProfileId)
   ) {
     state.defaultLocalShellProfileId = '';
+  }
+  if (!isKeywordHighlightProfileArray(state.keywordHighlightProfiles)) {
+    delete state.keywordHighlightProfiles;
   }
   // The sidebar grew in v6 to fit its search box. A stored copy of the old
   // default was never a choice, so it follows; a dragged width is left alone.
@@ -335,6 +341,7 @@ export const usePrefsStore = create<PrefsState>()(
       commandButtons: [],
       showCommandBar: true,
       keywordHighlights: [],
+      keywordHighlightProfiles: [],
       sidebarCollapsed: false,
       sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
       sidebarCollapsedFolders: [],
@@ -347,7 +354,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 11,
+      version: 12,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/client/src/terminal/keyword-highlighting.ts
+++ b/client/src/terminal/keyword-highlighting.ts
@@ -52,11 +52,12 @@ export function findKeywordMatches(
 export function resolveKeywordHighlights(
   globalRules: readonly KeywordHighlightRule[],
   hostConfig?: HostKeywordHighlightConfig,
+  profileRules: readonly KeywordHighlightRule[] = [],
 ): KeywordHighlightRule[] {
   if (!hostConfig) return [...globalRules];
   return hostConfig.inheritGlobal
-    ? [...globalRules, ...hostConfig.rules]
-    : [...hostConfig.rules];
+    ? [...globalRules, ...profileRules, ...hostConfig.rules]
+    : [...profileRules, ...hostConfig.rules];
 }
 
 interface CellSegment {

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -78,9 +78,12 @@ keeps. Current usage against the quota is displayed here.
 
 ## Highlighting
 
-Global keyword rules applied to every terminal: keyword, foreground, optional background,
-case sensitivity and whole-word matching. Hosts can add their own rules or replace the
-global set.
+Global keyword rules apply to every terminal: keyword, foreground, optional background,
+case sensitivity and whole-word matching. **Reusable profiles** keep named,
+platform-specific rule sets that can be assigned to several SSH, Telnet or serial hosts.
+Profiles have stable IDs and can be imported or exported as JSON, so importing an updated
+copy refreshes existing assignments. Hosts can add their own rules and choose whether to
+include the global set.
 
 <figure markdown="span">
   ![Keyword highlighting rules](../assets/screenshots/settings-highlighting.png#only-light){ .shadow }

--- a/docs/guide/terminal.md
+++ b/docs/guide/terminal.md
@@ -105,8 +105,14 @@ whole-word switches.
   <figcaption>Global rules, with per-host rules that add to them or replace them.</figcaption>
 </figure>
 
-A host can carry its own rules, either in addition to the global set or instead of it. See
-the **Highlighting** section of the
+A named highlighting profile can hold a platform-specific rule set—such as one for Nokia
+SR OS—and be assigned to any number of SSH, Telnet or serial hosts. Profiles can be
+imported and exported as JSON files from **Settings → Highlighting**, so a rule set can be
+shared without recreating it. Editing a profile updates every assigned open terminal.
+
+A host can also carry its own additional rules. It can combine global, profile and host
+rules, or disable the global set and use only its profile and host rules. See the
+**Highlighting** section of the
 [host editor](adding-hosts.md#session-logging-highlighting).
 
 ## Command buttons

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -2016,7 +2016,16 @@ function keywordHighlightsFromJson(value: unknown): HostKeywordHighlightConfig |
   if (typeof value !== 'string') return undefined;
   try {
     const parsed = JSON.parse(value) as Partial<HostKeywordHighlightConfig>;
-    if (typeof parsed.inheritGlobal !== 'boolean' || !Array.isArray(parsed.rules)) return undefined;
+    if (
+      typeof parsed.inheritGlobal !== 'boolean' ||
+      !Array.isArray(parsed.rules) ||
+      (parsed.profileId !== undefined &&
+        (typeof parsed.profileId !== 'string' ||
+          !parsed.profileId ||
+          parsed.profileId.length > 200))
+    ) {
+      return undefined;
+    }
     return parsed as HostKeywordHighlightConfig;
   } catch {
     return undefined;

--- a/server/src/routes/metadata-schema.ts
+++ b/server/src/routes/metadata-schema.ts
@@ -13,6 +13,7 @@ const keywordHighlightRuleSchema = z.object({
 
 export const hostKeywordHighlightsSchema = z.object({
   inheritGlobal: z.boolean(),
+  profileId: z.string().min(1).max(200).optional(),
   rules: z.array(keywordHighlightRuleSchema).max(100),
 });
 

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -407,9 +407,19 @@ export interface KeywordHighlightRule {
   wholeWord: boolean;
 }
 
+/** A named, reusable rule set that can be assigned to any saved host. */
+export interface KeywordHighlightProfile {
+  /** Stable across export/import so assigned hosts keep following the profile. */
+  id: string;
+  name: string;
+  rules: KeywordHighlightRule[];
+}
+
 /** Host rules are additive by default, but can replace the global rule set. */
 export interface HostKeywordHighlightConfig {
   inheritGlobal: boolean;
+  /** Reusable profile applied before this host's own rules. */
+  profileId?: string;
   rules: KeywordHighlightRule[];
 }
 

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
     inactivePaneDimStrength: 0.15,
     localShellProfiles: [],
     defaultLocalShellProfileId: '',
+    keywordHighlightProfiles: [],
   });
 });
 
@@ -195,6 +196,28 @@ describe('backing up preferences', () => {
     expect(document.data.preferences.localShellProfiles).toHaveLength(1);
     expect(document.data.preferences.defaultLocalShellProfileId).toBe('ubuntu');
   });
+
+  it('includes reusable keyword highlighting profiles', async () => {
+    const profile = {
+      id: 'nokia-sros',
+      name: 'Nokia SR OS',
+      rules: [
+        {
+          id: 'alarm',
+          keyword: 'MAJOR',
+          foreground: '#ffffff',
+          caseSensitive: true,
+          wholeWord: true,
+        },
+      ],
+    };
+    usePrefsStore.setState({ keywordHighlightProfiles: [profile] });
+    mockBackupSnapshot();
+
+    const document = await createBackupDocument();
+
+    expect(document.data.preferences.keywordHighlightProfiles).toEqual([profile]);
+  });
 });
 
 describe('restoring terminal color scheme preferences', () => {
@@ -278,6 +301,37 @@ describe('restoring local shell profiles', () => {
     expect(
       sanitizePreferences(prefs({ localShellProfiles: [{ ...ubuntu, args: '-d Ubuntu' }] }))
         .localShellProfiles,
+    ).toBeUndefined();
+  });
+});
+
+describe('restoring keyword highlighting profiles', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+  const profile = {
+    id: 'nokia-sros',
+    name: 'Nokia SR OS',
+    rules: [
+      {
+        id: 'alarm',
+        keyword: 'MAJOR',
+        foreground: '#ffffff',
+        caseSensitive: true,
+        wholeWord: true,
+      },
+    ],
+  };
+
+  it('restores bounded reusable profiles', () => {
+    expect(
+      sanitizePreferences(prefs({ keywordHighlightProfiles: [profile] })),
+    ).toMatchObject({ keywordHighlightProfiles: [profile] });
+  });
+
+  it('drops malformed reusable profiles', () => {
+    expect(
+      sanitizePreferences(
+        prefs({ keywordHighlightProfiles: [{ ...profile, name: '' }] }),
+      ).keywordHighlightProfiles,
     ).toBeUndefined();
   });
 });

--- a/tests/unit/client/highlight-profiles.test.ts
+++ b/tests/unit/client/highlight-profiles.test.ts
@@ -3,6 +3,7 @@ import type { KeywordHighlightProfile } from '@muxus/shared';
 import {
   HIGHLIGHT_PROFILE_FORMAT,
   HIGHLIGHT_PROFILE_VERSION,
+  MAX_KEYWORD_HIGHLIGHT_PROFILES,
   createHighlightProfileDocument,
   isKeywordHighlightProfileArray,
   mergeHighlightProfiles,
@@ -70,6 +71,27 @@ describe('highlighting profile files', () => {
       updated,
       cisco,
     ]);
+  });
+
+  it('allows replacements at the profile limit but rejects a distinct profile beyond it', () => {
+    const existing = Array.from(
+      { length: MAX_KEYWORD_HIGHLIGHT_PROFILES },
+      (_, index): KeywordHighlightProfile => ({
+        ...nokia,
+        id: `profile-${index}`,
+        name: `Profile ${index}`,
+      }),
+    );
+    const replacement = { ...existing[0]!, name: 'Updated profile' };
+
+    expect(mergeHighlightProfiles(existing, [replacement])).toHaveLength(
+      MAX_KEYWORD_HIGHLIGHT_PROFILES,
+    );
+    expect(() =>
+      mergeHighlightProfiles(existing, [
+        { ...nokia, id: 'one-too-many', name: 'One too many' },
+      ]),
+    ).toThrow(/limit of 100 highlighting profiles/);
   });
 
   it('rejects duplicate profile and rule IDs', () => {

--- a/tests/unit/client/highlight-profiles.test.ts
+++ b/tests/unit/client/highlight-profiles.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { KeywordHighlightProfile } from '@muxus/shared';
+import {
+  HIGHLIGHT_PROFILE_FORMAT,
+  HIGHLIGHT_PROFILE_VERSION,
+  createHighlightProfileDocument,
+  isKeywordHighlightProfileArray,
+  mergeHighlightProfiles,
+  parseHighlightProfileDocument,
+} from '../../../client/src/highlight-profiles.js';
+
+const nokia: KeywordHighlightProfile = {
+  id: 'nokia-sros',
+  name: 'Nokia SR OS',
+  rules: [
+    {
+      id: 'major-alarm',
+      keyword: 'MAJOR',
+      foreground: '#ffffff',
+      background: '#b91c1c',
+      caseSensitive: true,
+      wholeWord: true,
+    },
+  ],
+};
+
+describe('highlighting profile files', () => {
+  it('round-trips a bounded, versioned profile document', () => {
+    const document = createHighlightProfileDocument([nokia]);
+
+    expect(document).toMatchObject({
+      format: HIGHLIGHT_PROFILE_FORMAT,
+      version: HIGHLIGHT_PROFILE_VERSION,
+      profiles: [nokia],
+    });
+    expect(parseHighlightProfileDocument(JSON.stringify(document))).toEqual(document);
+  });
+
+  it('rejects unrelated, future, and malformed documents', () => {
+    expect(() => parseHighlightProfileDocument('{no json')).toThrow(/valid JSON/);
+    expect(() =>
+      parseHighlightProfileDocument(
+        JSON.stringify({
+          format: 'another-format',
+          version: HIGHLIGHT_PROFILE_VERSION,
+          createdAt: new Date().toISOString(),
+          profiles: [nokia],
+        }),
+      ),
+    ).toThrow(/not a Muxus highlighting profile/);
+    expect(() =>
+      parseHighlightProfileDocument(
+        JSON.stringify({
+          format: HIGHLIGHT_PROFILE_FORMAT,
+          version: HIGHLIGHT_PROFILE_VERSION + 1,
+          createdAt: new Date().toISOString(),
+          profiles: [nokia],
+        }),
+      ),
+    ).toThrow(/not supported/);
+    expect(isKeywordHighlightProfileArray([{ ...nokia, rules: [{ ...nokia.rules[0], foreground: 'red' }] }]))
+      .toBe(false);
+  });
+
+  it('updates matching stable IDs without dropping unrelated profiles', () => {
+    const cisco = { ...nokia, id: 'cisco-ios', name: 'Cisco IOS' };
+    const updated = { ...nokia, name: 'Nokia SR OS 24' };
+
+    expect(mergeHighlightProfiles([nokia, cisco], [updated])).toEqual([
+      updated,
+      cisco,
+    ]);
+  });
+
+  it('rejects duplicate profile and rule IDs', () => {
+    expect(isKeywordHighlightProfileArray([nokia, { ...nokia }])).toBe(false);
+    expect(
+      isKeywordHighlightProfileArray([
+        { ...nokia, rules: [nokia.rules[0]!, { ...nokia.rules[0]! }] },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/client/keyword-highlighting.test.ts
+++ b/tests/unit/client/keyword-highlighting.test.ts
@@ -48,6 +48,7 @@ describe('findKeywordMatches', () => {
 
 describe('resolveKeywordHighlights', () => {
   const global = [rule('global', 'ERROR')];
+  const profile = [rule('profile', 'WARNING')];
   const host = [rule('host', 'FAILED')];
 
   it('uses globals for terminals without host configuration', () => {
@@ -64,5 +65,25 @@ describe('resolveKeywordHighlights', () => {
     expect(
       resolveKeywordHighlights(global, { inheritGlobal: false, rules: host }),
     ).toEqual(host);
+  });
+
+  it('applies an assigned profile between global and host-specific rules', () => {
+    expect(
+      resolveKeywordHighlights(
+        global,
+        { inheritGlobal: true, profileId: 'nokia-sros', rules: host },
+        profile,
+      ),
+    ).toEqual([...global, ...profile, ...host]);
+  });
+
+  it('keeps an assigned profile when global rules are disabled', () => {
+    expect(
+      resolveKeywordHighlights(
+        global,
+        { inheritGlobal: false, profileId: 'nokia-sros', rules: host },
+        profile,
+      ),
+    ).toEqual([...profile, ...host]);
   });
 });

--- a/tests/unit/client/native-host-draft.test.ts
+++ b/tests/unit/client/native-host-draft.test.ts
@@ -27,6 +27,7 @@ const serialHost: SavedHostProfile = {
     group: 'Lab',
     keywordHighlights: {
       inheritGlobal: false,
+      profileId: 'nokia-sros',
       rules: [
         {
           id: 'r1',
@@ -77,7 +78,10 @@ describe('nativeDraftFromProfile', () => {
       parity: 'even',
       flowControl: 'hardware',
     });
-    expect(draft.keywordHighlights.rules).toHaveLength(1);
+    expect(draft.keywordHighlights).toMatchObject({
+      profileId: 'nokia-sros',
+      rules: [expect.objectContaining({ keyword: 'ERROR' })],
+    });
   });
 
   it('renames duplicates', () => {

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -233,6 +233,41 @@ describe('local shell profile preferences', () => {
   });
 });
 
+describe('keyword highlighting profile preferences', () => {
+  const profile = {
+    id: 'nokia-sros',
+    name: 'Nokia SR OS',
+    rules: [
+      {
+        id: 'alarm',
+        keyword: 'MAJOR',
+        foreground: '#ffffff',
+        background: '#b91c1c',
+        caseSensitive: true,
+        wholeWord: true,
+      },
+    ],
+  };
+
+  it('keeps valid reusable profiles during preference migration', () => {
+    expect(migratePrefsState({ keywordHighlightProfiles: [profile] }, 11)).toEqual({
+      keywordHighlightProfiles: [profile],
+    });
+  });
+
+  it('drops malformed reusable profiles without changing other preferences', () => {
+    expect(
+      migratePrefsState(
+        {
+          monoFontSize: 16,
+          keywordHighlightProfiles: [{ ...profile, rules: [{ ...profile.rules[0], foreground: 'red' }] }],
+        },
+        11,
+      ),
+    ).toEqual({ monoFontSize: 16 });
+  });
+});
+
 describe('interface zoom', () => {
   it('keeps the window scale inside a usable range', () => {
     expect(clampInterfaceZoom(1)).toBe(1);

--- a/tests/unit/server/profile-routes.test.ts
+++ b/tests/unit/server/profile-routes.test.ts
@@ -130,6 +130,7 @@ describe('saved host profile routes', () => {
 
     const highlights = {
       inheritGlobal: false,
+      profileId: 'nokia-sros',
       rules: [
         {
           id: 'rule-1',

--- a/tests/unit/server/ssh-routes.test.ts
+++ b/tests/unit/server/ssh-routes.test.ts
@@ -52,6 +52,7 @@ describe('OpenSSH host keyword metadata', () => {
       payload: {
         keywordHighlights: {
           inheritGlobal: false,
+          profileId: 'nokia-sros',
           rules: [
             {
               id: 'failed',
@@ -70,6 +71,7 @@ describe('OpenSSH host keyword metadata', () => {
     expect(response.json()).toMatchObject({
       keywordHighlights: {
         inheritGlobal: false,
+        profileId: 'nokia-sros',
         rules: [expect.objectContaining({ keyword: 'FAILED' })],
       },
     });
@@ -92,6 +94,23 @@ describe('OpenSSH host keyword metadata', () => {
               wholeWord: false,
             },
           ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects an empty reusable highlighting profile ID', async () => {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/ssh/config/hosts/production/metadata',
+      headers: auth(),
+      payload: {
+        keywordHighlights: {
+          inheritGlobal: true,
+          profileId: '',
+          rules: [],
         },
       },
     });


### PR DESCRIPTION
## Summary

- add named, reusable keyword-highlighting profiles in Settings
- allow SSH, Telnet, and serial hosts to reference a shared profile while retaining global and host-specific rules
- support validated profile import/export with stable IDs
- include profile definitions and host assignments in Muxus backup and restore
- document the workflow and add regression coverage for persistence, transfer, resolution order, and API validation

## Why

Platform-specific highlighting rules should be defined once and reused across the sessions that need them. Portable profile files also make those rules easy to share and update.

Closes #79

## Validation

- `pnpm test` — 800 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @muxus/client build`
- `pnpm --filter @muxus/client check:bundle`