### PR TITLE
Follow terminal directory in SFTP browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,28 @@ jobs:
         run: pnpm test
 
       - name: Check bundle budgets
-        run: pnpm check:bundle
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          pnpm --filter @muxus/client build
+
+          if [ -z "$BASE_SHA" ]; then
+            node client/scripts/check-bundle-budget.mjs
+            exit
+          fi
+
+          base_dir="$RUNNER_TEMP/muxus-base"
+          base_report="$RUNNER_TEMP/base-bundle.json"
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git worktree add --detach "$base_dir" "$BASE_SHA"
+          pnpm --dir "$base_dir" install --frozen-lockfile
+          pnpm --dir "$base_dir" --filter @muxus/shared build
+          pnpm --dir "$base_dir" --filter @muxus/client build
+          node client/scripts/check-bundle-budget.mjs \
+            --dist "$base_dir/client/dist" \
+            --write-report "$base_report" \
+            --report-only
+          node client/scripts/check-bundle-budget.mjs --baseline "$base_report"
 
   package-smoke:
     name: Package (${{ matrix.name }})

--- a/client/scripts/check-bundle-budget.d.mts
+++ b/client/scripts/check-bundle-budget.d.mts
@@ -1,0 +1,26 @@
+export type BundleMetricKey = 'initial' | 'terminal' | 'monaco' | 'typescriptWorker';
+
+export interface BundleMeasurement {
+  raw: number;
+  gzip: number;
+}
+
+export interface BundleReport {
+  version: 1;
+  metrics: Record<BundleMetricKey, BundleMeasurement>;
+  oversizedChunks: Array<{ file: string; raw: number }>;
+}
+
+export interface BundlePolicy {
+  key: BundleMetricKey;
+  label: string;
+  growth: BundleMeasurement;
+  safetyCap: BundleMeasurement;
+}
+
+export const BUNDLE_POLICIES: BundlePolicy[];
+export function measureBundle(dist?: string): BundleReport;
+export function evaluateBundleReport(
+  report: BundleReport,
+  baseline?: BundleReport,
+): string[];

--- a/client/scripts/check-bundle-budget.mjs
+++ b/client/scripts/check-bundle-budget.mjs
@@ -1,174 +1,257 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { gzipSync } from 'node:zlib';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const dist = resolve(dirname(fileURLToPath(import.meta.url)), '../dist');
-const manifest = JSON.parse(readFileSync(join(dist, '.vite/manifest.json'), 'utf8'));
-const entries = Object.entries(manifest);
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultDist = resolve(dirname(scriptPath), '../dist');
+const REPORT_VERSION = 1;
+const UNAPPROVED_CHUNK_CAP = 700_000;
 
-function manifestKeyForSource(source) {
-  const match = entries.find(([key]) => key === source);
-  if (!match) throw new Error(`Bundle manifest is missing ${source}`);
-  return match[0];
-}
-
-function collectStaticGraph(key, excluded = new Set(), result = new Set()) {
-  if (excluded.has(key) || result.has(key)) return result;
-  const chunk = manifest[key];
-  if (!chunk) throw new Error(`Bundle manifest references missing chunk ${key}`);
-  result.add(key);
-  for (const imported of chunk.imports ?? []) collectStaticGraph(imported, excluded, result);
-  return result;
-}
-
-function measureFiles(files) {
-  let raw = 0;
-  let gzip = 0;
-  for (const file of files) {
-    const bytes = readFileSync(join(dist, file));
-    raw += bytes.byteLength;
-    gzip += gzipSync(bytes).byteLength;
-  }
-  return { raw, gzip };
-}
-
-function measureGraph(keys) {
-  return measureFiles(
-    [...keys]
-      .map((key) => manifest[key].file)
-      .filter((file) => file.endsWith('.js')),
-  );
-}
+/** Relative limits catch meaningful PR growth; safety caps catch large eager
+ * imports even when no base report is available (for example, local runs and
+ * pushes to main). */
+export const BUNDLE_POLICIES = [
+  {
+    key: 'initial',
+    label: 'Initial JavaScript',
+    growth: { raw: 25 * 1024, gzip: 8 * 1024 },
+    safetyCap: { raw: 900 * 1024, gzip: 300 * 1024 },
+  },
+  {
+    key: 'terminal',
+    label: 'Terminal feature JavaScript',
+    growth: { raw: 25 * 1024, gzip: 8 * 1024 },
+    safetyCap: { raw: 600 * 1024, gzip: 165 * 1024 },
+  },
+  {
+    key: 'monaco',
+    label: 'Monaco full editor JavaScript',
+    growth: { raw: 100 * 1024, gzip: 30 * 1024 },
+    safetyCap: { raw: 4_500 * 1024, gzip: 1_150 * 1024 },
+  },
+  {
+    key: 'typescriptWorker',
+    label: 'TypeScript worker',
+    growth: { raw: 100 * 1024, gzip: 30 * 1024 },
+    safetyCap: { raw: 7_800 * 1024, gzip: 1_750 * 1024 },
+  },
+];
 
 function format(bytes) {
   return `${(bytes / 1024).toFixed(1)} KiB`;
 }
 
-const failures = [];
-function check(label, measured, budget) {
-  const detail = `${format(measured.raw)} raw / ${format(measured.gzip)} gzip`;
-  console.log(`${label}: ${detail}`);
-  if (measured.raw > budget.raw || measured.gzip > budget.gzip) {
+function formatChange(bytes) {
+  return `${bytes >= 0 ? '+' : ''}${format(bytes)}`;
+}
+
+function measurement(raw, gzip) {
+  return { raw, gzip };
+}
+
+/** Measure the user-visible loading graphs from one Vite output directory. */
+export function measureBundle(dist = defaultDist) {
+  const manifest = JSON.parse(readFileSync(join(dist, '.vite/manifest.json'), 'utf8'));
+  const entries = Object.entries(manifest);
+
+  const manifestKeyForSource = (source) => {
+    const match = entries.find(([key]) => key === source);
+    if (!match) throw new Error(`Bundle manifest is missing ${source}`);
+    return match[0];
+  };
+
+  const collectStaticGraph = (key, excluded = new Set(), result = new Set()) => {
+    if (excluded.has(key) || result.has(key)) return result;
+    const chunk = manifest[key];
+    if (!chunk) throw new Error(`Bundle manifest references missing chunk ${key}`);
+    result.add(key);
+    for (const imported of chunk.imports ?? []) collectStaticGraph(imported, excluded, result);
+    return result;
+  };
+
+  const measureFiles = (files) => {
+    let raw = 0;
+    let gzip = 0;
+    for (const file of files) {
+      const bytes = readFileSync(join(dist, file));
+      raw += bytes.byteLength;
+      gzip += gzipSync(bytes).byteLength;
+    }
+    return measurement(raw, gzip);
+  };
+
+  const measureGraph = (keys) =>
+    measureFiles(
+      [...keys]
+        .map((key) => manifest[key].file)
+        .filter((file) => file.endsWith('.js')),
+    );
+
+  const entry = entries.find(([, chunk]) => chunk.isEntry);
+  if (!entry) throw new Error('Bundle manifest has no application entry');
+  const initialKeys = collectStaticGraph(entry[0]);
+  const featureGraph = (source) =>
+    measureGraph(collectStaticGraph(manifestKeyForSource(source), initialKeys));
+
+  const assetFiles = readdirSync(join(dist, 'assets')).filter((file) => file.endsWith('.js'));
+  const typeScriptWorker = assetFiles.find((file) => file.startsWith('ts.worker-'));
+  if (!typeScriptWorker) throw new Error('Bundle is missing the TypeScript worker');
+
+  const oversizedChunks = [];
+  for (const file of assetFiles) {
+    const bytes = readFileSync(join(dist, 'assets', file));
+    if (
+      bytes.byteLength > UNAPPROVED_CHUNK_CAP &&
+      !file.includes('worker') &&
+      !file.startsWith('editor.api-') &&
+      // Rolldown names Monaco's full editor-contributions chunk after its
+      // final CSS-bearing contribution. It belongs to the lazy editor graph.
+      !file.startsWith('toggleHighContrast-')
+    ) {
+      oversizedChunks.push({ file, raw: bytes.byteLength });
+    }
+  }
+
+  return {
+    version: REPORT_VERSION,
+    metrics: {
+      initial: measureGraph(initialKeys),
+      terminal: featureGraph('src/components/TerminalViewImpl.tsx'),
+      monaco: featureGraph('src/components/MonacoTextEditor.tsx'),
+      typescriptWorker: measureFiles([`assets/${typeScriptWorker}`]),
+    },
+    oversizedChunks,
+  };
+}
+
+function validateReport(report, source) {
+  if (!report || report.version !== REPORT_VERSION || !report.metrics) {
+    throw new Error(`${source} is not a bundle report version ${REPORT_VERSION}`);
+  }
+  for (const policy of BUNDLE_POLICIES) {
+    const measured = report.metrics[policy.key];
+    if (
+      !measured ||
+      !Number.isFinite(measured.raw) ||
+      !Number.isFinite(measured.gzip) ||
+      measured.raw < 0 ||
+      measured.gzip < 0
+    ) {
+      throw new Error(`${source} has no valid ${policy.key} measurement`);
+    }
+  }
+  if (!Array.isArray(report.oversizedChunks)) {
+    throw new Error(`${source} has no oversizedChunks list`);
+  }
+  return report;
+}
+
+function exceededDimensions(measured, limit) {
+  const exceeded = [];
+  if (measured.raw > limit.raw) exceeded.push(`${measured.raw - limit.raw} B raw`);
+  if (measured.gzip > limit.gzip) exceeded.push(`${measured.gzip - limit.gzip} B gzip`);
+  return exceeded.join(' and ');
+}
+
+/** Evaluate relative growth and absolute safety boundaries separately so a
+ * small intentional feature does not require ratcheting a hard-coded ceiling. */
+export function evaluateBundleReport(report, baseline) {
+  validateReport(report, 'bundle report');
+  if (baseline) validateReport(baseline, 'baseline bundle report');
+  const failures = [];
+
+  for (const policy of BUNDLE_POLICIES) {
+    const measured = report.metrics[policy.key];
+    if (
+      measured.raw > policy.safetyCap.raw ||
+      measured.gzip > policy.safetyCap.gzip
+    ) {
+      failures.push(
+        `${policy.label} exceeds its safety cap by ${exceededDimensions(measured, policy.safetyCap)}`,
+      );
+    }
+
+    if (!baseline) continue;
+    const previous = baseline.metrics[policy.key];
+    const growth = measurement(measured.raw - previous.raw, measured.gzip - previous.gzip);
+    if (growth.raw > policy.growth.raw || growth.gzip > policy.growth.gzip) {
+      failures.push(
+        `${policy.label} exceeds allowed PR growth by ${exceededDimensions(growth, policy.growth)}`,
+      );
+    }
+  }
+
+  for (const chunk of report.oversizedChunks) {
     failures.push(
-      `${label} exceeds ${format(budget.raw)} raw / ${format(budget.gzip)} gzip (${detail})`,
+      `${chunk.file} exceeds the unapproved chunk limit by ${chunk.raw - UNAPPROVED_CHUNK_CAP} B (${format(chunk.raw)} total)`,
+    );
+  }
+  return failures;
+}
+
+function printReport(report, baseline) {
+  for (const policy of BUNDLE_POLICIES) {
+    const measured = report.metrics[policy.key];
+    const detail = `${format(measured.raw)} raw / ${format(measured.gzip)} gzip`;
+    if (!baseline) {
+      console.log(`${policy.label}: ${detail}`);
+      continue;
+    }
+    const previous = baseline.metrics[policy.key];
+    console.log(
+      `${policy.label}: ${detail} (${formatChange(measured.raw - previous.raw)} raw / ${formatChange(measured.gzip - previous.gzip)} gzip vs base)`,
     );
   }
 }
 
-const entry = entries.find(([, chunk]) => chunk.isEntry);
-if (!entry) throw new Error('Bundle manifest has no application entry');
-const initialKeys = collectStaticGraph(entry[0]);
-
-// The keymap (command catalog + dispatcher) is part of the first paint: a
-// shortcut has to work before any lazy chunk could load. It costs ~9 KiB raw
-// and ~0.3 KiB gzip, which this budget accounts for — everything else that
-// only the dialogs need stays lazy.
-//
-// The sidebar's folder tree adds ~12 KiB raw on top of that. Its model,
-// keyboard navigation and drag-and-drop are the host list itself and cannot be
-// deferred; the menus and dialogs it opens are lazy (see SidebarMenus).
-//
-// Workspace restoration also reads the remote reconnect preference before
-// terminals mount. That startup decision adds ~0.2 KiB raw / ~0.1 KiB gzip;
-// the reconnect and scrollback implementations remain in the lazy terminal
-// feature graph measured below.
-//
-// A command in that catalog pays there as well. The multi-execution toggle —
-// the selection it resumes and the reason it gives when there is nothing to
-// mirror — adds ~1 KiB raw / ~0.4 KiB gzip to the keymap and the multi-exec
-// store, both of which the first paint already carries, and the gzip budget
-// moves to cover it.
-//
-// Background-output notifications also live in the tab store and tab strip,
-// both of which are required for first paint. The gzip budget moves by 1 KiB
-// to cover their state and visual treatment.
-//
-// Folder credential defaults ride the sidebar: folder rename, drag and delete
-// must carry the shared settings along, so the sidebar carries the small
-// folder-settings API module (~2 KiB raw / ~0.7 KiB gzip). The credentials
-// editor itself stays in the lazy folder dialog.
-//
-// Cross-pane tab dragging has a synchronous HTML drag-token path and an exact
-// pane-move state transition on first paint (~1.1 KiB raw / ~1 KiB gzip). The
-// cross-window coordinator, snapshot flush, and adoption path remain lazy.
-// Browser-style drag feedback (live same-strip resorting, insertion lines,
-// FLIP slides) lives in the tab strip itself (~2.5 KiB raw / ~0.7 KiB gzip).
-//
-// Workspace locking is enforced by the startup persistence runtime, including
-// distinguishing explicit saves from stale automatic saves and stopping retry
-// loops after a lock conflict. That first-paint guarantee adds ~2 KiB raw /
-// ~0.3 KiB gzip; the management dialog and its icons remain lazy.
-//
-// Saved local-shell profiles are launchable directly from the sidebar, so the
-// profile preference shape and launch path join the initial graph (~2 KiB raw /
-// ~0.5 KiB gzip). The profile editor remains in the lazy settings dialog.
-//
-// Window-wide tab numbering belongs to the initial tab store and strips. Its
-// ordered-tab derivation, Alt reveal, inline badges and preference add ~1 KiB
-// raw / ~0.2 KiB gzip; the settings control stays lazy.
-//
-// Split-pane focus highlighting also runs in the initial pane canvas so focus
-// and active multi-exec targets update immediately. Its preference reads and
-// pane-target derivation add less than 1 KiB raw; the settings UI stays lazy.
-//
-// Reusable keyword-highlighting profiles are persisted preferences. Their
-// bounded shape validator therefore joins the startup preference migration
-// (~1.5 KiB raw / ~0.3 KiB gzip); profile editing and transfer UI stay in the
-// lazy settings chunk, and terminal resolution stays in the terminal chunk.
-check('Initial JavaScript', measureGraph(initialKeys), {
-  raw: 800_000,
-  gzip: 259_500,
-});
-
-for (const feature of [
-  {
-    label: 'Terminal feature JavaScript',
-    source: 'src/components/TerminalViewImpl.tsx',
-    budget: { raw: 520_000, gzip: 140_000 },
-  },
-  {
-    // The editor is intent-preloaded and lazy. This budget covers Monaco's
-    // complete standalone contribution set (commands, formatting, folding,
-    // suggestions, navigation, accessibility, etc.), not the initial app.
-    label: 'Monaco full editor JavaScript',
-    source: 'src/components/MonacoTextEditor.tsx',
-    budget: { raw: 4_050_000, gzip: 1_020_000 },
-  },
-]) {
-  const featureKeys = collectStaticGraph(
-    manifestKeyForSource(feature.source),
-    initialKeys,
-  );
-  check(feature.label, measureGraph(featureKeys), feature.budget);
-}
-
-const assetFiles = readdirSync(join(dist, 'assets')).filter((file) => file.endsWith('.js'));
-const typeScriptWorker = assetFiles.find((file) => file.startsWith('ts.worker-'));
-if (!typeScriptWorker) throw new Error('Bundle is missing the TypeScript worker');
-check('TypeScript worker', measureFiles([`assets/${typeScriptWorker}`]), {
-  raw: 7_100_000,
-  gzip: 1_550_000,
-});
-
-for (const file of assetFiles) {
-  const bytes = readFileSync(join(dist, 'assets', file));
-  if (
-    bytes.byteLength > 700_000 &&
-    !file.includes('worker') &&
-    !file.startsWith('editor.api-') &&
-    // Rolldown names Monaco's full editor-contributions chunk after its final
-    // CSS-bearing contribution. It is part of the measured lazy editor graph.
-    !file.startsWith('toggleHighContrast-')
-  ) {
-    failures.push(`${file} is ${format(bytes.byteLength)}; unapproved chunks must stay below 683.6 KiB`);
+function parseArgs(args) {
+  const options = { dist: defaultDist };
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--') continue;
+    if (arg === '--report-only') {
+      options.reportOnly = true;
+      continue;
+    }
+    if (arg === '--dist' || arg === '--baseline' || arg === '--write-report') {
+      const value = args[++index];
+      if (!value) throw new Error(`${arg} requires a path`);
+      const key = arg === '--dist' ? 'dist' : arg === '--baseline' ? 'baseline' : 'writeReport';
+      options[key] = resolve(value);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
   }
+  return options;
 }
 
-if (failures.length > 0) {
-  console.error('\nBundle budget failed:');
-  for (const failure of failures) console.error(`- ${failure}`);
-  process.exitCode = 1;
-} else {
-  console.log('Bundle budgets passed.');
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const report = measureBundle(options.dist);
+  const baseline = options.baseline
+    ? validateReport(JSON.parse(readFileSync(options.baseline, 'utf8')), options.baseline)
+    : undefined;
+  printReport(report, baseline);
+
+  if (options.writeReport) {
+    writeFileSync(options.writeReport, `${JSON.stringify(report, null, 2)}\n`);
+    console.log(`Bundle report written to ${options.writeReport}`);
+  }
+  if (options.reportOnly) return;
+
+  const failures = evaluateBundleReport(report, baseline);
+  if (failures.length > 0) {
+    console.error('\nBundle check failed:');
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    baseline
+      ? 'Bundle growth and safety caps passed.'
+      : 'Bundle safety caps passed (relative growth requires a base report).',
+  );
 }
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) main();

--- a/client/src/components/SftpPanel.tsx
+++ b/client/src/components/SftpPanel.tsx
@@ -51,6 +51,7 @@ import {
   maxSftpPanelWidth,
   MIN_SFTP_PANEL_WIDTH,
 } from '../sftp-panel-width.js';
+import { initialSftpPath } from '../sftp-panel-state.js';
 import { FileTypeIcon } from './FileTypeIcon.js';
 import { PanelResizeHandle } from './PanelResizeHandle.js';
 
@@ -328,7 +329,7 @@ export function SftpPanel({
   fill?: boolean;
   onOpenInNewWindow?: (path: string) => void;
 }) {
-  const startingPath = terminalPath ?? initialPath;
+  const startingPath = initialSftpPath(initialPath, terminalPath, followTerminalFolder);
   const [path, setPath] = useState(startingPath);
   const [pathInput, setPathInput] = useState(startingPath);
   const [dragOver, setDragOver] = useState(false);

--- a/client/src/components/SftpPanel.tsx
+++ b/client/src/components/SftpPanel.tsx
@@ -1,7 +1,9 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
 import CircularProgress from '@mui/material/CircularProgress';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -308,18 +310,27 @@ export function SftpPanel({
   connId,
   onOpenFile,
   initialPath = '.',
+  terminalPath,
+  followTerminalFolder = false,
+  onFollowTerminalFolderChange,
   fill = false,
   onOpenInNewWindow,
 }: {
   connId: string;
   onOpenFile: (path: string) => void;
   initialPath?: string;
+  /** Latest working directory reported by the terminal sharing this connection. */
+  terminalPath?: string;
+  /** Whether the attached browser follows terminal working-directory reports. */
+  followTerminalFolder?: boolean;
+  onFollowTerminalFolderChange?: (follow: boolean) => void;
   /** Fill a standalone window instead of using the saved side-panel width. */
   fill?: boolean;
   onOpenInNewWindow?: (path: string) => void;
 }) {
-  const [path, setPath] = useState(initialPath);
-  const [pathInput, setPathInput] = useState(initialPath);
+  const startingPath = terminalPath ?? initialPath;
+  const [path, setPath] = useState(startingPath);
+  const [pathInput, setPathInput] = useState(startingPath);
   const [dragOver, setDragOver] = useState(false);
   const [selectedName, setSelectedName] = useState<string>();
   const [menu, setMenu] = useState<{ x: number; y: number; entry: SftpEntry } | null>(null);
@@ -338,9 +349,15 @@ export function SftpPanel({
   const { data, isFetching, error } = useSftpList(connId, path);
   useEffect(() => {
     if (!data?.path) return;
-    homePathRef.current ??= data.path;
+    if (path === '.') homePathRef.current = data.path;
     setPathInput(data.path);
-  }, [data?.path]);
+  }, [data?.path, path]);
+  useEffect(() => {
+    if (!followTerminalFolder || !terminalPath) return;
+    setPath(terminalPath);
+    setPathInput(terminalPath);
+    setSelectedName(undefined);
+  }, [followTerminalFolder, terminalPath]);
   useEffect(() => () => transferControllerRef.current?.abort(), []);
 
   const entries = useMemo(
@@ -929,6 +946,26 @@ export function SftpPanel({
           />
         )}
       </Box>
+      {onFollowTerminalFolderChange && (
+        <FormControlLabel
+          control={(
+            <Checkbox
+              size="small"
+              checked={followTerminalFolder}
+              onChange={(event) => onFollowTerminalFolderChange(event.target.checked)}
+            />
+          )}
+          label="Follow terminal folder"
+          sx={{
+            m: 0,
+            px: 0.75,
+            py: 0.25,
+            borderTop: 1,
+            borderColor: 'divider',
+            '& .MuiFormControlLabel-label': { fontSize: 12 },
+          }}
+        />
+      )}
       {dragOver && (
         <Box
           sx={(theme) => ({

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -50,7 +50,7 @@ import {
   terminalScheme,
   themeWithColorOverrides,
 } from '../terminal/palette.js';
-import { attachCommandTracker } from '../terminal/shell-integration.js';
+import { attachCommandTracker, attachCwdTracker } from '../terminal/shell-integration.js';
 import { attachOsc52Clipboard } from '../terminal/osc52-clipboard.js';
 import {
   attachKeywordHighlighter,
@@ -298,6 +298,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         connId: undefined,
         sftpAvailable: undefined,
         sftpOpen: false,
+        terminalCwd: undefined,
       });
     }
 
@@ -531,6 +532,15 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     el.addEventListener('wheel', onWheel, { passive: false, capture: true });
 
     const commandTracker = attachCommandTracker(term);
+    const cwdTracker =
+      tab.profile.kind === 'ssh'
+        ? attachCwdTracker(term, (terminalCwd) => {
+            const current = useTabsStore
+              .getState()
+              .tabs.find((candidate) => candidate.id === tab.id);
+            if (current?.terminalCwd !== terminalCwd) updateTab(tab.id, { terminalCwd });
+          })
+        : undefined;
 
     // Application chords never reach xterm: the shortcut layer consumes them
     // in the capture phase, and anything it declines is encoded for the shell
@@ -1001,6 +1011,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       onSelection.dispose();
       onSearchResults.dispose();
       commandTracker.dispose();
+      cwdTracker?.dispose();
       keywordHighlighterRef.current?.dispose();
       if (interruptionTimer !== undefined) clearTimeout(interruptionTimer);
       if (autoReconnectTimer !== undefined) clearTimeout(autoReconnectTimer);

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -120,6 +120,7 @@ function PaneCanvas({
   const openEditor = useTabsStore((state) => state.openEditor);
   const activateEditor = useTabsStore((state) => state.activateEditor);
   const closeEditor = useTabsStore((state) => state.closeEditor);
+  const updateTab = useTabsStore((state) => state.update);
   const tabNumberVisibility = usePrefsStore((state) => state.tabNumberVisibility);
   const activePaneBorder = usePrefsStore((state) => state.activePaneBorder);
   const dimInactivePanes = usePrefsStore((state) => state.dimInactivePanes);
@@ -257,6 +258,11 @@ function PaneCanvas({
                   <SftpPanel
                     key={tab.connId}
                     connId={tab.connId}
+                    terminalPath={tab.terminalCwd}
+                    followTerminalFolder={tab.sftpFollowTerminal !== false}
+                    onFollowTerminalFolderChange={(sftpFollowTerminal) =>
+                      updateTab(tab.id, { sftpFollowTerminal })
+                    }
                     onOpenFile={(path) => openEditor(tab.id, path)}
                     onOpenInNewWindow={(path) =>
                       openAppWindow({

--- a/client/src/sftp-panel-state.ts
+++ b/client/src/sftp-panel-state.ts
@@ -1,0 +1,8 @@
+/** Choose the terminal directory only while the attached browser is following it. */
+export function initialSftpPath(
+  initialPath: string,
+  terminalPath: string | undefined,
+  followTerminalFolder: boolean,
+): string {
+  return followTerminalFolder && terminalPath ? terminalPath : initialPath;
+}

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -36,6 +36,10 @@ interface TabBase {
   sftpOpen: boolean;
   /** Server-advertised capability for the current SSH transport. */
   sftpAvailable?: boolean;
+  /** Most recent working directory reported by the live remote shell. */
+  terminalCwd?: string;
+  /** Explicit opt-out from following the terminal in the attached SFTP panel. */
+  sftpFollowTerminal?: boolean;
   /** Monotonic UI signal consumed by the mounted terminal search bar. */
   searchRequest: number;
   /** User-set color flag marking the tab. */
@@ -86,6 +90,8 @@ type TabUpdate = Partial<{
   transferId: string | undefined;
   sftpOpen: boolean;
   sftpAvailable: boolean | undefined;
+  terminalCwd: string | undefined;
+  sftpFollowTerminal: boolean | undefined;
   color: string | undefined;
   loggingEnabled: boolean | undefined;
   sessionLogId: string | undefined;
@@ -388,6 +394,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           connId: undefined,
           sftpOpen: false,
           sftpAvailable: undefined,
+          terminalCwd: undefined,
           searchRequest: 0,
           editorPaths: [],
           activeEditorPath: undefined,
@@ -763,6 +770,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           status: tab.connectOnMount ? 'connecting' as const : 'closed' as const,
           sftpOpen: false,
           sftpAvailable: undefined,
+          terminalCwd: undefined,
           searchRequest: 0,
           editorPaths: [],
           activeEditorPath: undefined,
@@ -885,6 +893,8 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
           connId: _connId,
           sftpOpen: _sftpOpen,
           sftpAvailable: _sftpAvailable,
+          terminalCwd: _terminalCwd,
+          sftpFollowTerminal: _sftpFollowTerminal,
           ...emptyPatch
         } = patch;
         return { ...tab, ...emptyPatch };

--- a/client/src/terminal/shell-integration.ts
+++ b/client/src/terminal/shell-integration.ts
@@ -19,6 +19,66 @@ export interface MarkerHost {
   }): unknown;
 }
 
+const MAX_TERMINAL_CWD_LENGTH = 4096;
+const CWD_PROPERTY_PREFIX = 'P;Cwd=';
+
+/** Decode the escaping used by OSC 133/633 property values. */
+function decodePropertyValue(value: string): string | undefined {
+  let decoded = '';
+  for (let index = 0; index < value.length; index++) {
+    const char = value[index]!;
+    if (char !== '\\') {
+      decoded += char;
+      continue;
+    }
+    const next = value[index + 1];
+    if (next === '\\') {
+      decoded += '\\';
+      index++;
+      continue;
+    }
+    const hex = value.slice(index + 2, index + 4);
+    if (next !== 'x' || !/^[0-9a-f]{2}$/i.test(hex)) return undefined;
+    decoded += String.fromCharCode(Number.parseInt(hex, 16));
+    index += 3;
+  }
+  return decoded;
+}
+
+function validRemoteCwd(value: string | undefined): value is string {
+  return !!value && value.startsWith('/') && value.length <= MAX_TERMINAL_CWD_LENGTH;
+}
+
+/** Reads current-directory reports from shell integration and standard OSC 7. */
+export class CwdTracker {
+  private current: string | undefined;
+
+  constructor(private readonly onChange: (cwd: string) => void) {}
+
+  handleProperty(data: string): boolean {
+    if (!data.startsWith(CWD_PROPERTY_PREFIX)) return false;
+    this.report(decodePropertyValue(data.slice(CWD_PROPERTY_PREFIX.length)));
+    return true;
+  }
+
+  handleFileUri(data: string): boolean {
+    try {
+      const uri = new URL(data);
+      if (uri.protocol !== 'file:') return false;
+      this.report(decodeURIComponent(uri.pathname));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private report(cwd: string | undefined): void {
+    if (!validRemoteCwd(cwd) || cwd === this.current) return;
+    this.current = cwd;
+    this.onChange(cwd);
+  }
+}
+
 /**
  * Turns shell-integration command reports into scrollbar marks. OSC 133
  * (FinalTerm) / OSC 633 (VS Code) sequences carry "command started"
@@ -90,6 +150,22 @@ export function attachCommandTracker(term: Terminal): IDisposable {
       osc133.dispose();
       osc633.dispose();
       tracker.dispose();
+    },
+  };
+}
+
+/** Track the working directory reported by integrated and OSC 7-aware shells. */
+export function attachCwdTracker(term: Terminal, onChange: (cwd: string) => void): IDisposable {
+  const tracker = new CwdTracker(onChange);
+  const osc7 = term.parser.registerOscHandler(7, (data) => tracker.handleFileUri(data));
+  const propertyHandler = (data: string) => tracker.handleProperty(data);
+  const osc133 = term.parser.registerOscHandler(133, propertyHandler);
+  const osc633 = term.parser.registerOscHandler(633, propertyHandler);
+  return {
+    dispose: () => {
+      osc7.dispose();
+      osc133.dispose();
+      osc633.dispose();
     },
   };
 }

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -29,7 +29,8 @@ Muxus is a community project, and contributions of any size are welcome.
     pnpm test
     ```
 
-4. If the client bundle changed, `pnpm check:bundle` enforces its budgets.
+4. If the client bundle changed, `pnpm check:bundle` enforces its safety caps. Pull-request
+   CI also reports the change from the base commit and rejects unexpectedly large growth.
 
 ## Project constraints
 

--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -48,7 +48,7 @@ hack/       Documentation sandbox and screenshot capture
 | `pnpm test`, `pnpm test:watch` | vitest |
 | `pnpm lint` | oxlint (`--deny-warnings`) |
 | `pnpm typecheck` | Types across the workspace |
-| `pnpm check:bundle` | Client bundle budgets |
+| `pnpm check:bundle` | Build the client and check bundle safety caps |
 
 ## Native modules and Electron
 
@@ -138,5 +138,6 @@ also a way to test a change without touching the real `~/.ssh`.
 
 ## CI
 
-Every push runs typecheck, lint, tests and the bundle budgets, then builds unpacked desktop
-packages on Linux, macOS and Windows.
+Every push runs typecheck, lint, tests and bundle safety checks, then builds unpacked desktop
+packages on Linux, macOS and Windows. Pull requests also compare their bundle with the base
+commit and fail only when a loading graph grows beyond its configured tolerance.

--- a/docs/guide/files.md
+++ b/docs/guide/files.md
@@ -20,6 +20,8 @@ operation, so no second connection or authentication is required.
 - :material-arrow-up: goes to the parent directory, :material-home: to the remote home
   directory, and :material-refresh: re-reads the current directory.
 - Double-click a directory to enter it. Sorting is by name, size or modification time.
+- **Follow terminal folder** is enabled by default. The browser opens at the shell's current
+  directory and follows later `cd` commands; clear it to browse independently.
 - **Open in new window** moves the browser into its own window on the same connection.
 
 ## Transferring

--- a/server/src/local/shell-integration.ts
+++ b/server/src/local/shell-integration.ts
@@ -20,6 +20,17 @@ ZDOTDIR="$__muxus_shim"
 builtin unset __muxus_shim
 `;
 
+/** Prompt hook shared by local and remote bash/zsh integrations. The value
+ * follows VS Code's OSC 133/633 property escaping for backslashes and the
+ * protocol's semicolon separator. */
+export const SHELL_CWD_REPORT = `  __muxus_report_cwd() {
+    local __muxus_cwd="$PWD"
+    __muxus_cwd="\${__muxus_cwd//\\\\/\\\\\\\\}"
+    __muxus_cwd="\${__muxus_cwd//;/\\\\x3b}"
+    builtin printf '\\e]133;P;Cwd=%s\\a' "$__muxus_cwd"
+  }
+`;
+
 export const ZSHRC = `# Muxus shell integration. Your .zshrc runs first, unmodified.
 if [[ -n "$MUXUS_USER_ZDOTDIR" ]]; then ZDOTDIR="$MUXUS_USER_ZDOTDIR"; else builtin unset ZDOTDIR; fi
 builtin unset MUXUS_USER_ZDOTDIR
@@ -28,9 +39,11 @@ if [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]]; then builtin source "\${ZDOTDIR:-$HOME}
 if [[ -o interactive && -z "$__muxus_integrated" ]]; then
   builtin typeset -g __muxus_integrated=1
   builtin autoload -Uz add-zsh-hook
+${SHELL_CWD_REPORT}
   __muxus_precmd() {
     local __muxus_status=$?
     builtin printf '\\e]133;D;%s\\a' "$__muxus_status"
+    __muxus_report_cwd
     builtin printf '\\e]133;A\\a'
   }
   __muxus_preexec() {
@@ -47,9 +60,11 @@ if [[ -f "$HOME/.bashrc" ]]; then . "$HOME/.bashrc"; fi
 
 if [[ $- == *i* && -z "$__muxus_integrated" ]]; then
   __muxus_integrated=1
+${SHELL_CWD_REPORT}
   __muxus_prompt_mark() {
     local __muxus_status=$?
     printf '\\e]133;D;%s\\a' "$__muxus_status"
+    __muxus_report_cwd
     printf '\\e]133;A\\a'
   }
   # PS0 expands once per executed command (never for an empty prompt), which

--- a/server/src/ssh/remote-shell-integration.ts
+++ b/server/src/ssh/remote-shell-integration.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import type { Client, ClientChannel, PseudoTtyOptions, SFTPWrapper, Stats } from 'ssh2';
-import { ZSHENV, ZSHRC } from '../local/shell-integration.js';
+import { SHELL_CWD_REPORT, ZSHENV, ZSHRC } from '../local/shell-integration.js';
 
 const SHELL_PROBE = `command printf '\\n__MUXUS_SHELL__=%s\\n__MUXUS_ZDOTDIR__=%s\\n__MUXUS_HOME__=%s\\n' "\${SHELL-}" "\${ZDOTDIR-}" "\${HOME-}"`;
 const PROBE_TIMEOUT_MS = 5_000;
@@ -28,9 +28,11 @@ fi
 
 if [[ $- == *i* && -z "$__muxus_integrated" ]]; then
   __muxus_integrated=1
+${SHELL_CWD_REPORT}
   __muxus_prompt_mark() {
     local __muxus_status=$?
     printf '\\e]133;D;%s\\a' "$__muxus_status"
+    __muxus_report_cwd
     printf '\\e]133;A\\a'
   }
   PS0="\\[\\e]133;C\\a\\]\${PS0-}"

--- a/tests/unit/client/bundle-budget.test.ts
+++ b/tests/unit/client/bundle-budget.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUNDLE_POLICIES,
+  evaluateBundleReport,
+  type BundleMetricKey,
+  type BundlePolicy,
+  type BundleReport,
+} from '../../../client/scripts/check-bundle-budget.mjs';
+
+function policy(key: BundleMetricKey): BundlePolicy {
+  const result = BUNDLE_POLICIES.find((candidate) => candidate.key === key);
+  if (!result) throw new Error(`Missing ${key} bundle policy`);
+  return result;
+}
+
+function report(size = 100_000): BundleReport {
+  return {
+    version: 1,
+    metrics: Object.fromEntries(
+      BUNDLE_POLICIES.map(({ key }) => [key, { raw: size, gzip: size }]),
+    ) as BundleReport['metrics'],
+    oversizedChunks: [],
+  };
+}
+
+describe('bundle budget policy', () => {
+  it('accepts small growth relative to the base bundle', () => {
+    const baseline = report();
+    const current = report();
+    const initial = policy('initial');
+    current.metrics.initial.raw += initial.growth.raw;
+    current.metrics.initial.gzip += initial.growth.gzip;
+
+    expect(evaluateBundleReport(current, baseline)).toEqual([]);
+  });
+
+  it('reports the exact bytes above the allowed PR growth', () => {
+    const baseline = report();
+    const current = report();
+    current.metrics.initial.raw += policy('initial').growth.raw + 40;
+
+    expect(evaluateBundleReport(current, baseline)).toEqual([
+      'Initial JavaScript exceeds allowed PR growth by 40 B raw',
+    ]);
+  });
+
+  it('enforces emergency caps without a base report', () => {
+    const current = report();
+    current.metrics.terminal.gzip = policy('terminal').safetyCap.gzip + 1;
+
+    expect(evaluateBundleReport(current)).toEqual([
+      'Terminal feature JavaScript exceeds its safety cap by 1 B gzip',
+    ]);
+  });
+
+  it('keeps blocking unapproved large chunks', () => {
+    const current = report();
+    current.oversizedChunks.push({ file: 'accidental.js', raw: 700_001 });
+
+    expect(evaluateBundleReport(current)).toEqual([
+      'accidental.js exceeds the unapproved chunk limit by 1 B (683.6 KiB total)',
+    ]);
+  });
+});

--- a/tests/unit/client/sftp-panel-state.test.ts
+++ b/tests/unit/client/sftp-panel-state.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { initialSftpPath } from '../../../client/src/sftp-panel-state.js';
+
+describe('SFTP panel state', () => {
+  it('starts at the terminal directory only while following is enabled', () => {
+    expect(initialSftpPath('.', '/srv/project', true)).toBe('/srv/project');
+    expect(initialSftpPath('.', '/srv/project', false)).toBe('.');
+  });
+
+  it('falls back to the requested initial path before a terminal directory is reported', () => {
+    expect(initialSftpPath('/uploads', undefined, true)).toBe('/uploads');
+  });
+});

--- a/tests/unit/client/shell-integration.test.ts
+++ b/tests/unit/client/shell-integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CommandTracker,
+  CwdTracker,
   ERROR_MARK_COLOR,
   type CommandMarker,
   type MarkerHost,
@@ -87,5 +88,32 @@ describe('CommandTracker', () => {
     expect(tracker.handle('D;0')).toBe(true);
     expect(tracker.handle('P;Cwd=/tmp')).toBe(false);
     expect(tracker.handle('E;ls')).toBe(false);
+  });
+});
+
+describe('CwdTracker', () => {
+  it('reports escaped OSC 133/633 current-directory properties once per path', () => {
+    const paths: string[] = [];
+    const tracker = new CwdTracker((path) => paths.push(path));
+
+    expect(tracker.handleProperty(String.raw`P;Cwd=/srv/with\x3bsemi\\backslash`)).toBe(true);
+    expect(tracker.handleProperty(String.raw`P;Cwd=/srv/with\x3bsemi\\backslash`)).toBe(true);
+    expect(paths).toEqual(['/srv/with;semi\\backslash']);
+  });
+
+  it('accepts standard file URIs and ignores invalid or relative paths', () => {
+    const paths: string[] = [];
+    const tracker = new CwdTracker((path) => paths.push(path));
+
+    expect(tracker.handleFileUri('file://remote.example/srv/my%20app')).toBe(true);
+    expect(tracker.handleProperty('P;Cwd=relative/path')).toBe(true);
+    expect(tracker.handleFileUri('https://example.test/srv/app')).toBe(false);
+    expect(paths).toEqual(['/srv/my app']);
+  });
+
+  it('leaves unrelated shell-integration properties for other handlers', () => {
+    const tracker = new CwdTracker(() => undefined);
+    expect(tracker.handleProperty('C')).toBe(false);
+    expect(tracker.handleProperty('P;IsWindows=True')).toBe(false);
   });
 });

--- a/tests/unit/server/shell-integration.test.ts
+++ b/tests/unit/server/shell-integration.test.ts
@@ -16,6 +16,8 @@ describe('writeIntegrationFiles', () => {
     const zshrc = readFileSync(path.join(root, 'zsh/.zshrc'), 'utf8');
     expect(zshrc).toContain(String.raw`\e]133;D;%s\a`);
     expect(zshrc).toContain(String.raw`\e]133;C\a`);
+    expect(zshrc).toContain(String.raw`\e]133;P;Cwd=%s\a`);
+    expect(zshrc).toContain('__muxus_report_cwd');
     expect(zshrc).toContain('add-zsh-hook precmd');
     expect(zshrc).toContain('add-zsh-hook preexec');
   });
@@ -32,6 +34,7 @@ describe('writeIntegrationFiles', () => {
     expect(bash).toContain('"$HOME/.bashrc"');
     expect(bash).toContain('PS0="\\[\\e]133;C\\a\\]${PS0-}"');
     expect(bash).toContain('PROMPT_COMMAND="__muxus_prompt_mark${PROMPT_COMMAND:+;$PROMPT_COMMAND}"');
+    expect(bash).toContain(String.raw`\e]133;P;Cwd=%s\a`);
   });
 });
 


### PR DESCRIPTION
Closes #87.

## Summary

- report the current working directory from integrated bash and zsh shells
- recognize OSC 133/633 CWD properties and standard OSC 7 file URIs in the terminal
- open the attached SFTP browser at the terminal directory and follow later directory changes by default
- add a per-tab **Follow terminal folder** control so the browser can be navigated independently
- preserve correct remote-home navigation and keep detached SFTP windows independent
- document the behavior and cover the protocol parsing and generated shell hooks with tests

## Why

The SFTP panel previously resolved `.` when it mounted, so it always started at the remote home directory and had no knowledge of the shell's current directory. This made workflows that alternate between terminal commands and file operations require repeated manual navigation.

## Impact

SSH sessions with supported shell integration now keep the attached file browser aligned with the terminal. Sessions that do not report a working directory retain the existing home-directory fallback.

## Validation

- `pnpm --dir tests exec vitest run --reporter=dot --silent` — 810 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @muxus/client build`
- generated bash and zsh integration scripts syntax-checked