### PR TITLE
Fix console mode by dropping env requests, not the TTY

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/api/ssh-config.ts
+++ b/client/src/api/ssh-config.ts
@@ -77,6 +77,9 @@ export function useUpdateSshMetadata(onSuccess?: (metadata: OpenSshProfileMetada
               ...(patch.disableSftp !== undefined
                 ? { disableSftp: patch.disableSftp || undefined }
                 : {}),
+              ...(patch.consoleCompatibility !== undefined
+                ? { consoleCompatibility: patch.consoleCompatibility || undefined }
+                : {}),
             };
             return { ...host, metadata };
           }),

--- a/client/src/components/HostEditorDialog.tsx
+++ b/client/src/components/HostEditorDialog.tsx
@@ -212,6 +212,7 @@ function SshHostEditorContent({
         group: draft.group.trim() || null,
         color: draft.color ?? null,
         disableSftp: draft.disableSftp,
+        consoleCompatibility: draft.consoleCompatibility,
         keywordHighlights:
           highlights.inheritGlobal &&
           !highlights.profileId &&
@@ -290,7 +291,10 @@ function SshHostEditorContent({
       value: 'advanced',
       label: 'Advanced',
       icon: <CodeOutlinedIcon fontSize="small" />,
-      count: draft.extras.length + (draft.disableSftp ? 1 : 0),
+      count:
+        draft.extras.length +
+        (draft.disableSftp ? 1 : 0) +
+        (draft.consoleCompatibility ? 1 : 0),
     },
   ];
 

--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -55,8 +55,7 @@ export function AdvancedSection({
           label="Enable console compatibility mode"
         />
         <Typography variant="body2" color="text.secondary">
-          Skips SFTP, shell integration, and automatic TTY allocation. Explicit TTY settings still
-          apply.
+          Skips SFTP, shell integration, and SendEnv/SetEnv requests. TTY settings still apply.
         </Typography>
       </Stack>
 

--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -48,14 +48,27 @@ export function AdvancedSection({
         <FormControlLabel
           control={
             <Switch
-              checked={draft.disableSftp}
-              onChange={(event) => set({ disableSftp: event.target.checked })}
+              checked={draft.consoleCompatibility}
+              onChange={(event) => set({ consoleCompatibility: event.target.checked })}
             />
           }
           label="Enable console compatibility mode"
         />
         <Typography variant="body2" color="text.secondary">
           Skips SFTP, shell integration, and SendEnv/SetEnv requests. TTY settings still apply.
+        </Typography>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={draft.disableSftp}
+              onChange={(event) => set({ disableSftp: event.target.checked })}
+            />
+          }
+          label="Disable SFTP and shell integration only"
+        />
+        <Typography variant="body2" color="text.secondary">
+          Keeps SendEnv/SetEnv and normal TTY behavior. Console mode already disables SFTP and
+          shell integration, regardless of this setting.
         </Typography>
       </Stack>
 

--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -52,24 +52,18 @@ export function AdvancedSection({
               onChange={(event) => set({ disableSftp: event.target.checked })}
             />
           }
-          label="Disable SFTP for this host"
+          label="Enable console compatibility mode"
         />
-        <Typography variant="caption" color="text.secondary">
-          Opens a plain SSH shell without SFTP or Unix shell-integration probes. Muxus normally
-          detects incompatible console servers after one safe retry; enable this to skip the first
-          probe entirely.
+        <Typography variant="body2" color="text.secondary">
+          Skips SFTP, shell integration, and automatic TTY allocation. Explicit TTY settings still
+          apply.
         </Typography>
       </Stack>
 
       <Stack spacing={1}>
         <Typography variant="body2" color="text.secondary">
-          Raw ssh_config options for algorithm policies, environment variables, known-hosts files,
-          keepalives, and other expert settings. Rows marked <em>applied</em> are honoured by Muxus;
-          the rest are kept for OpenSSH.
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          Agent selection and host-key security have dedicated controls in Authentication;
-          startup commands and TTY behavior are in General.
+          Additional ssh_config options. Applied options are used by Muxus; others are preserved
+          for OpenSSH.
         </Typography>
         {draft.extras.map((e, i) => {
           const keyword = e.keyword.trim().toLowerCase();

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -24,8 +24,10 @@ export interface HostDraft {
   displayName: string;
   group: string;
   color?: string;
-  /** Muxus-only console compatibility: no SFTP, shell integration, or env requests. */
+  /** Muxus-only plain-shell mode: no SFTP or shell integration. */
   disableSftp: boolean;
+  /** Muxus-only console mode: also no env requests, with PTY rejection fallback. */
+  consoleCompatibility: boolean;
   /** Target config file; '' keeps the block's file (or the root for new hosts). */
   file: string;
   hostname: string;
@@ -64,6 +66,7 @@ export function blankDraft(prefillTarget = ''): HostDraft {
     group: '',
     color: undefined,
     disableSftp: false,
+    consoleCompatibility: false,
     file: '',
     hostname: parsed?.host ?? '',
     user: parsed?.user ?? '',
@@ -103,6 +106,7 @@ export function draftFromEntry(entry: SshHostEntry, duplicate: boolean): HostDra
     group: entry.metadata?.group ?? '',
     color: entry.metadata?.color,
     disableSftp: entry.metadata?.disableSftp ?? false,
+    consoleCompatibility: entry.metadata?.consoleCompatibility ?? false,
     file: entry.file,
     hostname: o.hostname ?? '',
     user: o.user ?? '',

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -24,7 +24,7 @@ export interface HostDraft {
   displayName: string;
   group: string;
   color?: string;
-  /** Muxus-only console compatibility: never request SFTP or shell integration. */
+  /** Muxus-only console compatibility: skip SFTP, integration, and implicit TTY allocation. */
   disableSftp: boolean;
   /** Target config file; '' keeps the block's file (or the root for new hosts). */
   file: string;

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -24,7 +24,7 @@ export interface HostDraft {
   displayName: string;
   group: string;
   color?: string;
-  /** Muxus-only console compatibility: skip SFTP, integration, and implicit TTY allocation. */
+  /** Muxus-only console compatibility: no SFTP, shell integration, or env requests. */
   disableSftp: boolean;
   /** Target config file; '' keeps the block's file (or the root for new hosts). */
   file: string;

--- a/client/src/components/sidebar/host-details.ts
+++ b/client/src/components/sidebar/host-details.ts
@@ -16,7 +16,8 @@ export function hostDetailLines(host: ManagedHost): string[] {
     lines.push(`Key ${resolved.identityFiles.map((file) => file.split(/[\\/]/).pop()).join(', ')}`);
   }
   if (resolved.passwordOnly) lines.push('Password authentication');
-  if (host.entry.metadata?.disableSftp) lines.push('SFTP disabled');
+  if (host.entry.metadata?.consoleCompatibility) lines.push('Console compatibility');
+  else if (host.entry.metadata?.disableSftp) lines.push('SFTP disabled');
   if (resolved.forwards.length > 0) {
     lines.push(
       `${resolved.forwards.length} port forward${resolved.forwards.length > 1 ? 's' : ''} on connect`,

--- a/client/src/components/sidebar/host-sftp-action.ts
+++ b/client/src/components/sidebar/host-sftp-action.ts
@@ -6,7 +6,11 @@ import { useTabsStore } from '../../state/tabs.js';
 export function managedHostSupportsSftp(
   host: ManagedHost,
 ): host is Extract<ManagedHost, { kind: 'ssh' }> {
-  return host.kind === 'ssh' && host.entry.metadata?.disableSftp !== true;
+  return (
+    host.kind === 'ssh' &&
+    host.entry.metadata?.disableSftp !== true &&
+    host.entry.metadata?.consoleCompatibility !== true
+  );
 }
 
 /**

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -452,6 +452,7 @@ function portableMetadata(
     icon: metadata.icon,
     keywordHighlights: metadata.keywordHighlights,
     disableSftp: metadata.disableSftp,
+    consoleCompatibility: metadata.consoleCompatibility,
     sortOrder: metadata.sortOrder,
   };
 }
@@ -603,6 +604,7 @@ function metadataPatch(metadata: PortableHostMetadata): OpenSshMetadataPatch {
     icon: metadata.icon ?? null,
     keywordHighlights: metadata.keywordHighlights ?? null,
     disableSftp: metadata.disableSftp ?? false,
+    consoleCompatibility: metadata.consoleCompatibility ?? false,
   };
 }
 

--- a/docs/guide/adding-hosts.md
+++ b/docs/guide/adding-hosts.md
@@ -100,9 +100,11 @@ console server disconnects when it sees even that probe, Muxus reconnects once i
 mode and remembers the compatibility choice until the app restarts. No manual setting is required
 for the session to connect.
 
-For known-sensitive SSH console servers and network appliances, **Disable SFTP for this host**
-skips the initial probe as well. This persistent override avoids the first reconnect entirely.
-The file-browser controls are unavailable for plain-console sessions.
+For known-sensitive SSH console servers and network appliances, **Enable console compatibility
+mode** skips the initial probe and automatic terminal allocation. This persistent override avoids
+the first reconnect and supports devices that reject SSH `pty-req`. An explicit **Always allocate
+a terminal** or **Force terminal allocation** setting is still honored. The file-browser controls
+are unavailable for plain-console sessions.
 
 Any other keyword OpenSSH understands is entered here as free-form option/value pairs. The
 panel shows the **exact block** that will be written.

--- a/docs/guide/adding-hosts.md
+++ b/docs/guide/adding-hosts.md
@@ -107,6 +107,11 @@ Terminal allocation follows the host's TTY setting either way: Muxus asks for a 
 continues without one when the device rejects `pty-req`. The file-browser controls are unavailable
 for plain-console sessions.
 
+For an otherwise normal SSH server that only lacks SFTP or cannot use Muxus shell integration,
+**Disable SFTP and shell integration only** keeps environment requests and normal terminal
+allocation intact. This remains separate from console compatibility so existing disabled-SFTP
+hosts keep their previous session behavior.
+
 Any other keyword OpenSSH understands is entered here as free-form option/value pairs. The
 panel shows the **exact block** that will be written.
 

--- a/docs/guide/adding-hosts.md
+++ b/docs/guide/adding-hosts.md
@@ -101,10 +101,11 @@ mode and remembers the compatibility choice until the app restarts. No manual se
 for the session to connect.
 
 For known-sensitive SSH console servers and network appliances, **Enable console compatibility
-mode** skips the initial probe and automatic terminal allocation. This persistent override avoids
-the first reconnect and supports devices that reject SSH `pty-req`. An explicit **Always allocate
-a terminal** or **Force terminal allocation** setting is still honored. The file-browser controls
-are unavailable for plain-console sessions.
+mode** skips the initial probe as well, and stops sending `SendEnv`/`SetEnv` values that these
+devices have no environment for. This persistent override avoids the first reconnect entirely.
+Terminal allocation follows the host's TTY setting either way: Muxus asks for a terminal and
+continues without one when the device rejects `pty-req`. The file-browser controls are unavailable
+for plain-console sessions.
 
 Any other keyword OpenSSH understands is entered here as free-form option/value pairs. The
 panel shows the **exact block** that will be written.

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -106,8 +106,8 @@ or to a new group file that Muxus creates and adds an `Include` for.
 Its own database holds only what OpenSSH has no field for:
 
 - display name, folder, colour and sidebar order;
-- the per-host SFTP/console-compatibility override (Muxus also falls back to plain-console mode
-  automatically when optional shell-integration setup disconnects a transport);
+- separate per-host SFTP and console-compatibility overrides (Muxus also falls back to
+  plain-console mode automatically when optional shell-integration setup disconnects a transport);
 - per-host keyword-highlighting rules and session-logging policy;
 - last-connected timestamps and connection counts;
 - workspaces, saved tunnels, and saved Telnet/serial hosts;

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "packageManager": "pnpm@11.17.0",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -94,6 +94,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
     vault,
     folderAuth: folderAuthResolver(database),
     disableSftpForHost: (alias) => database.sftpDisabledForAlias(alias),
+    consoleCompatibilityForHost: (alias) => database.consoleCompatibilityForAlias(alias),
   });
   const forwards = new ForwardManager(connections, app.log);
   const historySettings = database.sessionHistorySettings();

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -382,6 +382,15 @@ const MIGRATIONS = [
         CHECK(disable_sftp IN (0, 1));
     `,
   },
+  {
+    version: 20,
+    name: 'host-console-compatibility',
+    sql: `
+      ALTER TABLE connection_profiles
+        ADD COLUMN console_compatibility INTEGER NOT NULL DEFAULT 0
+        CHECK(console_compatibility IN (0, 1));
+    `,
+  },
 ] as const;
 
 function migrateDraftPasswordVault(db: DatabaseSync): void {
@@ -462,6 +471,7 @@ export interface OpenSshMetadata {
   icon?: string;
   keywordHighlights?: HostKeywordHighlightConfig;
   disableSftp?: boolean;
+  consoleCompatibility?: boolean;
   lastConnectedAt?: string;
   connectCount: number;
 }
@@ -642,6 +652,7 @@ export class MuxusDatabase {
         profiles.icon,
         profiles.keyword_highlights_json,
         profiles.disable_sftp,
+        profiles.console_compatibility,
         profiles.last_connected_at,
         profiles.connect_count,
         groups.name AS group_name
@@ -684,6 +695,12 @@ export class MuxusDatabase {
     return Number(row?.disable_sftp) === 1;
   }
 
+  /** Whether this OpenSSH alias needs the stricter console session shape. */
+  consoleCompatibilityForAlias(alias: string): boolean {
+    const row = this.metadataByAlias.get(alias);
+    return Number(row?.console_compatibility) === 1;
+  }
+
   updateOpenSshMetadata(
     alias: string,
     patch: OpenSshMetadataPatch,
@@ -703,6 +720,7 @@ export class MuxusDatabase {
             icon = ?,
             keyword_highlights_json = ?,
             disable_sftp = ?,
+            console_compatibility = ?,
             updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
       `)
@@ -719,6 +737,11 @@ export class MuxusDatabase {
         patch.disableSftp === undefined
           ? Number(current.disable_sftp)
           : patch.disableSftp
+            ? 1
+            : 0,
+        patch.consoleCompatibility === undefined
+          ? Number(current.console_compatibility)
+          : patch.consoleCompatibility
             ? 1
             : 0,
         String(current.id),
@@ -1171,6 +1194,7 @@ export class MuxusDatabase {
             icon = ?,
             keyword_highlights_json = ?,
             disable_sftp = ?,
+            console_compatibility = ?,
             updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
       `)
@@ -1187,6 +1211,11 @@ export class MuxusDatabase {
         patch.disableSftp === undefined
           ? Number(current.disable_sftp)
           : patch.disableSftp
+            ? 1
+            : 0,
+        patch.consoleCompatibility === undefined
+          ? Number(current.console_compatibility)
+          : patch.consoleCompatibility
             ? 1
             : 0,
         id,
@@ -1982,6 +2011,7 @@ function metadataFromRow(row: SqlRow): OpenSshMetadata {
     icon: optionalString(row.icon),
     keywordHighlights: keywordHighlightsFromJson(row.keyword_highlights_json),
     ...(Number(row.disable_sftp) === 1 ? { disableSftp: true } : {}),
+    ...(Number(row.console_compatibility) === 1 ? { consoleCompatibility: true } : {}),
     lastConnectedAt: optionalString(row.last_connected_at),
     connectCount: Number(row.connect_count),
   };
@@ -2004,6 +2034,7 @@ function savedHostFromRow(row: SqlRow): SavedHostProfile {
       icon: optionalString(row.icon),
       keywordHighlights: keywordHighlightsFromJson(row.keyword_highlights_json),
       ...(Number(row.disable_sftp) === 1 ? { disableSftp: true } : {}),
+      ...(Number(row.console_compatibility) === 1 ? { consoleCompatibility: true } : {}),
       lastConnectedAt: optionalString(row.last_connected_at),
       connectCount: Number(row.connect_count),
     },

--- a/server/src/routes/metadata-schema.ts
+++ b/server/src/routes/metadata-schema.ts
@@ -28,5 +28,6 @@ export const metadataPatchSchema = z
     icon: z.string().max(64).nullable().optional(),
     keywordHighlights: hostKeywordHighlightsSchema.nullable().optional(),
     disableSftp: z.boolean().optional(),
+    consoleCompatibility: z.boolean().optional(),
   })
   .refine((patch) => Object.keys(patch).length > 0, 'at least one metadata field is required');

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -111,19 +111,10 @@ export function sessionSettings(resolved: ResolvedTarget): SessionSettings {
   };
 }
 
-/**
- * RequestTTY the way ssh(1) treats it: auto ⇒ a tty only for plain shells.
- * Console compatibility suppresses that implicit allocation because some
- * appliances reject pty-req outright; explicit yes/force still wins.
- */
-function wantsPty(
-  requestTty: ResolvedTarget['requestTty'],
-  hasCommand: boolean,
-  consoleCompatibility = false,
-): boolean {
+/** RequestTTY the way ssh(1) treats it: auto ⇒ a tty only for plain shells. */
+function wantsPty(requestTty: ResolvedTarget['requestTty'], hasCommand: boolean): boolean {
   if (requestTty === 'no') return false;
   if (requestTty === 'yes' || requestTty === 'force') return true;
-  if (consoleCompatibility) return false;
   return !hasCommand;
 }
 
@@ -615,7 +606,7 @@ export class SshConnectionManager {
       health: () => transportHealth,
       configForwards: target.resolved.forwards,
       shell: async (cols, rows, term, session = sessionSettings(target.resolved)) => {
-        const pty = wantsPty(session.requestTty, !!session.remoteCommand, disableSftp)
+        const pty = wantsPty(session.requestTty, !!session.remoteCommand)
           ? terminalPtyOptions(cols, rows, term)
           : undefined;
         if (session.remoteCommand) {
@@ -624,11 +615,10 @@ export class SshConnectionManager {
         if (pty && !disableSftp) {
           return openRemoteShell(client, getSftp, pty, session.env);
         }
-        return new Promise((resolve, reject) => {
-          client.shell(pty ?? false, { env: session.env }, (err, stream) =>
-            err ? reject(err) : resolve(stream),
-          );
-        });
+        // Console compatibility drops SendEnv/SetEnv: ssh2 can only send env
+        // requests before pty-req, an order some appliances answer with a
+        // protocol-error disconnect, and a serial console has no environment.
+        return openPlainShell(client, pty, disableSftp ? undefined : session.env);
       },
       // One SFTP channel per connection, shared by every file operation.
       sftp: () =>
@@ -1889,6 +1879,39 @@ function openSessionExec(
       err ? reject(err) : resolve(stream),
     );
   });
+}
+
+/**
+ * Console appliances disagree about pty-req: some reject it, others refuse a
+ * shell without one. Ask for the tty ssh(1) would and, like ssh(1), carry on
+ * without it when the server says no. ssh2 closes the channel on a failed
+ * pty-req, so the retry needs a fresh session channel.
+ */
+async function openPlainShell(
+  client: Client,
+  pty: PseudoTtyOptions | undefined,
+  env?: Record<string, string>,
+): Promise<ClientChannel> {
+  try {
+    return await requestShell(client, pty ?? false, env);
+  } catch (err) {
+    if (!pty || !isPtyRejection(err)) throw err;
+    return requestShell(client, false, env);
+  }
+}
+
+function requestShell(
+  client: Client,
+  pty: PseudoTtyOptions | false,
+  env?: Record<string, string>,
+): Promise<ClientChannel> {
+  return new Promise((resolve, reject) => {
+    client.shell(pty, { env }, (err, stream) => (err ? reject(err) : resolve(stream)));
+  });
+}
+
+function isPtyRejection(err: unknown): boolean {
+  return err instanceof Error && /Unable to request a pseudo-terminal/.test(err.message);
 }
 
 /** Translate the common ssh2 failure modes into user-actionable messages. */

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -111,10 +111,19 @@ export function sessionSettings(resolved: ResolvedTarget): SessionSettings {
   };
 }
 
-/** RequestTTY the way ssh(1) treats it: auto ⇒ a tty only for plain shells. */
-function wantsPty(requestTty: ResolvedTarget['requestTty'], hasCommand: boolean): boolean {
+/**
+ * RequestTTY the way ssh(1) treats it: auto ⇒ a tty only for plain shells.
+ * Console compatibility suppresses that implicit allocation because some
+ * appliances reject pty-req outright; explicit yes/force still wins.
+ */
+function wantsPty(
+  requestTty: ResolvedTarget['requestTty'],
+  hasCommand: boolean,
+  consoleCompatibility = false,
+): boolean {
   if (requestTty === 'no') return false;
   if (requestTty === 'yes' || requestTty === 'force') return true;
+  if (consoleCompatibility) return false;
   return !hasCommand;
 }
 
@@ -606,7 +615,7 @@ export class SshConnectionManager {
       health: () => transportHealth,
       configForwards: target.resolved.forwards,
       shell: async (cols, rows, term, session = sessionSettings(target.resolved)) => {
-        const pty = wantsPty(session.requestTty, !!session.remoteCommand)
+        const pty = wantsPty(session.requestTty, !!session.remoteCommand, disableSftp)
           ? terminalPtyOptions(cols, rows, term)
           : undefined;
         if (session.remoteCommand) {

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -257,6 +257,7 @@ export class SshConnectionManager {
   private readonly vault: PasswordVault | undefined;
   private readonly folderAuth: FolderAuthLookup | undefined;
   private readonly disableSftpForHost: ((alias: string) => boolean) | undefined;
+  private readonly consoleCompatibilityForHost: ((alias: string) => boolean) | undefined;
   private readonly agentOperationTimeoutMs: number;
   private readonly agentWaitStatusMs: number;
   readonly knownHosts: KnownHostsStore;
@@ -271,6 +272,8 @@ export class SshConnectionManager {
       folderAuth?: FolderAuthLookup;
       /** Muxus-owned per-host compatibility setting; never written to ssh_config. */
       disableSftpForHost?: (alias: string) => boolean;
+      /** Muxus-owned console compatibility setting; never written to ssh_config. */
+      consoleCompatibilityForHost?: (alias: string) => boolean;
       /** Test seam; production uses the exported responsive-agent defaults. */
       agentOperationTimeoutMs?: number;
       /** Test seam; production uses the exported responsive-agent defaults. */
@@ -282,6 +285,7 @@ export class SshConnectionManager {
     this.vault = options.vault;
     this.folderAuth = options.folderAuth;
     this.disableSftpForHost = options.disableSftpForHost;
+    this.consoleCompatibilityForHost = options.consoleCompatibilityForHost;
     this.agentOperationTimeoutMs =
       options.agentOperationTimeoutMs ?? DEFAULT_AGENT_OPERATION_TIMEOUT_MS;
     this.agentWaitStatusMs =
@@ -331,12 +335,15 @@ export class SshConnectionManager {
     const target = chain[chain.length - 1]!;
     const metadataAlias =
       profile.useConfig === false ? undefined : findMetadataAlias(doc, target.spec.host);
-    const regularKey = muxKey(chain, false);
-    const disableSftp =
-      (metadataAlias ? (this.disableSftpForHost?.(metadataAlias) ?? false) : false) ||
+    const regularKey = muxKey(chain);
+    const consoleCompatibility =
+      (metadataAlias ? (this.consoleCompatibilityForHost?.(metadataAlias) ?? false) : false) ||
       this.automaticPlainShellKeys.has(regularKey) ||
       opts.forcePlainShell === true;
-    const key = muxKey(chain, disableSftp);
+    const disableSftp =
+      consoleCompatibility ||
+      (metadataAlias ? (this.disableSftpForHost?.(metadataAlias) ?? false) : false);
+    const key = muxKey(chain, disableSftp, consoleCompatibility);
     const configForwards = target.resolved.forwards;
     const label = `${target.user}@${target.resolved.hostname}:${target.port}`;
     this.log.debug(
@@ -378,6 +385,7 @@ export class SshConnectionManager {
       key,
       metadataAlias,
       disableSftp,
+      consoleCompatibility,
     );
     const tracked = dial.then((lease) => lease.connection);
     tracked.catch(() => undefined); // waiters observe the rejection through their own await
@@ -507,6 +515,7 @@ export class SshConnectionManager {
     key: string,
     metadataAlias: string | undefined,
     disableSftp: boolean,
+    consoleCompatibility: boolean,
   ): Promise<ConnectionLease> {
     const clients: Client[] = [];
     const postAuth: Promise<void>[] = [];
@@ -609,16 +618,23 @@ export class SshConnectionManager {
         const pty = wantsPty(session.requestTty, !!session.remoteCommand)
           ? terminalPtyOptions(cols, rows, term)
           : undefined;
+        const env = consoleCompatibility ? undefined : session.env;
         if (session.remoteCommand) {
-          return openSessionExec(client, session.remoteCommand, pty, session.env);
+          return openSessionExec(
+            client,
+            session.remoteCommand,
+            pty,
+            env,
+            consoleCompatibility,
+          );
         }
         if (pty && !disableSftp) {
-          return openRemoteShell(client, getSftp, pty, session.env);
+          return openRemoteShell(client, getSftp, pty, env);
         }
         // Console compatibility drops SendEnv/SetEnv: ssh2 can only send env
         // requests before pty-req, an order some appliances answer with a
         // protocol-error disconnect, and a serial console has no environment.
-        return openPlainShell(client, pty, disableSftp ? undefined : session.env);
+        return openPlainShell(client, pty, env, consoleCompatibility);
       },
       // One SFTP channel per connection, shared by every file operation.
       sftp: () =>
@@ -934,15 +950,21 @@ export class SshConnectionManager {
  * deliberately absent — they matter while establishing a transport, not for
  * attaching to an established one.
  */
-export function muxKey(chain: ChainHop[], disableSftp = false): string {
+export function muxKey(
+  chain: ChainHop[],
+  disableSftp = false,
+  consoleCompatibility = false,
+): string {
   const hops = chain.map(
     (hop) =>
       `${hop.user}@${hop.resolved.hostname}:${hop.port};agentForward=${hop.resolved.forwardAgent ? 'yes' : 'no'}`,
   );
   const first = chain[0];
   const proxy = first?.resolved.proxyCommand ? expandedProxyCommand(first) : undefined;
-  const key = (proxy ? [`proxy(${proxy})`, ...hops] : hops).join(' -> ');
-  return disableSftp ? `${key};muxusSftp=disabled` : key;
+  let key = (proxy ? [`proxy(${proxy})`, ...hops] : hops).join(' -> ');
+  if (disableSftp) key += ';muxusSftp=disabled';
+  if (consoleCompatibility) key += ';muxusConsole=compatible';
+  return key;
 }
 
 function mergeConfigForwards(
@@ -1868,7 +1890,22 @@ function defaultIdentityFiles(): string[] {
 }
 
 /** RemoteCommand session: exec instead of a shell, tty per RequestTTY. */
-function openSessionExec(
+async function openSessionExec(
+  client: Client,
+  command: string,
+  pty: PseudoTtyOptions | undefined,
+  env?: Record<string, string>,
+  retryWithoutPty = false,
+): Promise<ClientChannel> {
+  try {
+    return await requestSessionExec(client, command, pty, env);
+  } catch (err) {
+    if (!retryWithoutPty || !pty || !isPtyRejection(err)) throw err;
+    return requestSessionExec(client, command, undefined, env);
+  }
+}
+
+function requestSessionExec(
   client: Client,
   command: string,
   pty: PseudoTtyOptions | undefined,
@@ -1891,11 +1928,12 @@ async function openPlainShell(
   client: Client,
   pty: PseudoTtyOptions | undefined,
   env?: Record<string, string>,
+  retryWithoutPty = false,
 ): Promise<ClientChannel> {
   try {
     return await requestShell(client, pty ?? false, env);
   } catch (err) {
-    if (!pty || !isPtyRejection(err)) throw err;
+    if (!retryWithoutPty || !pty || !isPtyRejection(err)) throw err;
     return requestShell(client, false, env);
   }
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -435,7 +435,7 @@ export interface OpenSshProfileMetadata {
   icon?: string;
   /** Muxus-only terminal highlighting for this OpenSSH alias. */
   keywordHighlights?: HostKeywordHighlightConfig;
-  /** Do not open SFTP channels or probe for remote Unix shell integration. */
+  /** Console compatibility: skip SFTP/integration probes and implicit TTY allocation. */
   disableSftp?: boolean;
   lastConnectedAt?: string;
   connectCount: number;

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -435,8 +435,10 @@ export interface OpenSshProfileMetadata {
   icon?: string;
   /** Muxus-only terminal highlighting for this OpenSSH alias. */
   keywordHighlights?: HostKeywordHighlightConfig;
-  /** No SFTP channels, remote shell-integration probes, or env requests. */
+  /** Do not open SFTP channels or probe for remote Unix shell integration. */
   disableSftp?: boolean;
+  /** Console appliances: also suppress env requests and tolerate a rejected PTY. */
+  consoleCompatibility?: boolean;
   lastConnectedAt?: string;
   connectCount: number;
 }
@@ -448,6 +450,7 @@ export interface OpenSshMetadataPatch {
   icon?: string | null;
   keywordHighlights?: HostKeywordHighlightConfig | null;
   disableSftp?: boolean;
+  consoleCompatibility?: boolean;
 }
 
 /**

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -435,7 +435,7 @@ export interface OpenSshProfileMetadata {
   icon?: string;
   /** Muxus-only terminal highlighting for this OpenSSH alias. */
   keywordHighlights?: HostKeywordHighlightConfig;
-  /** Console compatibility: skip SFTP/integration probes and implicit TTY allocation. */
+  /** No SFTP channels, remote shell-integration probes, or env requests. */
   disableSftp?: boolean;
   lastConnectedAt?: string;
   connectCount: number;

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -466,6 +466,7 @@ describe('restoring imported serial hosts', () => {
           icon: null,
           keywordHighlights: null,
           disableSftp: false,
+          consoleCompatibility: false,
         }),
       }),
     );

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -72,6 +72,7 @@ describe('SSH host editor draft', () => {
     expect(draft.strictHostKeyChecking).toBe('inherit');
     expect(draft.identitiesOnly).toBe(true);
     expect(draft.disableSftp).toBe(false);
+    expect(draft.consoleCompatibility).toBe(false);
     expect(draftToRequest(draft).options.proxyCommand).toBeUndefined();
   });
 
@@ -83,13 +84,16 @@ describe('SSH host editor draft', () => {
           profileId: 'profile-cloud',
           connectCount: 0,
           disableSftp: true,
+          consoleCompatibility: true,
         },
       },
       false,
     );
 
     expect(draft.disableSftp).toBe(true);
+    expect(draft.consoleCompatibility).toBe(true);
     expect(draftToRequest(draft).options).not.toHaveProperty('disableSftp');
+    expect(draftToRequest(draft).options).not.toHaveProperty('consoleCompatibility');
   });
 
   it('makes the specific-key promise independent of the SSH agent', () => {

--- a/tests/unit/client/managed-hosts.test.ts
+++ b/tests/unit/client/managed-hosts.test.ts
@@ -155,6 +155,14 @@ describe('managed host identity and clipboard actions', () => {
 
     expect(managedHostSupportsSftp(ssh)).toBe(true);
     expect(managedHostSupportsSftp({ kind: 'ssh', entry: disabled })).toBe(false);
+
+    const consoleCompatible = sshHost('console-compatible');
+    consoleCompatible.metadata = {
+      profileId: 'ssh-console-compatible',
+      connectCount: 0,
+      consoleCompatibility: true,
+    };
+    expect(managedHostSupportsSftp({ kind: 'ssh', entry: consoleCompatible })).toBe(false);
     expect(managedHostSupportsSftp(telnet)).toBe(false);
     expect(managedHostSupportsSftp(serial)).toBe(false);
   });

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -46,7 +46,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.5.0',
+      currentVersion: '0.5.1',
       latestVersion: '0.6.0',
       releaseName: 'Muxus 0.6',
       releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.6.0',
@@ -56,7 +56,7 @@ describe('app routes', () => {
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.5.0' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.5.1' },
     });
   });
 
@@ -83,7 +83,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.5.0',
+      currentVersion: '0.5.1',
       latestVersion: '0.6.0',
       reason: 'missing-release-url',
     });

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -29,6 +29,7 @@ writeFileSync(emptyConfig, '');
 interface ServerStats {
   connections: number;
   auths: number;
+  envRequests: number;
   execs: number;
   ptyRequests: number;
   sftpRequests: number;
@@ -44,6 +45,8 @@ function startServer(opts: {
   maxShellsPerConnection?: number;
   disconnectOnExec?: boolean;
   rejectPty?: boolean;
+  /** Console servers that only serve interactive terminals reject shells with no pty. */
+  requirePty?: boolean;
 } = {}): Promise<{
   server: Server;
   port: number;
@@ -52,6 +55,7 @@ function startServer(opts: {
   const stats: ServerStats = {
     connections: 0,
     auths: 0,
+    envRequests: 0,
     execs: 0,
     ptyRequests: 0,
     sftpRequests: 0,
@@ -72,10 +76,19 @@ function startServer(opts: {
     conn.on('ready', () => {
       conn.on('session', (acceptSession) => {
         const session = acceptSession();
+        let hasPty = false;
         session.on('pty', (acceptPty, rejectPty) => {
           stats.ptyRequests += 1;
-          if (opts.rejectPty) rejectPty?.();
-          else acceptPty?.();
+          if (opts.rejectPty) {
+            rejectPty?.();
+            return;
+          }
+          hasPty = true;
+          acceptPty?.();
+        });
+        session.on('env', (acceptEnv) => {
+          stats.envRequests += 1;
+          acceptEnv?.();
         });
         // Empty probe output means "no integrated shell" — the manager then
         // opens a plain shell, which is what these tests exercise.
@@ -95,6 +108,10 @@ function startServer(opts: {
         });
         session.on('shell', (acceptShell, rejectShell) => {
           if (shells >= (opts.maxShellsPerConnection ?? Number.POSITIVE_INFINITY)) {
+            rejectShell?.();
+            return;
+          }
+          if (opts.requirePty && !hasPty) {
             rejectShell?.();
             return;
           }
@@ -292,9 +309,9 @@ describe('SSH connection multiplexing', () => {
     expect(started.stats.connections).toBe(2);
   }, 15_000);
 
-  it('opens a plain shell without probes or an implicit PTY in console mode', async () => {
-    // Network consoles commonly accept a shell but reject pty-req. Console
-    // compatibility must skip the implicit PTY as well as exec/SFTP probes.
+  it('opens a plain shell in console mode when the host rejects pty-req', async () => {
+    // Some network consoles reject pty-req; the shell must still open, without
+    // exec or SFTP probes.
     const started = await startServer({ rejectPty: true });
     server = started.server;
     const configFile = path.join(tmp, `ssh_config-console-${knownHostsCounter}`);
@@ -318,9 +335,10 @@ describe('SSH connection multiplexing', () => {
     );
 
     expect(shell.lease.connection.sftpAvailable).toBe(false);
+    // The rejected pty-req costs a channel, so the shell arrives on the retry.
     expect(started.stats).toMatchObject({
       execs: 0,
-      ptyRequests: 0,
+      ptyRequests: 1,
       sftpRequests: 0,
       shells: 1,
     });
@@ -328,6 +346,72 @@ describe('SSH connection multiplexing', () => {
       'SFTP is disabled for this host.',
     );
     expect(started.stats.sftpRequests).toBe(0);
+  }, 15_000);
+
+  it('allocates a PTY in console mode for hosts that require one', async () => {
+    // Serial console servers such as Lantronix answer a shell request with
+    // CHANNEL_FAILURE unless the channel already has a pty.
+    const started = await startServer({ requirePty: true });
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-console-needs-pty-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host console',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  SetEnv TERM=xterm-256color',
+      ].join('\n'),
+    );
+    manager = makeManager(configFile, (alias) => alias === 'console');
+
+    const shell = await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(shell.lease.connection.sftpAvailable).toBe(false);
+    // ssh2 can only send env requests ahead of pty-req, so console mode sends
+    // none: appliances reject that order with a protocol-error disconnect.
+    expect(started.stats).toMatchObject({
+      envRequests: 0,
+      execs: 0,
+      ptyRequests: 1,
+      sftpRequests: 0,
+      shells: 1,
+    });
+  }, 15_000);
+
+  it('still applies SetEnv for hosts outside console mode', async () => {
+    const started = await startServer();
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-setenv-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host regular',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  SetEnv TERM=xterm-256color',
+      ].join('\n'),
+    );
+    manager = makeManager(configFile);
+
+    await manager.connectShell(
+      { kind: 'ssh', target: 'regular', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(started.stats.envRequests).toBeGreaterThan(0);
+    expect(started.stats.shells).toBe(1);
   }, 15_000);
 
   it('honors an explicit RequestTTY yes in console mode', async () => {

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -132,7 +132,10 @@ function startServer(opts: {
 let knownHostsCounter = 0;
 function makeManager(
   configFile = emptyConfig,
-  disableSftpForHost?: (alias: string) => boolean,
+  options: {
+    disableSftpForHost?: (alias: string) => boolean;
+    consoleCompatibilityForHost?: (alias: string) => boolean;
+  } = {},
 ): SshConnectionManager {
   const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
   return new SshConnectionManager(log as never, {
@@ -141,7 +144,7 @@ function makeManager(
       path.join(tmp, 'no-global-known-hosts'),
     ),
     loadConfig: () => loadConfigDocument(configFile),
-    disableSftpForHost,
+    ...options,
   });
 }
 
@@ -324,7 +327,9 @@ describe('SSH connection multiplexing', () => {
         `  Port ${started.port}`,
       ].join('\n'),
     );
-    manager = makeManager(configFile, (alias) => alias === 'console');
+    manager = makeManager(configFile, {
+      consoleCompatibilityForHost: (alias) => alias === 'console',
+    });
 
     const shell = await manager.connectShell(
       { kind: 'ssh', target: 'console', passwordOnly: true },
@@ -364,7 +369,9 @@ describe('SSH connection multiplexing', () => {
         '  SetEnv TERM=xterm-256color',
       ].join('\n'),
     );
-    manager = makeManager(configFile, (alias) => alias === 'console');
+    manager = makeManager(configFile, {
+      consoleCompatibilityForHost: (alias) => alias === 'console',
+    });
 
     const shell = await manager.connectShell(
       { kind: 'ssh', target: 'console', passwordOnly: true },
@@ -414,6 +421,80 @@ describe('SSH connection multiplexing', () => {
     expect(started.stats.shells).toBe(1);
   }, 15_000);
 
+  it('preserves env requests for existing disable-SFTP hosts', async () => {
+    const started = await startServer();
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-disable-sftp-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host legacy',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  SetEnv MUXUS_TEST=from-config',
+      ].join('\n'),
+    );
+    manager = makeManager(configFile, {
+      disableSftpForHost: (alias) => alias === 'legacy',
+    });
+
+    const shell = await manager.connectShell(
+      { kind: 'ssh', target: 'legacy', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(shell.lease.connection.sftpAvailable).toBe(false);
+    expect(started.stats).toMatchObject({
+      envRequests: 1,
+      execs: 0,
+      ptyRequests: 1,
+      sftpRequests: 0,
+      shells: 1,
+    });
+  }, 15_000);
+
+  it('applies console compatibility to RemoteCommand sessions', async () => {
+    const started = await startServer({ rejectPty: true });
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-console-command-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host console',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  SetEnv MUXUS_TEST=from-config',
+        '  RemoteCommand show version',
+        '  RequestTTY yes',
+      ].join('\n'),
+    );
+    manager = makeManager(configFile, {
+      consoleCompatibilityForHost: (alias) => alias === 'console',
+    });
+
+    const shell = await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(shell.lease.connection.sftpAvailable).toBe(false);
+    expect(started.stats).toMatchObject({
+      envRequests: 0,
+      execs: 1,
+      ptyRequests: 1,
+      sftpRequests: 0,
+      shells: 0,
+    });
+  }, 15_000);
+
   it('honors an explicit RequestTTY yes in console mode', async () => {
     const started = await startServer();
     server = started.server;
@@ -428,7 +509,9 @@ describe('SSH connection multiplexing', () => {
         '  RequestTTY yes',
       ].join('\n'),
     );
-    manager = makeManager(configFile, (alias) => alias === 'console');
+    manager = makeManager(configFile, {
+      consoleCompatibilityForHost: (alias) => alias === 'console',
+    });
 
     await manager.connectShell(
       { kind: 'ssh', target: 'console', passwordOnly: true },
@@ -490,23 +573,27 @@ describe('SSH connection multiplexing', () => {
     );
   }, 15_000);
 
-  it('does not share transports across different SFTP compatibility settings', async () => {
+  it('does not share transports between disable-SFTP and console modes', async () => {
     const started = await startServer();
     server = started.server;
     const configFile = path.join(tmp, `ssh_config-sftp-isolation-${knownHostsCounter}`);
     writeFileSync(
       configFile,
       [
-        'Host regular console',
+        'Host legacy console',
         '  HostName 127.0.0.1',
         '  User tester',
         `  Port ${started.port}`,
+        '  SetEnv MUXUS_TEST=from-config',
       ].join('\n'),
     );
-    manager = makeManager(configFile, (alias) => alias === 'console');
+    manager = makeManager(configFile, {
+      disableSftpForHost: (alias) => alias === 'legacy',
+      consoleCompatibilityForHost: (alias) => alias === 'console',
+    });
 
-    const regular = await manager.connectShell(
-      { kind: 'ssh', target: 'regular', passwordOnly: true },
+    const legacy = await manager.connectShell(
+      { kind: 'ssh', target: 'legacy', passwordOnly: true },
       makeIo().io,
       80,
       24,
@@ -520,7 +607,8 @@ describe('SSH connection multiplexing', () => {
       'xterm-256color',
     );
 
-    expect(consoleShell.lease.connection.id).not.toBe(regular.lease.connection.id);
+    expect(consoleShell.lease.connection.id).not.toBe(legacy.lease.connection.id);
     expect(started.stats.connections).toBe(2);
+    expect(started.stats.envRequests).toBe(1);
   }, 15_000);
 });

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -30,6 +30,7 @@ interface ServerStats {
   connections: number;
   auths: number;
   execs: number;
+  ptyRequests: number;
   sftpRequests: number;
   shells: number;
 }
@@ -42,6 +43,7 @@ interface ServerStats {
 function startServer(opts: {
   maxShellsPerConnection?: number;
   disconnectOnExec?: boolean;
+  rejectPty?: boolean;
 } = {}): Promise<{
   server: Server;
   port: number;
@@ -51,6 +53,7 @@ function startServer(opts: {
     connections: 0,
     auths: 0,
     execs: 0,
+    ptyRequests: 0,
     sftpRequests: 0,
     shells: 0,
   };
@@ -69,7 +72,11 @@ function startServer(opts: {
     conn.on('ready', () => {
       conn.on('session', (acceptSession) => {
         const session = acceptSession();
-        session.on('pty', (acceptPty) => acceptPty?.());
+        session.on('pty', (acceptPty, rejectPty) => {
+          stats.ptyRequests += 1;
+          if (opts.rejectPty) rejectPty?.();
+          else acceptPty?.();
+        });
         // Empty probe output means "no integrated shell" — the manager then
         // opens a plain shell, which is what these tests exercise.
         session.on('exec', (acceptExec) => {
@@ -285,8 +292,10 @@ describe('SSH connection multiplexing', () => {
     expect(started.stats.connections).toBe(2);
   }, 15_000);
 
-  it('opens a plain shell without probes when SFTP is disabled for the host', async () => {
-    const started = await startServer();
+  it('opens a plain shell without probes or an implicit PTY in console mode', async () => {
+    // Network consoles commonly accept a shell but reject pty-req. Console
+    // compatibility must skip the implicit PTY as well as exec/SFTP probes.
+    const started = await startServer({ rejectPty: true });
     server = started.server;
     const configFile = path.join(tmp, `ssh_config-console-${knownHostsCounter}`);
     writeFileSync(
@@ -309,11 +318,48 @@ describe('SSH connection multiplexing', () => {
     );
 
     expect(shell.lease.connection.sftpAvailable).toBe(false);
-    expect(started.stats).toMatchObject({ execs: 0, sftpRequests: 0, shells: 1 });
+    expect(started.stats).toMatchObject({
+      execs: 0,
+      ptyRequests: 0,
+      sftpRequests: 0,
+      shells: 1,
+    });
     await expect(shell.lease.connection.sftp()).rejects.toThrow(
       'SFTP is disabled for this host.',
     );
     expect(started.stats.sftpRequests).toBe(0);
+  }, 15_000);
+
+  it('honors an explicit RequestTTY yes in console mode', async () => {
+    const started = await startServer();
+    server = started.server;
+    const configFile = path.join(tmp, `ssh_config-console-tty-${knownHostsCounter}`);
+    writeFileSync(
+      configFile,
+      [
+        'Host console',
+        '  HostName 127.0.0.1',
+        '  User tester',
+        `  Port ${started.port}`,
+        '  RequestTTY yes',
+      ].join('\n'),
+    );
+    manager = makeManager(configFile, (alias) => alias === 'console');
+
+    await manager.connectShell(
+      { kind: 'ssh', target: 'console', passwordOnly: true },
+      makeIo().io,
+      80,
+      24,
+      'xterm-256color',
+    );
+
+    expect(started.stats).toMatchObject({
+      execs: 0,
+      ptyRequests: 1,
+      sftpRequests: 0,
+      shells: 1,
+    });
   }, 15_000);
 
   it('automatically redials in plain-console mode when integration drops the transport', async () => {

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -44,7 +44,38 @@ describe('MuxusDatabase migrations', () => {
       { version: 17, name: 'folder-settings' },
       { version: 18, name: 'lock-workspaces' },
       { version: 19, name: 'host-disable-sftp' },
+      { version: 20, name: 'host-console-compatibility' },
     ]);
+  });
+
+  it('preserves version 19 disable-SFTP records when adding console compatibility', () => {
+    temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), 'muxus-v19-migration-'));
+    const filename = path.join(temporaryDirectory, 'muxus.sqlite3');
+    database = new MuxusDatabase(filename);
+    database.updateOpenSshMetadata('legacy', { disableSftp: true });
+    database.close();
+    database = undefined;
+
+    const legacy = new DatabaseSync(filename);
+    try {
+      legacy.exec(`
+        DELETE FROM schema_migrations WHERE version = 20;
+        ALTER TABLE connection_profiles DROP COLUMN console_compatibility;
+        PRAGMA user_version = 19;
+      `);
+    } finally {
+      legacy.close();
+    }
+
+    database = new MuxusDatabase(filename);
+    expect(database.openSshMetadata(['legacy']).get('legacy')).toMatchObject({
+      disableSftp: true,
+    });
+    expect(database.openSshMetadata(['legacy']).get('legacy')).not.toHaveProperty(
+      'consoleCompatibility',
+    );
+    expect(database.sftpDisabledForAlias('legacy')).toBe(true);
+    expect(database.consoleCompatibilityForAlias('legacy')).toBe(false);
   });
 
   it('upgrades the draft version 13 vault without deleting credentials', () => {
@@ -120,8 +151,8 @@ describe('MuxusDatabase migrations', () => {
 
     database = new MuxusDatabase(filename);
     expect(database.appliedMigrations().at(-1)).toEqual({
-      version: 19,
-      name: 'host-disable-sftp',
+      version: 20,
+      name: 'host-console-compatibility',
     });
     expect(database.passwordVaultConfig()).toMatchObject({
       formatVersion: 2,
@@ -302,6 +333,7 @@ describe('hybrid OpenSSH metadata', () => {
       group: 'Work',
       color: '#3b82f6',
       disableSftp: true,
+      consoleCompatibility: true,
       keywordHighlights: {
         inheritGlobal: true,
         rules: [
@@ -324,6 +356,7 @@ describe('hybrid OpenSSH metadata', () => {
       group: 'Work',
       color: '#3b82f6',
       disableSftp: true,
+      consoleCompatibility: true,
       keywordHighlights: {
         inheritGlobal: true,
         rules: [expect.objectContaining({ keyword: 'ERROR' })],
@@ -333,6 +366,12 @@ describe('hybrid OpenSSH metadata', () => {
     expect(database.openSshMetadata(['production']).get('production')).toEqual(connected);
     expect(database.sftpDisabledForAlias('production')).toBe(true);
     expect(database.sftpDisabledForAlias('missing')).toBe(false);
+    expect(database.consoleCompatibilityForAlias('production')).toBe(true);
+    expect(database.consoleCompatibilityForAlias('missing')).toBe(false);
+
+    database.updateOpenSshMetadata('production', { consoleCompatibility: false });
+    expect(database.consoleCompatibilityForAlias('production')).toBe(false);
+    expect(database.sftpDisabledForAlias('production')).toBe(true);
 
     database.updateOpenSshMetadata('production', { disableSftp: false });
     expect(database.sftpDisabledForAlias('production')).toBe(false);

--- a/tests/unit/server/ssh-routes.test.ts
+++ b/tests/unit/server/ssh-routes.test.ts
@@ -32,16 +32,19 @@ afterEach(async () => {
 const auth = () => ({ authorization: `Bearer ${TOKEN}` });
 
 describe('OpenSSH host keyword metadata', () => {
-  it('persists the per-host SFTP compatibility setting', async () => {
+  it('persists independent per-host SFTP and console compatibility settings', async () => {
     const response = await app.inject({
       method: 'PATCH',
       url: '/api/ssh/config/hosts/production/metadata',
       headers: auth(),
-      payload: { disableSftp: true },
+      payload: { disableSftp: true, consoleCompatibility: true },
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toMatchObject({ disableSftp: true });
+    expect(response.json()).toMatchObject({
+      disableSftp: true,
+      consoleCompatibility: true,
+    });
   });
 
   it('persists validated per-host highlighting without rewriting ssh_config', async () => {


### PR DESCRIPTION
## Summary
Follow-up to #85. Console-compatibility mode could not open a shell on a real
Lantronix console server, and suppressing the implicit `pty-req` made it worse
rather than better.
- **Root cause.** ssh2 can only send `env` channel requests *ahead* of
  `pty-req` (`reqEnv` runs immediately while `reqPty` is queued in
  `Client.prototype.shell`), the reverse of OpenSSH's order. The appliance
  answers that sequence with `SSH_MSG_DISCONNECT` /
  `SSH_DISCONNECT_PROTOCOL_ERROR` ("Sorry"). Any host with `SendEnv`/`SetEnv`
  in scope — commonly a `Host *` block — was affected. Console mode now sends
  no `env` requests, which a serial console has no environment for.
- **The TTY is back.** Suppressing the implicit `pty-req` breaks appliances
  that only serve interactive terminals: they answer the shell request with
  `CHANNEL_FAILURE`, surfacing as `Unable to open shell`. The tty again follows
  `RequestTTY` as ssh(1) defines it.
- **No per-host guess needed.** Devices that genuinely refuse `pty-req` now get
  a retry without one, so both kinds of appliance work from the same setting.
`SendEnv`/`SetEnv` still apply to every host outside console mode.
## Test plan
- [x] New `requirePty` mode in the fake sshd refuses a shell on a channel with
      no pty; reverting the server change reproduces `Unable to open shell`
      with the same `CHANNEL_FAILURE` stack as the field report.
- [x] `env` request counter asserts console mode sends none while `SetEnv` is
      still honored for normal hosts.
- [x] Existing `rejectPty` test still passes, now asserting one rejected
      `pty-req` followed by a successful plain shell.
- [x] 320 server unit tests, `pnpm lint`, `pnpm typecheck` all clean.
- [x] Verified against a Lantronix console server on port 22.
Two things to mention when you open it. First, 887393b's title and description are now inaccurate — the "hosts without PTY support" symptom was really the env ordering — so #85 will want a reword once this lands. Second, unrelated to this work: keymap.test.ts has 8 failures on that branch that also fail on a clean tree, and one electron database test times out at 5s under parallel load but passes in isolation.