### PR TITLE
Enlarge macOS app icon

### DIFF
--- a/electron/scripts/render-icon.mjs
+++ b/electron/scripts/render-icon.mjs
@@ -10,10 +10,10 @@ const script = fileURLToPath(import.meta.url);
 const svg = path.resolve(root, '../../client/public/muxus.svg');
 const main = path.resolve(root, '../build/icon.png');
 const sizes = [16, 24, 32, 48, 64, 128, 256, 512, 1024];
-// Keep the macOS/Windows source inside a platform-friendly safe area. Linux
-// launchers add their own spacing, so its hicolor icons should use the full
-// canvas (the SVG already contains a small amount of transparent padding).
-const mainContentScale = 0.82;
+// The SVG already includes transparent padding. Keep only a small additional
+// inset so the macOS/Windows icon has the same optical size as native app icons.
+// Linux launchers add their own spacing, so hicolor icons use the full canvas.
+const mainContentScale = 0.91;
 const linuxContentScale = 1;
 const transparent = { r: 0, g: 0, b: 0, alpha: 0 };
 


### PR DESCRIPTION
## Summary

- increase the desktop icon render scale from 82% to 91%
- retain a small safe-area inset while matching the optical size of native macOS app icons
- leave Linux hicolor icon sizing unchanged

## Root cause

The source SVG already contains transparent padding, and the desktop renderer added another substantial inset. Together they reduced the visible artwork to roughly 74% of the icon canvas, making Muxus appear smaller than neighboring Dock icons.

## Impact

The generated macOS and Windows icon source now has an approximately 11% larger visible footprint. A rebuilt application will display at a size consistent with other macOS Dock icons.

## Validation

- `pnpm --dir electron run build`
- regenerated the 1024px icon and verified its visible bounds increased from 759×778 to 843×863 pixels