### PR TITLE
Fix console mode for hosts without PTY support

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -52,24 +52,18 @@ export function AdvancedSection({
               onChange={(event) => set({ disableSftp: event.target.checked })}
             />
           }
-          label="Disable SFTP for this host"
+          label="Enable console compatibility mode"
         />
-        <Typography variant="caption" color="text.secondary">
-          Opens a plain SSH shell without SFTP or Unix shell-integration probes. Muxus normally
-          detects incompatible console servers after one safe retry; enable this to skip the first
-          probe entirely.
+        <Typography variant="body2" color="text.secondary">
+          Skips SFTP, shell integration, and automatic TTY allocation. Explicit TTY settings still
+          apply.
         </Typography>
       </Stack>
 
       <Stack spacing={1}>
         <Typography variant="body2" color="text.secondary">
-          Raw ssh_config options for algorithm policies, environment variables, known-hosts files,
-          keepalives, and other expert settings. Rows marked <em>applied</em> are honoured by Muxus;
-          the rest are kept for OpenSSH.
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          Agent selection and host-key security have dedicated controls in Authentication;
-          startup commands and TTY behavior are in General.
+          Additional ssh_config options. Applied options are used by Muxus; others are preserved
+          for OpenSSH.
         </Typography>
         {draft.extras.map((e, i) => {
           const keyword = e.keyword.trim().toLowerCase();

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -24,7 +24,7 @@ export interface HostDraft {
   displayName: string;
   group: string;
   color?: string;
-  /** Muxus-only console compatibility: never request SFTP or shell integration. */
+  /** Muxus-only console compatibility: skip SFTP, integration, and implicit TTY allocation. */
   disableSftp: boolean;
   /** Target config file; '' keeps the block's file (or the root for new hosts). */
   file: string;

--- a/docs/guide/adding-hosts.md
+++ b/docs/guide/adding-hosts.md
@@ -100,9 +100,11 @@ console server disconnects when it sees even that probe, Muxus reconnects once i
 mode and remembers the compatibility choice until the app restarts. No manual setting is required
 for the session to connect.
 
-For known-sensitive SSH console servers and network appliances, **Disable SFTP for this host**
-skips the initial probe as well. This persistent override avoids the first reconnect entirely.
-The file-browser controls are unavailable for plain-console sessions.
+For known-sensitive SSH console servers and network appliances, **Enable console compatibility
+mode** skips the initial probe and automatic terminal allocation. This persistent override avoids
+the first reconnect and supports devices that reject SSH `pty-req`. An explicit **Always allocate
+a terminal** or **Force terminal allocation** setting is still honored. The file-browser controls
+are unavailable for plain-console sessions.
 
 Any other keyword OpenSSH understands is entered here as free-form option/value pairs. The
 panel shows the **exact block** that will be written.

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "packageManager": "pnpm@11.17.0",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -111,10 +111,19 @@ export function sessionSettings(resolved: ResolvedTarget): SessionSettings {
   };
 }
 
-/** RequestTTY the way ssh(1) treats it: auto ⇒ a tty only for plain shells. */
-function wantsPty(requestTty: ResolvedTarget['requestTty'], hasCommand: boolean): boolean {
+/**
+ * RequestTTY the way ssh(1) treats it: auto ⇒ a tty only for plain shells.
+ * Console compatibility suppresses that implicit allocation because some
+ * appliances reject pty-req outright; explicit yes/force still wins.
+ */
+function wantsPty(
+  requestTty: ResolvedTarget['requestTty'],
+  hasCommand: boolean,
+  consoleCompatibility = false,
+): boolean {
   if (requestTty === 'no') return false;
   if (requestTty === 'yes' || requestTty === 'force') return true;
+  if (consoleCompatibility) return false;
   return !hasCommand;
 }
 
@@ -606,7 +615,7 @@ export class SshConnectionManager {
       health: () => transportHealth,
       configForwards: target.resolved.forwards,
       shell: async (cols, rows, term, session = sessionSettings(target.resolved)) => {
-        const pty = wantsPty(session.requestTty, !!session.remoteCommand)
+        const pty = wantsPty(session.requestTty, !!session.remoteCommand, disableSftp)
           ? terminalPtyOptions(cols, rows, term)
           : undefined;
         if (session.remoteCommand) {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -435,7 +435,7 @@ export interface OpenSshProfileMetadata {
   icon?: string;
   /** Muxus-only terminal highlighting for this OpenSSH alias. */
   keywordHighlights?: HostKeywordHighlightConfig;
-  /** Do not open SFTP channels or probe for remote Unix shell integration. */
+  /** Console compatibility: skip SFTP/integration probes and implicit TTY allocation. */
   disableSftp?: boolean;
   lastConnectedAt?: string;
   connectCount: number;

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -46,7 +46,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.5.0',
+      currentVersion: '0.5.1',
       latestVersion: '0.6.0',
       releaseName: 'Muxus 0.6',
       releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.6.0',
@@ -56,7 +56,7 @@ describe('app routes', () => {
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.5.0' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.5.1' },
     });
   });
 
@@ -83,7 +83,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.5.0',
+      currentVersion: '0.5.1',
       latestVersion: '0.6.0',
       reason: 'missing-release-url',
     });

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -30,6 +30,7 @@ interface ServerStats {
   connections: number;
   auths: number;
   execs: number;
+  ptyRequests: number;
   sftpRequests: number;
   shells: number;
 }
@@ -42,6 +43,7 @@ interface ServerStats {
 function startServer(opts: {
   maxShellsPerConnection?: number;
   disconnectOnExec?: boolean;
+  rejectPty?: boolean;
 } = {}): Promise<{
   server: Server;
   port: number;
@@ -51,6 +53,7 @@ function startServer(opts: {
     connections: 0,
     auths: 0,
     execs: 0,
+    ptyRequests: 0,
     sftpRequests: 0,
     shells: 0,
   };
@@ -69,7 +72,11 @@ function startServer(opts: {
     conn.on('ready', () => {
       conn.on('session', (acceptSession) => {
         const session = acceptSession();
-        session.on('pty', (acceptPty) => acceptPty?.());
+        session.on('pty', (acceptPty, rejectPty) => {
+          stats.ptyRequests += 1;
+          if (opts.rejectPty) rejectPty?.();
+          else acceptPty?.();
+        });
         // Empty probe output means "no integrated shell" — the manager then
         // opens a plain shell, which is what these tests exercise.
         session.on('exec', (acceptExec) => {
@@ -285,8 +292,10 @@ describe('SSH connection multiplexing', () => {
     expect(started.stats.connections).toBe(2);
   }, 15_000);
 
-  it('opens a plain shell without probes when SFTP is disabled for the host', async () => {
-    const started = await startServer();
+  it('opens a plain shell without probes or an implicit PTY in console mode', async () => {
+    // Network consoles commonly accept a shell but reject pty-req. Console
+    // compatibility must skip the implicit PTY as well as exec/SFTP probes.
+    const started = await startServer({ rejectPty: true });
     server = started.server;
     const configFile = path.join(tmp, `ssh_config-console-${knownHostsCounter}`);
     writeFileSync(
@@ -309,11 +318,48 @@ describe('SSH connection multiplexing', () => {
     );
 
     expect(shell.lease.connection.sftpAvailable).toBe(false);
-    expect(started.stats).toMatchObject({ execs: 0, sftpRequests: 0, shells: 1 });
+    expect(started.stats).toMatchObject({
+      execs: 0,
+      ptyRequests: 0,
+      sftpRequests: 0,
+      shells: 1,
+    });
     await expect(shell.lease.connection.sftp()).rejects.toThrow(
       'SFTP is disabled for this host.',
     );
     expect(started.stats.sftpRequests).toBe(0);
+  }, 15_000);
+
+  it('honors an explicit RequestTTY yes in console mode', async () => {
+    const started = await startServer();
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-console-tty-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host console',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  RequestTTY yes',
+      ].join('\n'),
+    );
+    manager = makeManager(configFile, (alias) => alias === 'console');
+
+    await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(started.stats).toMatchObject({
+      execs: 0,
+      ptyRequests: 1,
+      sftpRequests: 0,
+      shells: 1,
+    });
   }, 15_000);
 
   it('automatically redials in plain-console mode when integration drops the transport', async () => {


### PR DESCRIPTION
## Summary

- make console compatibility skip implicit PTY allocation as well as SFTP and shell-integration probes
- continue honoring explicit `RequestTTY yes` and `RequestTTY force`
- simplify the console compatibility copy and bump the application to v0.5.1

## Root cause

Console compatibility bypassed the SFTP and shell-integration probes but still supplied PTY options for normal shells. Hosts that reject the SSH `pty-req` therefore failed before the shell request was sent.

## Impact

Network consoles that do not support pseudo-terminals can connect when console compatibility mode is enabled. Hosts with an explicit TTY requirement retain their existing behavior.

## Validation

- `pnpm test` — 802 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
