### PR TITLE
Open terminal files in Monaco

### DIFF
--- a/client/src/components/QuickLauncherDialog.tsx
+++ b/client/src/components/QuickLauncherDialog.tsx
@@ -780,7 +780,7 @@ function buildCatalogResults({
         path,
         label: basename(path),
         detail: `${tab.title} · ${path}`,
-        keywords: ['editor', 'remote file', path],
+        keywords: ['editor', tab.profile.kind === 'local' ? 'local file' : 'remote file', path],
         priority: tab.id === activeId ? 420 : 300,
         showWhenEmpty: path === tab.activeEditorPath,
       });

--- a/client/src/components/RemoteEditorWorkspace.tsx
+++ b/client/src/components/RemoteEditorWorkspace.tsx
@@ -15,8 +15,8 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import SaveAsOutlinedIcon from '@mui/icons-material/SaveAsOutlined';
 import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
 import type {
-  SftpFileResponse,
-  SftpFileSaveResponse,
+  EditorFileResponse,
+  EditorFileSaveResponse,
 } from '@muxus/shared';
 import { ApiError, apiFetch, apiFetchRaw } from '../api/http.js';
 import {
@@ -54,9 +54,17 @@ function downloadBlob(name: string, blob: Blob): void {
   setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
-/** VS Code-like, multi-file Monaco workspace attached to one live SSH session. */
+type EditorSourceKind = 'local' | 'sftp';
+
+function editorFileUrl(sourceKind: EditorSourceKind, connId: string | undefined, path: string): string {
+  const root = sourceKind === 'local' ? '/api/local-files' : `/api/sftp/${connId}`;
+  return `${root}/file?path=${encodeURIComponent(path)}`;
+}
+
+/** VS Code-like, multi-file Monaco workspace attached to one terminal session. */
 export function RemoteEditorWorkspace({
   tabId,
+  sourceKind,
   connId,
   paths,
   activePath,
@@ -64,6 +72,7 @@ export function RemoteEditorWorkspace({
   onClose,
 }: {
   tabId: string;
+  sourceKind: EditorSourceKind;
   connId?: string;
   paths: string[];
   activePath?: string;
@@ -71,12 +80,14 @@ export function RemoteEditorWorkspace({
   onClose: (path: string) => void;
 }) {
   const theme = useTheme();
+  const available = sourceKind === 'local' || !!connId;
+  const local = sourceKind === 'local';
   const [documents, setDocuments] = useState<Record<string, EditorDocument>>({});
   const [languageOverrides, setLanguageOverrides] = useState<Record<string, string>>({});
 
   const load = useCallback(
     async (path: string) => {
-      if (!connId) {
+      if (!available) {
         setDocuments((current) => ({
           ...current,
           [path]: {
@@ -102,8 +113,8 @@ export function RemoteEditorWorkspace({
         },
       }));
       try {
-        const file = await apiFetch<SftpFileResponse>(
-          `/api/sftp/${connId}/file?path=${encodeURIComponent(path)}`,
+        const file = await apiFetch<EditorFileResponse>(
+          editorFileUrl(sourceKind, connId, path),
         );
         setDocuments((current) => ({
           ...current,
@@ -131,7 +142,7 @@ export function RemoteEditorWorkspace({
         }));
       }
     },
-    [connId],
+    [available, connId, sourceKind],
   );
 
   // Typing rewrites `documents`; only whether the active file has been opened
@@ -150,15 +161,15 @@ export function RemoteEditorWorkspace({
 
   const save = async (path: string, force = false, notify = true): Promise<boolean> => {
     const document = documents[path];
-    if (!connId || !document || document.loading || document.saving) return false;
+    if (!available || !document || document.loading || document.saving) return false;
     const contentToSave = document.content;
     setDocuments((current) => ({
       ...current,
       [path]: { ...current[path]!, saving: true, conflict: false },
     }));
     try {
-      const result = await apiFetch<SftpFileSaveResponse>(
-        `/api/sftp/${connId}/file?path=${encodeURIComponent(path)}`,
+      const result = await apiFetch<EditorFileSaveResponse>(
+        editorFileUrl(sourceKind, connId, path),
         {
           method: 'PUT',
           headers: { 'content-type': 'application/json' },
@@ -186,7 +197,7 @@ export function RemoteEditorWorkspace({
       if (
         error instanceof ApiError &&
         error.status === 409 &&
-        error.body?.code === 'SFTP_FILE_CHANGED'
+        (error.body?.code === 'SFTP_FILE_CHANGED' || error.body?.code === 'LOCAL_FILE_CHANGED')
       ) {
         setDocuments((current) => ({
           ...current,
@@ -365,11 +376,11 @@ export function RemoteEditorWorkspace({
           <Typography variant="caption" color="text.disabled" sx={{ mr: 0.5 }}>
             {language === GENERAL_TEXT_LANGUAGE_ID ? 'General text' : language}
           </Typography>
-          <Tooltip title="Reload from remote">
+          <Tooltip title={local ? 'Reload from disk' : 'Reload from remote'}>
             <span>
               <IconButton
                 size="small"
-                aria-label="Reload from remote"
+                aria-label={local ? 'Reload from disk' : 'Reload from remote'}
                 disabled={document?.loading}
                 onClick={() => {
                   if (!dirtyPaths.has(activePath)) {
@@ -377,8 +388,8 @@ export function RemoteEditorWorkspace({
                     return;
                   }
                   void confirmAction({
-                    title: 'Reload from remote?',
-                    description: 'Your local changes to this file are discarded.',
+                    title: local ? 'Reload from disk?' : 'Reload from remote?',
+                    description: 'Your unsaved changes to this file are discarded.',
                     confirmLabel: 'Discard and reload',
                     destructive: true,
                   }).then((confirmed) => {
@@ -390,33 +401,35 @@ export function RemoteEditorWorkspace({
               </IconButton>
             </span>
           </Tooltip>
-          <Tooltip title="Download">
-            <span>
-              <IconButton
-                size="small"
-                aria-label="Download this file"
-                disabled={!connId}
-                onClick={() => {
-                  if (!connId) return;
-                  void apiFetchRaw(
-                    `/api/sftp/${connId}/download?path=${encodeURIComponent(activePath)}`,
-                  )
-                    .then((response) => response.blob())
-                    .then((blob) => downloadBlob(baseName(activePath), blob))
-                    .catch(showErrorToast);
-                }}
-              >
-                <DownloadOutlinedIcon fontSize="small" />
-              </IconButton>
-            </span>
-          </Tooltip>
+          {!local ? (
+            <Tooltip title="Download">
+              <span>
+                <IconButton
+                  size="small"
+                  aria-label="Download this file"
+                  disabled={!connId}
+                  onClick={() => {
+                    if (!connId) return;
+                    void apiFetchRaw(
+                      `/api/sftp/${connId}/download?path=${encodeURIComponent(activePath)}`,
+                    )
+                      .then((response) => response.blob())
+                      .then((blob) => downloadBlob(baseName(activePath), blob))
+                      .catch(showErrorToast);
+                  }}
+                >
+                  <DownloadOutlinedIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          ) : null}
           <Tooltip title="Save (Ctrl/Cmd+S)">
             <span>
               <IconButton
                 size="small"
                 aria-label="Save this file"
                 color={dirtyPaths.has(activePath) ? 'primary' : 'default'}
-                disabled={!document || document.loading || document.saving || !connId}
+                disabled={!document || document.loading || document.saving || !available}
                 onClick={() => void save(activePath)}
               >
                 {document?.saving ? <CircularProgress size={16} /> : <SaveOutlinedIcon fontSize="small" />}
@@ -429,7 +442,7 @@ export function RemoteEditorWorkspace({
                 size="small"
                 aria-label="Save all files"
                 color={dirtyPaths.size > 0 ? 'primary' : 'default'}
-                disabled={dirtyPaths.size === 0 || savingCount > 0 || !connId}
+                disabled={dirtyPaths.size === 0 || savingCount > 0 || !available}
                 onClick={() => void saveAll()}
               >
                 {savingCount > 0 ? <CircularProgress size={16} /> : <SaveAsOutlinedIcon fontSize="small" />}
@@ -451,8 +464,8 @@ export function RemoteEditorWorkspace({
                 color="inherit"
                 onClick={() => {
                   void confirmAction({
-                    title: 'Load the remote version?',
-                    description: 'Your local changes to this file are discarded.',
+                    title: local ? 'Load the version on disk?' : 'Load the remote version?',
+                    description: 'Your unsaved changes to this file are discarded.',
                     confirmLabel: 'Discard and reload',
                     destructive: true,
                   }).then((confirmed) => {
@@ -460,15 +473,17 @@ export function RemoteEditorWorkspace({
                   });
                 }}
               >
-                Reload remote
+                {local ? 'Reload disk' : 'Reload remote'}
               </Button>
               <Button color="warning" variant="contained" onClick={() => void save(activePath, true)}>
-                Overwrite remote
+                {local ? 'Overwrite disk' : 'Overwrite remote'}
               </Button>
             </Stack>
           }
         >
-          The remote file changed after you opened it.
+          {local
+            ? 'The file changed on disk after you opened it.'
+            : 'The remote file changed after you opened it.'}
         </Alert>
       )}
       {document?.loading && <LinearProgress />}
@@ -478,7 +493,7 @@ export function RemoteEditorWorkspace({
             <Typography variant="body2" color="error">
               {document.error}
             </Typography>
-            <Button startIcon={<RefreshIcon />} disabled={!connId} onClick={() => activePath && void load(activePath)}>
+            <Button startIcon={<RefreshIcon />} disabled={!available} onClick={() => activePath && void load(activePath)}>
               Try again
             </Button>
           </Stack>
@@ -491,7 +506,7 @@ export function RemoteEditorWorkspace({
               language={language}
               value={document.content}
               dark={theme.palette.mode === 'dark'}
-              readOnly={!connId}
+              readOnly={!available}
               onChange={(content) =>
                 setDocuments((current) => ({
                   ...current,

--- a/client/src/components/ShortcutsDialog.tsx
+++ b/client/src/components/ShortcutsDialog.tsx
@@ -51,7 +51,7 @@ const CATEGORY_ORDER: CommandCategory[] = ['panes', 'tabs', 'terminal', 'app'];
 /** Interactions worth documenting that no keymap entry can express. */
 const EXTRAS: Array<[string, string]> = [
   ['Zoom the terminal with the mouse', `${IS_MAC ? '⌃ ' : 'Ctrl+'}Scroll wheel`],
-  ['Open a remote terminal path in the editor', 'Click the underlined path'],
+  ['Open a terminal path in the editor', 'Click the underlined path'],
   ['Resize a split / reset it to half', 'Drag the divider · double-click'],
   ['Pane actions (split, zoom, close)', 'Right-click the tab strip'],
   ['Rename a tab / close a tab', 'Double-click it · middle-click it'],
@@ -271,7 +271,7 @@ export function ShortcutsDialog() {
         ) : null}
 
         <StaticSection title="Mouse and other gestures" rows={EXTRAS} />
-        <StaticSection title="Remote editor" rows={EDITOR_SHORTCUTS} />
+        <StaticSection title="File editor" rows={EDITOR_SHORTCUTS} />
       </DialogContent>
       <DialogActions>
         <Button

--- a/client/src/components/ShortcutsDialog.tsx
+++ b/client/src/components/ShortcutsDialog.tsx
@@ -51,6 +51,7 @@ const CATEGORY_ORDER: CommandCategory[] = ['panes', 'tabs', 'terminal', 'app'];
 /** Interactions worth documenting that no keymap entry can express. */
 const EXTRAS: Array<[string, string]> = [
   ['Zoom the terminal with the mouse', `${IS_MAC ? '⌃ ' : 'Ctrl+'}Scroll wheel`],
+  ['Open a remote terminal path in the editor', 'Click the underlined path'],
   ['Resize a split / reset it to half', 'Drag the divider · double-click'],
   ['Pane actions (split, zoom, close)', 'Right-click the tab strip'],
   ['Rename a tab / close a tab', 'Double-click it · middle-click it'],

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -32,9 +32,10 @@ import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import type { TerminalServerMessage } from '@muxus/shared';
-import { wsProtocols, wsUrl } from '../api/http.js';
+import { apiFetch, wsProtocols, wsUrl } from '../api/http.js';
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import { copyToClipboard, readFromClipboard } from '../clipboard.js';
+import { loadMonacoTextEditor, loadRemoteEditorWorkspace } from '../lazy-features.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
 import { showToast } from '../state/toast.js';
 import { broadcastTerminalInput } from '../state/multi-exec.js';
@@ -58,6 +59,11 @@ import {
   type KeywordHighlighter,
 } from '../terminal/keyword-highlighting.js';
 import { registerTerminal } from '../terminal/terminal-registry.js';
+import {
+  attachTerminalFileLinks,
+  resolveRemoteFilePath,
+} from '../terminal/file-links.js';
+import { openTerminalWebLink } from '../terminal/web-links.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
 import {
@@ -117,6 +123,50 @@ function bufferText(term: Terminal): string {
   }
   while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
   return lines.length ? `${lines.join('\n')}\n` : '';
+}
+
+async function openLinkedRemoteFile(tabId: string, candidate: string): Promise<void> {
+  let current = useTabsStore.getState().tabs.find((tab) => tab.id === tabId);
+  if (!current?.profile || current.profile.kind !== 'ssh') return;
+  if (current.sftpAvailable === false) {
+    showToast('warning', 'SFTP is disabled for this host, so remote files cannot be edited.');
+    return;
+  }
+  const connId = current.connId;
+  if (!connId) {
+    showToast('warning', 'Reconnect the SSH session before opening a remote file.');
+    return;
+  }
+
+  let path = resolveRemoteFilePath(candidate, current.terminalCwd);
+  if (!path && candidate.startsWith('~/')) {
+    try {
+      const home = await apiFetch<{ path: string }>(`/api/sftp/${connId}/home`);
+      current = useTabsStore.getState().tabs.find((tab) => tab.id === tabId);
+      if (current?.connId !== connId) return;
+      path = resolveRemoteFilePath(candidate, current.terminalCwd, home.path);
+    } catch (error) {
+      showToast(
+        'warning',
+        `Could not resolve the remote home directory: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return;
+    }
+  }
+  if (!path) {
+    showToast(
+      'warning',
+      'The remote working directory is unavailable. Click an absolute path instead.',
+    );
+    return;
+  }
+
+  // Start both lazy chunks together; the editor still stays out of the
+  // terminal bundle and is loaded only after an explicit file-open gesture.
+  void Promise.all([loadRemoteEditorWorkspace(), loadMonacoTextEditor()]).catch(() => undefined);
+  useTabsStore.getState().openEditor(tabId, path);
 }
 
 export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; active: boolean }) {
@@ -346,7 +396,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     term.loadAddon(fit);
     term.loadAddon(new Unicode11Addon());
     term.unicode.activeVersion = '11';
-    term.loadAddon(new WebLinksAddon());
+    term.loadAddon(new WebLinksAddon(openTerminalWebLink));
     // xterm 6.1 streams Kitty APC payloads straight into ImageAddon's WASM
     // base64 decoder. This also handles Sixel and iTerm2 inline images.
     const image = new ImageAddon({
@@ -540,6 +590,10 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               .tabs.find((candidate) => candidate.id === tab.id);
             if (current?.terminalCwd !== terminalCwd) updateTab(tab.id, { terminalCwd });
           })
+        : undefined;
+    const fileLinks =
+      tab.profile.kind === 'ssh'
+        ? attachTerminalFileLinks(term, (candidate) => openLinkedRemoteFile(tab.id, candidate))
         : undefined;
 
     // Application chords never reach xterm: the shortcut layer consumes them
@@ -1012,6 +1066,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       onSearchResults.dispose();
       commandTracker.dispose();
       cwdTracker?.dispose();
+      fileLinks?.dispose();
       keywordHighlighterRef.current?.dispose();
       if (interruptionTimer !== undefined) clearTimeout(interruptionTimer);
       if (autoReconnectTimer !== undefined) clearTimeout(autoReconnectTimer);

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -31,7 +31,7 @@ import { SerializeAddon } from '@xterm/addon-serialize';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
-import type { TerminalServerMessage } from '@muxus/shared';
+import type { AppInfo, TerminalServerMessage } from '@muxus/shared';
 import { apiFetch, wsProtocols, wsUrl } from '../api/http.js';
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import { copyToClipboard, readFromClipboard } from '../clipboard.js';
@@ -61,7 +61,7 @@ import {
 import { registerTerminal } from '../terminal/terminal-registry.js';
 import {
   attachTerminalFileLinks,
-  resolveRemoteFilePath,
+  resolveTerminalFilePath,
 } from '../terminal/file-links.js';
 import { openTerminalWebLink } from '../terminal/web-links.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
@@ -125,41 +125,72 @@ function bufferText(term: Terminal): string {
   return lines.length ? `${lines.join('\n')}\n` : '';
 }
 
-async function openLinkedRemoteFile(tabId: string, candidate: string): Promise<void> {
+async function openLinkedTerminalFile(tabId: string, candidate: string): Promise<void> {
   let current = useTabsStore.getState().tabs.find((tab) => tab.id === tabId);
-  if (!current?.profile || current.profile.kind !== 'ssh') return;
-  if (current.sftpAvailable === false) {
-    showToast('warning', 'SFTP is disabled for this host, so remote files cannot be edited.');
-    return;
-  }
-  const connId = current.connId;
-  if (!connId) {
-    showToast('warning', 'Reconnect the SSH session before opening a remote file.');
-    return;
-  }
+  if (!current?.profile) return;
 
-  let path = resolveRemoteFilePath(candidate, current.terminalCwd);
-  if (!path && candidate.startsWith('~/')) {
-    try {
-      const home = await apiFetch<{ path: string }>(`/api/sftp/${connId}/home`);
-      current = useTabsStore.getState().tabs.find((tab) => tab.id === tabId);
-      if (current?.connId !== connId) return;
-      path = resolveRemoteFilePath(candidate, current.terminalCwd, home.path);
-    } catch (error) {
+  let path: string | undefined;
+  if (current.profile.kind === 'local') {
+    path = resolveTerminalFilePath(candidate, current.terminalCwd);
+    if (!path && candidate.startsWith('~/')) {
+      try {
+        const info = await apiFetch<AppInfo>('/api/app/info');
+        current = useTabsStore.getState().tabs.find((tab) => tab.id === tabId);
+        if (current?.profile?.kind !== 'local') return;
+        path = resolveTerminalFilePath(candidate, current.terminalCwd, info.homeDir);
+      } catch (error) {
+        showToast(
+          'warning',
+          `Could not resolve the local home directory: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return;
+      }
+    }
+    if (!path) {
       showToast(
         'warning',
-        `Could not resolve the remote home directory: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        'The local working directory is unavailable. Click an absolute path instead.',
       );
       return;
     }
-  }
-  if (!path) {
-    showToast(
-      'warning',
-      'The remote working directory is unavailable. Click an absolute path instead.',
-    );
+  } else if (current.profile.kind === 'ssh') {
+    if (current.sftpAvailable === false) {
+      showToast('warning', 'SFTP is disabled for this host, so remote files cannot be edited.');
+      return;
+    }
+    const connId = current.connId;
+    if (!connId) {
+      showToast('warning', 'Reconnect the SSH session before opening a remote file.');
+      return;
+    }
+
+    path = resolveTerminalFilePath(candidate, current.terminalCwd);
+    if (!path && candidate.startsWith('~/')) {
+      try {
+        const home = await apiFetch<{ path: string }>(`/api/sftp/${connId}/home`);
+        current = useTabsStore.getState().tabs.find((tab) => tab.id === tabId);
+        if (current?.connId !== connId) return;
+        path = resolveTerminalFilePath(candidate, current.terminalCwd, home.path);
+      } catch (error) {
+        showToast(
+          'warning',
+          `Could not resolve the remote home directory: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return;
+      }
+    }
+    if (!path) {
+      showToast(
+        'warning',
+        'The remote working directory is unavailable. Click an absolute path instead.',
+      );
+      return;
+    }
+  } else {
     return;
   }
 
@@ -583,7 +614,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
 
     const commandTracker = attachCommandTracker(term);
     const cwdTracker =
-      tab.profile.kind === 'ssh'
+      tab.profile.kind === 'ssh' || tab.profile.kind === 'local'
         ? attachCwdTracker(term, (terminalCwd) => {
             const current = useTabsStore
               .getState()
@@ -592,8 +623,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
           })
         : undefined;
     const fileLinks =
-      tab.profile.kind === 'ssh'
-        ? attachTerminalFileLinks(term, (candidate) => openLinkedRemoteFile(tab.id, candidate))
+      tab.profile.kind === 'ssh' || tab.profile.kind === 'local'
+        ? attachTerminalFileLinks(term, (candidate) => openLinkedTerminalFile(tab.id, candidate))
         : undefined;
 
     // Application chords never reach xterm: the shortcut layer consumes them

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -131,13 +131,13 @@ async function openLinkedTerminalFile(tabId: string, candidate: string): Promise
 
   let path: string | undefined;
   if (current.profile.kind === 'local') {
-    path = resolveTerminalFilePath(candidate, current.terminalCwd);
+    path = resolveTerminalFilePath(candidate, current.terminalCwd, undefined, 'local');
     if (!path && candidate.startsWith('~/')) {
       try {
         const info = await apiFetch<AppInfo>('/api/app/info');
         current = useTabsStore.getState().tabs.find((tab) => tab.id === tabId);
         if (current?.profile?.kind !== 'local') return;
-        path = resolveTerminalFilePath(candidate, current.terminalCwd, info.homeDir);
+        path = resolveTerminalFilePath(candidate, current.terminalCwd, info.homeDir, 'local');
       } catch (error) {
         showToast(
           'warning',

--- a/client/src/editor/language-detection.ts
+++ b/client/src/editor/language-detection.ts
@@ -260,7 +260,7 @@ function languageFromFirstLine(content: string): string | undefined {
   return undefined;
 }
 
-/** Resolve a remote file to one of Monaco's built-in language ids. */
+/** Resolve a file to one of Monaco's built-in language ids. */
 export function languageForPath(path: string, content = ''): string {
   const lowerPath = path.toLowerCase().replaceAll('\\', '/');
   if (

--- a/client/src/editor/remote-editor-registry.ts
+++ b/client/src/editor/remote-editor-registry.ts
@@ -19,9 +19,9 @@ export async function confirmDiscardRemoteEditors(tabIds: string[]): Promise<boo
   const dirty = tabIds.some((tabId) => handles.get(tabId)?.hasDirty());
   if (!dirty) return true;
   return confirmAction({
-    title: 'Discard unsaved remote files?',
+    title: 'Discard unsaved files?',
     description:
-      'One or more remote files have unsaved changes. Closing them now loses those edits.',
+      'One or more files have unsaved changes. Closing them now loses those edits.',
     confirmLabel: 'Discard changes',
     destructive: true,
   });

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -238,6 +238,7 @@ function PaneCanvas({
                       <Suspense fallback={null}>
                         <RemoteEditorWorkspace
                           tabId={tab.id}
+                          sourceKind={tab.profile.kind === 'local' ? 'local' : 'sftp'}
                           connId={tab.connId}
                           paths={tab.editorPaths}
                           activePath={tab.activeEditorPath}

--- a/client/src/layout/SftpWindow.tsx
+++ b/client/src/layout/SftpWindow.tsx
@@ -94,6 +94,7 @@ export function SftpWindow({ launch }: { launch: SftpLaunch }) {
             <Box sx={{ flex: 1, minWidth: 0 }}>
               <RemoteEditorWorkspace
                 tabId={editorId.current}
+                sourceKind="sftp"
                 connId={launch.connId}
                 paths={editorPaths}
                 activePath={activePath}

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -314,7 +314,7 @@ async function confirmEndingLiveSessions(
 }
 
 /**
- * Close tabs, asking first when any of them still has unsaved remote files or
+ * Close tabs, asking first when any of them still has unsaved files or
  * a live session (the latter is pref-gated).
  */
 export async function requestCloseTabs(tabIds: string[]): Promise<void> {

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -36,7 +36,7 @@ interface TabBase {
   sftpOpen: boolean;
   /** Server-advertised capability for the current SSH transport. */
   sftpAvailable?: boolean;
-  /** Most recent working directory reported by the live remote shell. */
+  /** Most recent working directory reported by a live local or remote shell. */
   terminalCwd?: string;
   /** Explicit opt-out from following the terminal in the attached SFTP panel. */
   sftpFollowTerminal?: boolean;
@@ -46,7 +46,7 @@ interface TabBase {
   color?: string;
   /** Pinned tabs stay grouped at the start of their pane. */
   pinned?: boolean;
-  /** Remote files open in the Monaco workspace attached to this session. */
+  /** Files open in the Monaco workspace attached to this session. */
   editorPaths: string[];
   activeEditorPath?: string;
   /** Durable server-side history state for this live tab. */

--- a/client/src/terminal/file-links.ts
+++ b/client/src/terminal/file-links.ts
@@ -42,7 +42,23 @@ function escapedAt(value: string, index: number): boolean {
 }
 
 function decodeShellEscapes(value: string): string {
+  // Backslashes are separators rather than shell escapes in native Windows
+  // absolute paths. Preserve them so the local-file resolver receives the
+  // path that was displayed in the terminal.
+  if (windowsAbsolutePathRoot(value)) return value;
   return value.replace(/\\(.)/gs, '$1');
+}
+
+function windowsAbsolutePathRoot(
+  value: string,
+): { root: string; remainder: string } | undefined {
+  const normalized = value.replaceAll('/', '\\');
+  const drive = normalized.match(/^([a-z]:)\\(.*)$/i);
+  if (drive) return { root: `${drive[1]}\\`, remainder: drive[2] ?? '' };
+
+  const unc = normalized.match(/^\\\\([^\\]+)\\([^\\]+)(?:\\(.*))?$/);
+  if (!unc?.[1] || !unc[2]) return undefined;
+  return { root: `\\\\${unc[1]}\\${unc[2]}`, remainder: unc[3] ?? '' };
 }
 
 function containsUnsafePathCharacter(value: string): boolean {
@@ -99,7 +115,13 @@ function looksLikePath(value: string): boolean {
   ) {
     return false;
   }
-  if (/^(?:\/|\.\.?\/|~\/)/.test(value) || value.includes('/')) return true;
+  if (
+    windowsAbsolutePathRoot(value) ||
+    /^(?:\/|\.\.?\/|~\/)/.test(value) ||
+    value.includes('/')
+  ) {
+    return true;
+  }
   const lower = value.toLocaleLowerCase();
   if (CONVENTIONAL_FILENAMES.has(lower)) return true;
   if (value.startsWith('.') && value.length > 1) return true;
@@ -225,11 +247,25 @@ function normalizeAbsolutePath(value: string): string {
   return `/${segments.join('/')}`;
 }
 
-/** Resolve a path exactly as a POSIX shell would before handing it to SFTP. */
+function normalizeWindowsAbsolutePath(value: string): string | undefined {
+  const parsed = windowsAbsolutePathRoot(value);
+  if (!parsed) return undefined;
+  const segments: string[] = [];
+  for (const segment of parsed.remainder.split('\\')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') segments.pop();
+    else segments.push(segment);
+  }
+  if (segments.length === 0) return parsed.root;
+  return `${parsed.root}${parsed.root.endsWith('\\') ? '' : '\\'}${segments.join('\\')}`;
+}
+
+/** Resolve a terminal path before handing it to the local editor or SFTP. */
 export function resolveTerminalFilePath(
   candidate: string,
   cwd?: string,
   home?: string,
+  source: 'posix' | 'local' = 'posix',
 ): string | undefined {
   if (
     !candidate ||
@@ -240,11 +276,20 @@ export function resolveTerminalFilePath(
     return undefined;
   }
   if (candidate === '~' || candidate.startsWith('~/')) {
+    if (source === 'local' && home && windowsAbsolutePathRoot(home)) {
+      return normalizeWindowsAbsolutePath(`${home}\\${candidate.slice(2)}`);
+    }
     if (!home?.startsWith('/')) return undefined;
     return normalizeAbsolutePath(`${home}/${candidate.slice(2)}`);
   }
   if (candidate.startsWith('~')) return undefined;
+  if (windowsAbsolutePathRoot(candidate)) {
+    return source === 'local' ? normalizeWindowsAbsolutePath(candidate) : undefined;
+  }
   if (candidate.startsWith('/')) return normalizeAbsolutePath(candidate);
+  if (source === 'local' && cwd && windowsAbsolutePathRoot(cwd)) {
+    return normalizeWindowsAbsolutePath(`${cwd}\\${candidate}`);
+  }
   if (!cwd?.startsWith('/')) return undefined;
   return normalizeAbsolutePath(`${cwd}/${candidate}`);
 }
@@ -327,13 +372,16 @@ function mappedFileLinks(term: Terminal, bufferLineNumber: number): MappedTermin
   const links: MappedTerminalFileLink[] = [];
   for (const candidate of terminalFileLinkCandidates(logicalLine.text)) {
     const start = bufferPosition(term, logicalLine.startLine, candidate.start);
-    const end = bufferPosition(term, logicalLine.startLine, candidate.end);
+    // xterm link ranges are inclusive and 1-based. Mapping the candidate's
+    // exclusive end offset can roll over to column zero on the next row when
+    // the path ends in the last cell, so map its final character instead.
+    const end = bufferPosition(term, logicalLine.startLine, candidate.end - 1);
     if (!start || !end) continue;
     links.push({
       candidate,
       range: {
         start: { x: start[1] + 1, y: start[0] + 1 },
-        end: { x: end[1], y: end[0] + 1 },
+        end: { x: end[1] + 1, y: end[0] + 1 },
       },
       text: logicalLine.text.slice(candidate.start, candidate.end),
     });

--- a/client/src/terminal/file-links.ts
+++ b/client/src/terminal/file-links.ts
@@ -1,0 +1,370 @@
+import type { IDisposable, ILink, Terminal } from '@xterm/xterm';
+
+const MAX_LOGICAL_LINE_LENGTH = 4_096;
+const SHELL_TOKEN_BOUNDARY = /\s/;
+const WRAPPER_PAIRS: Record<string, string> = { '(': ')', '[': ']', '{': '}', '<': '>' };
+const TRAILING_PUNCTUATION = new Set([',', ';', '!', '?']);
+const UNSAFE_PATH_CHARACTERS = new Set(['*', '?', '[', ']', '{', '}', '<', '>', '|']);
+// OCI image names overlap heavily with relative paths. Requiring a tag or
+// digest keeps ordinary paths clickable while excluding the form users most
+// commonly see in containerlab and Compose files.
+const CONTAINER_IMAGE_REFERENCE =
+  /^(?:(?:localhost|[a-z\d](?:[a-z\d.-]*[a-z\d])?)(?::\d+)?\/)?(?:[a-z\d._-]+\/)+[a-z\d._-]+(?::[a-z\d_][a-z\d._-]{0,127}|@sha256:[a-f\d]{32,})$/i;
+const CONVENTIONAL_FILENAMES = new Set([
+  'brewfile',
+  'cmakelists.txt',
+  'compose.yaml',
+  'compose.yml',
+  'containerfile',
+  'dockerfile',
+  'gemfile',
+  'justfile',
+  'license',
+  'makefile',
+  'procfile',
+  'rakefile',
+  'readme',
+  'vagrantfile',
+]);
+
+export interface TerminalFileLinkCandidate {
+  /** Decoded path passed to the remote-path resolver. */
+  path: string;
+  /** UTF-16 offsets into the logical terminal line. */
+  start: number;
+  end: number;
+}
+
+function escapedAt(value: string, index: number): boolean {
+  let slashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor--) slashes++;
+  return slashes % 2 === 1;
+}
+
+function decodeShellEscapes(value: string): string {
+  return value.replace(/\\(.)/gs, '$1');
+}
+
+function containsUnsafePathCharacter(value: string): boolean {
+  for (const character of value) {
+    if (UNSAFE_PATH_CHARACTERS.has(character)) return true;
+  }
+  return false;
+}
+
+function safePathValue(value: string): boolean {
+  if (
+    !value ||
+    value.length > 4_096 ||
+    value === '.' ||
+    value === '..' ||
+    value === '/' ||
+    value.includes('\0') ||
+    value.includes('\r') ||
+    value.includes('\n') ||
+    containsUnsafePathCharacter(value) ||
+    /^[a-z][a-z\d+.-]*:\/\//i.test(value)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function looksLikeContainerImageReference(value: string): boolean {
+  if (CONTAINER_IMAGE_REFERENCE.test(value)) return true;
+
+  // A registry-qualified image is still an image when the implicit `latest`
+  // tag is omitted. Restrict this form to an unmistakable registry host so a
+  // normal `directory/file` path remains clickable.
+  const slash = value.indexOf('/');
+  if (slash <= 0) return false;
+  const registry = value.slice(0, slash).toLocaleLowerCase();
+  const registryParts = registry.match(/^([a-z\d](?:[a-z\d.-]*[a-z\d])?)(?::\d+)?$/i);
+  if (
+    !registryParts?.[1] ||
+    (registryParts[1] !== 'localhost' &&
+      !registryParts[1].includes('.') &&
+      !/:\d+$/.test(registry))
+  ) {
+    return false;
+  }
+  return /^(?:[a-z\d._-]+\/)*[a-z\d._-]+$/i.test(value.slice(slash + 1));
+}
+
+function looksLikePath(value: string): boolean {
+  if (
+    !safePathValue(value) ||
+    looksLikeContainerImageReference(value) ||
+    /^v?\d+(?:\.\d+){1,3}(?:[-+][\w.-]+)?$/i.test(value)
+  ) {
+    return false;
+  }
+  if (/^(?:\/|\.\.?\/|~\/)/.test(value) || value.includes('/')) return true;
+  const lower = value.toLocaleLowerCase();
+  if (CONVENTIONAL_FILENAMES.has(lower)) return true;
+  if (value.startsWith('.') && value.length > 1) return true;
+  return /\.[a-z\d][a-z\d+_-]{0,15}$/i.test(value);
+}
+
+function candidateFromRange(
+  line: string,
+  initialStart: number,
+  initialEnd: number,
+): TerminalFileLinkCandidate | undefined {
+  let start = initialStart;
+  let end = initialEnd;
+  const closingWrappers: string[] = [];
+  while (start < end && WRAPPER_PAIRS[line[start]!]) {
+    closingWrappers.push(WRAPPER_PAIRS[line[start]!]!);
+    start++;
+  }
+  while (end > start && TRAILING_PUNCTUATION.has(line[end - 1]!)) end--;
+  while (closingWrappers.length > 0 && line[end - 1] === closingWrappers.pop()) end--;
+  if (start >= end) return undefined;
+
+  let displayed = line.slice(start, end);
+  if (looksLikeContainerImageReference(decodeShellEscapes(displayed))) return undefined;
+  const compilerLocation = displayed.match(/^(.+?):\d+(?::\d+)?(?::.*)?$/);
+  if (compilerLocation?.[1]) {
+    end = start + compilerLocation[1].length;
+    displayed = compilerLocation[1];
+  } else {
+    const parenthesizedLocation = displayed.match(/^(.+?)\(\d+(?:,\d+)?\)$/);
+    if (parenthesizedLocation?.[1]) {
+      end = start + parenthesizedLocation[1].length;
+      displayed = parenthesizedLocation[1];
+    } else if (displayed.endsWith(':')) {
+      end--;
+      displayed = displayed.slice(0, -1);
+    }
+  }
+
+  const path = decodeShellEscapes(displayed);
+  return looksLikePath(path) ? { path, start, end } : undefined;
+}
+
+/**
+ * Recognize the date/time fields in GNU/BSD `ls -l` output and treat what
+ * follows as authoritative. This keeps extensionless files clickable without
+ * mistaking values such as the `3.8K` size column for filenames; finding the
+ * date also tolerates SELinux contexts and device major/minor columns.
+ */
+function longListingFileCandidate(line: string): TerminalFileLinkCandidate[] | undefined {
+  const fields = Array.from(line.matchAll(/\S+/g));
+  const mode = fields[0]?.[0];
+  if (!mode || !/^[bcdlps-][rwxStTs-]{9}[.@+]?$/u.test(mode)) return undefined;
+  if (!mode.startsWith('-')) return [];
+
+  let filenameField = -1;
+  for (let index = 2; index < fields.length - 1; index++) {
+    const value = fields[index]![0];
+    const previous = fields[index - 1]![0];
+    const monthDayTime = /^\d{1,2}$/u.test(previous) && /^(?:\d{1,2}:\d{2}(?::\d{2})?|\d{4})$/u.test(value);
+    const isoTime = /^\d{4}-\d{2}-\d{2}$/u.test(previous) && /^\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/u.test(value);
+    if (!monthDayTime && !isoTime) continue;
+    filenameField = index + 1;
+    if (/^[+-]\d{4}$/u.test(fields[filenameField]?.[0] ?? '')) filenameField++;
+    break;
+  }
+  if (filenameField < 0 || filenameField >= fields.length) return [];
+
+  let start = fields[filenameField]!.index!;
+  let end = line.length;
+  while (end > start && /\s/u.test(line[end - 1]!)) end--;
+  const quote = line[start];
+  if ((quote === "'" || quote === '"') && line[end - 1] === quote) {
+    start++;
+    end--;
+  }
+  if (start >= end) return [];
+
+  const path = decodeShellEscapes(line.slice(start, end));
+  return safePathValue(path) ? [{ path, start, end }] : [];
+}
+
+/** Find path-shaped tokens without turning ordinary terminal prose into links. */
+export function terminalFileLinkCandidates(line: string): TerminalFileLinkCandidate[] {
+  const longListing = longListingFileCandidate(line);
+  if (longListing) return longListing;
+
+  const candidates: TerminalFileLinkCandidate[] = [];
+  let cursor = 0;
+  while (cursor < line.length) {
+    while (cursor < line.length && SHELL_TOKEN_BOUNDARY.test(line[cursor]!)) cursor++;
+    if (cursor >= line.length) break;
+
+    const tokenStart = cursor;
+    const quote = line[cursor] === "'" || line[cursor] === '"' ? line[cursor] : undefined;
+    if (quote) {
+      cursor++;
+      const contentStart = cursor;
+      while (cursor < line.length && (line[cursor] !== quote || escapedAt(line, cursor))) cursor++;
+      const candidate = candidateFromRange(line, contentStart, cursor);
+      if (candidate) candidates.push(candidate);
+      while (cursor < line.length && !SHELL_TOKEN_BOUNDARY.test(line[cursor]!)) cursor++;
+      continue;
+    }
+
+    while (cursor < line.length) {
+      if (SHELL_TOKEN_BOUNDARY.test(line[cursor]!) && !escapedAt(line, cursor)) break;
+      cursor++;
+    }
+    const candidate = candidateFromRange(line, tokenStart, cursor);
+    if (candidate) candidates.push(candidate);
+  }
+  return candidates;
+}
+
+function normalizeAbsolutePath(value: string): string {
+  const segments: string[] = [];
+  for (const segment of value.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') segments.pop();
+    else segments.push(segment);
+  }
+  return `/${segments.join('/')}`;
+}
+
+/** Resolve a path exactly as a POSIX shell would before handing it to SFTP. */
+export function resolveRemoteFilePath(
+  candidate: string,
+  cwd?: string,
+  home?: string,
+): string | undefined {
+  if (
+    !candidate ||
+    candidate.includes('\0') ||
+    candidate.includes('\r') ||
+    candidate.includes('\n')
+  ) {
+    return undefined;
+  }
+  if (candidate === '~' || candidate.startsWith('~/')) {
+    if (!home?.startsWith('/')) return undefined;
+    return normalizeAbsolutePath(`${home}/${candidate.slice(2)}`);
+  }
+  if (candidate.startsWith('~')) return undefined;
+  if (candidate.startsWith('/')) return normalizeAbsolutePath(candidate);
+  if (!cwd?.startsWith('/')) return undefined;
+  return normalizeAbsolutePath(`${cwd}/${candidate}`);
+}
+
+function logicalLineAt(term: Terminal, bufferLineNumber: number): { text: string; startLine: number } | undefined {
+  const buffer = term.buffer.active;
+  let startLine = bufferLineNumber - 1;
+  let line = buffer.getLine(startLine);
+  if (!line) return undefined;
+
+  let scanned = 0;
+  while (line.isWrapped && scanned < MAX_LOGICAL_LINE_LENGTH) {
+    const previous = buffer.getLine(startLine - 1);
+    if (!previous) break;
+    scanned += previous.translateToString(true).length;
+    startLine--;
+    line = previous;
+  }
+
+  const parts: string[] = [];
+  let lineIndex = startLine;
+  do {
+    const content = line.translateToString(true);
+    parts.push(content);
+    scanned += content.length;
+    lineIndex++;
+    line = buffer.getLine(lineIndex)!;
+  } while (line?.isWrapped && scanned < MAX_LOGICAL_LINE_LENGTH);
+
+  return { text: parts.join(''), startLine };
+}
+
+/** Map a UTF-16 string offset back to xterm's zero-based buffer coordinates. */
+function bufferPosition(
+  term: Terminal,
+  initialLine: number,
+  stringOffset: number,
+): [number, number] | undefined {
+  const buffer = term.buffer.active;
+  const cell = buffer.getNullCell();
+  let lineIndex = initialLine;
+  let column = 0;
+  let remaining = stringOffset;
+  while (remaining > 0) {
+    const line = buffer.getLine(lineIndex);
+    if (!line) return undefined;
+    for (let index = column; index < line.length; index++) {
+      line.getCell(index, cell);
+      const chars = cell.getChars();
+      if (cell.getWidth()) {
+        remaining -= chars.length || 1;
+        // A wide character split at the right edge is represented by a blank
+        // cell followed by its width-two cell on the wrapped line.
+        if (index === line.length - 1 && chars === '') {
+          const next = buffer.getLine(lineIndex + 1);
+          if (next?.isWrapped) {
+            next.getCell(0, cell);
+            if (cell.getWidth() === 2) remaining++;
+          }
+        }
+      }
+      if (remaining < 0) return [lineIndex, index];
+    }
+    lineIndex++;
+    column = 0;
+  }
+  return [lineIndex, column];
+}
+
+interface MappedTerminalFileLink {
+  candidate: TerminalFileLinkCandidate;
+  range: ILink['range'];
+  text: string;
+}
+
+function mappedFileLinks(term: Terminal, bufferLineNumber: number): MappedTerminalFileLink[] {
+  const logicalLine = logicalLineAt(term, bufferLineNumber);
+  if (!logicalLine) return [];
+
+  const links: MappedTerminalFileLink[] = [];
+  for (const candidate of terminalFileLinkCandidates(logicalLine.text)) {
+    const start = bufferPosition(term, logicalLine.startLine, candidate.start);
+    const end = bufferPosition(term, logicalLine.startLine, candidate.end);
+    if (!start || !end) continue;
+    links.push({
+      candidate,
+      range: {
+        start: { x: start[1] + 1, y: start[0] + 1 },
+        end: { x: end[1], y: end[0] + 1 },
+      },
+      text: logicalLine.text.slice(candidate.start, candidate.end),
+    });
+  }
+  return links;
+}
+
+/** Register ordinary hover-and-click file links while leaving other terminal text untouched. */
+export function attachTerminalFileLinks(
+  term: Terminal,
+  onOpen: (candidate: string) => void | Promise<void>,
+): IDisposable {
+  return term.registerLinkProvider({
+    provideLinks: (bufferLineNumber, callback) => {
+      const links = mappedFileLinks(term, bufferLineNumber).map(({ candidate, range, text }) => {
+        const link: ILink = {
+          range,
+          text,
+          // xterm applies these only while the link is hovered and removes
+          // them on leave, matching a normal browser-link affordance.
+          decorations: { pointerCursor: true, underline: true },
+          activate: (event) => {
+            if (event.button !== 0) return;
+            event.preventDefault();
+            event.stopPropagation();
+            void onOpen(candidate.path);
+          },
+        };
+        return link;
+      });
+      callback(links.length > 0 ? links : undefined);
+    },
+  });
+}

--- a/client/src/terminal/file-links.ts
+++ b/client/src/terminal/file-links.ts
@@ -226,7 +226,7 @@ function normalizeAbsolutePath(value: string): string {
 }
 
 /** Resolve a path exactly as a POSIX shell would before handing it to SFTP. */
-export function resolveRemoteFilePath(
+export function resolveTerminalFilePath(
   candidate: string,
   cwd?: string,
   home?: string,

--- a/client/src/terminal/shell-integration.ts
+++ b/client/src/terminal/shell-integration.ts
@@ -45,7 +45,7 @@ function decodePropertyValue(value: string): string | undefined {
   return decoded;
 }
 
-function validRemoteCwd(value: string | undefined): value is string {
+function validTerminalCwd(value: string | undefined): value is string {
   return !!value && value.startsWith('/') && value.length <= MAX_TERMINAL_CWD_LENGTH;
 }
 
@@ -73,7 +73,7 @@ export class CwdTracker {
   }
 
   private report(cwd: string | undefined): void {
-    if (!validRemoteCwd(cwd) || cwd === this.current) return;
+    if (!validTerminalCwd(cwd) || cwd === this.current) return;
     this.current = cwd;
     this.onChange(cwd);
   }

--- a/client/src/terminal/web-links.ts
+++ b/client/src/terminal/web-links.ts
@@ -1,0 +1,22 @@
+const WEB_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * Give Electron the complete URL in the initial window-open request. The
+ * desktop main process intercepts that request and opens it in the system
+ * browser; WebLinksAddon's default two-step about:blank flow is denied before
+ * it can assign the real URL.
+ */
+export function openTerminalWebLink(event: MouseEvent, uri: string): void {
+  let url: string;
+  try {
+    const parsed = new URL(uri);
+    if (!WEB_PROTOCOLS.has(parsed.protocol)) return;
+    url = parsed.toString();
+  } catch {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  window.open(url, '_blank', 'noopener');
+}

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -2,11 +2,13 @@
 icon: lucide/file-pen
 ---
 
-# Remote editor
+# File editor
 
-Double-clicking a file in the [file browser](files.md) opens it in
-[Monaco](https://microsoft.github.io/monaco-editor/), the editor used by VS Code. Reads and
-writes go over the live SSH transport of that session.
+Click an underlined file path in a local or SSH terminal to open it in
+[Monaco](https://microsoft.github.io/monaco-editor/), the editor used by VS Code. Files in
+SSH sessions use that session's live SFTP transport; files in local terminals are read and
+saved directly on the machine running Muxus. Double-clicking a file in the
+[file browser](files.md) opens the same editor.
 
 <figure markdown="span">
   ![Editing a remote file with Monaco](../assets/screenshots/remote-editor.png#only-light){ .shadow }
@@ -30,12 +32,12 @@ Several files stay open at once inside the tab, alongside the terminal.
 
 ## Conflict protection
 
-Saving carries the modification time the file had when it was read. If the file changed on
-the remote in the meantime, the save is refused and the editor offers **Reload from
-remote**.
+Saving carries the modification time the file had when it was read. If it changes on disk
+or on the remote host in the meantime, the save is refused and the editor offers to reload
+the newer version.
 
 ## Scope
 
 The editor targets single-file edits: a config change, a compose file, a systemd unit. For
 project-level work requiring a language server, a test runner or git history, use an
-editor's own remote support. Muxus provides a file editor, not a remote IDE.
+editor's own project support. Muxus provides a file editor, not a full IDE.

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -74,6 +74,7 @@ resetting them.
 | Action | Gesture |
 | --- | --- |
 | Zoom the terminal | ++ctrl++ + scroll wheel |
+| Open a remote terminal path in the editor | Hover for an underline, then left-click |
 | Resize a split, reset it to half | Drag the divider, double-click it |
 | Pane actions (split, zoom, close) | Right-click the tab strip |
 | Rename a tab, close a tab | Double-click it, middle-click it |

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -74,15 +74,15 @@ resetting them.
 | Action | Gesture |
 | --- | --- |
 | Zoom the terminal | ++ctrl++ + scroll wheel |
-| Open a remote terminal path in the editor | Hover for an underline, then left-click |
+| Open a terminal path in the editor | Hover for an underline, then left-click |
 | Resize a split, reset it to half | Drag the divider, double-click it |
 | Pane actions (split, zoom, close) | Right-click the tab strip |
 | Rename a tab, close a tab | Double-click it, middle-click it |
 | Search next / previous match | ++enter++, ++shift+enter++ |
 
-## Remote editor
+## File editor
 
-Monaco's own bindings apply inside the [remote editor](../guide/editor.md):
+Monaco's own bindings apply inside the [file editor](../guide/editor.md):
 
 | Action | Chord |
 | --- | --- |

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,6 +28,7 @@ import { registerSessionHistoryRoutes } from './routes/session-history.js';
 import { registerPasswordVaultRoutes } from './routes/password-vault.js';
 import { registerFolderRoutes } from './routes/folders.js';
 import { registerLogRoutes } from './routes/logs.js';
+import { registerLocalFileRoutes } from './routes/local-files.js';
 import { appLogPinoSink } from './logging/log-buffer.js';
 import {
   defaultHistoryRoot,
@@ -185,6 +186,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   registerPasswordVaultRoutes(app, ctx);
   registerFolderRoutes(app, ctx);
   registerLogRoutes(app);
+  registerLocalFileRoutes(app);
   registerTerminalSocket(app, ctx);
   registerSftpLeaseSocket(app, ctx);
 

--- a/server/src/routes/local-files.ts
+++ b/server/src/routes/local-files.ts
@@ -85,6 +85,12 @@ async function readLocalTextFile(file: string): Promise<EditorFileResponse> {
   try {
     const opened = await handle.stat();
     requireRegularFile(opened);
+    if (opened.size > MAX_EDITOR_BYTES) {
+      throw new HttpProblem(
+        413,
+        `files larger than ${formatBytes(MAX_EDITOR_BYTES)} cannot be opened in the editor`,
+      );
+    }
     const buffer = Buffer.allocUnsafe(opened.size);
     let total = 0;
     while (total < buffer.length) {

--- a/server/src/routes/local-files.ts
+++ b/server/src/routes/local-files.ts
@@ -1,0 +1,183 @@
+import { randomBytes } from 'node:crypto';
+import { constants } from 'node:fs';
+import { lstat, open, rename, stat, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type {
+  EditorFileResponse,
+  EditorFileSaveRequest,
+  EditorFileSaveResponse,
+} from '@muxus/shared';
+import { HttpProblem, sendError } from '../util/errors.js';
+
+const MAX_EDITOR_BYTES = 8 * 1024 * 1024;
+
+/** Authenticated text editing for files visible to a local terminal session. */
+export function registerLocalFileRoutes(app: FastifyInstance): void {
+  app.get('/api/local-files/file', async (req, reply) => {
+    try {
+      const file = requireAbsolutePath(req);
+      const response: EditorFileResponse = await readLocalTextFile(file);
+      return response;
+    } catch (error) {
+      return sendError(reply, localFileError(error));
+    }
+  });
+
+  app.put(
+    '/api/local-files/file',
+    { bodyLimit: MAX_EDITOR_BYTES + 64 * 1024 },
+    async (req, reply) => {
+      try {
+        const file = requireAbsolutePath(req);
+        const body = (req.body ?? {}) as Partial<EditorFileSaveRequest>;
+        if (typeof body.content !== 'string') {
+          throw new HttpProblem(400, 'content must be a string');
+        }
+        const bytes = Buffer.from(body.content, 'utf8');
+        if (bytes.length > MAX_EDITOR_BYTES) {
+          throw new HttpProblem(
+            413,
+            `files larger than ${formatBytes(MAX_EDITOR_BYTES)} cannot be saved from the editor`,
+          );
+        }
+
+        const current = await lstat(file);
+        requireRegularFile(current);
+        if (
+          !body.force &&
+          body.expectedMtimeMs !== undefined &&
+          current.mtimeMs !== body.expectedMtimeMs
+        ) {
+          throw new HttpProblem(
+            409,
+            'the local file changed since it was opened',
+            'LOCAL_FILE_CHANGED',
+          );
+        }
+
+        await atomicLocalTextSave(file, bytes, current.mode);
+        const saved = await stat(file);
+        const response: EditorFileSaveResponse = {
+          ok: true,
+          size: saved.size,
+          mtimeMs: saved.mtimeMs,
+        };
+        return response;
+      } catch (error) {
+        return sendError(reply, localFileError(error));
+      }
+    },
+  );
+}
+
+async function readLocalTextFile(file: string): Promise<EditorFileResponse> {
+  const initial = await lstat(file);
+  requireRegularFile(initial);
+  if (initial.size > MAX_EDITOR_BYTES) {
+    throw new HttpProblem(
+      413,
+      `files larger than ${formatBytes(MAX_EDITOR_BYTES)} cannot be opened in the editor`,
+    );
+  }
+
+  const handle = await open(file, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const opened = await handle.stat();
+    requireRegularFile(opened);
+    const buffer = Buffer.allocUnsafe(opened.size);
+    let total = 0;
+    while (total < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, total, buffer.length - total, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+    }
+    const afterRead = await handle.stat();
+    if (total !== opened.size || afterRead.size !== opened.size || afterRead.mtimeMs !== opened.mtimeMs) {
+      throw new HttpProblem(409, 'the local file changed while it was being opened');
+    }
+    const bytes = buffer.subarray(0, total);
+    if (bytes.includes(0)) {
+      throw new HttpProblem(415, 'this appears to be a binary file and cannot be opened as text');
+    }
+    let content: string;
+    try {
+      content = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch {
+      throw new HttpProblem(415, 'the file editor currently supports UTF-8 text files');
+    }
+    return {
+      path: file,
+      content,
+      size: total,
+      mtimeMs: opened.mtimeMs,
+      mode: opened.mode & 0o7777,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function requireRegularFile(attributes: {
+  isDirectory(): boolean;
+  isFile(): boolean;
+  isSymbolicLink(): boolean;
+}): void {
+  if (attributes.isDirectory()) throw new HttpProblem(400, 'cannot edit a directory');
+  if (attributes.isSymbolicLink()) {
+    throw new HttpProblem(
+      409,
+      'open the symbolic link target explicitly',
+      'LOCAL_EDITOR_SYMLINK',
+    );
+  }
+  if (!attributes.isFile()) {
+    throw new HttpProblem(415, 'only regular files can be opened in the editor');
+  }
+}
+
+async function atomicLocalTextSave(file: string, bytes: Buffer, mode: number): Promise<void> {
+  const temporary = `${file}.muxus-${randomBytes(6).toString('hex')}.tmp`;
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(temporary, 'wx', mode & 0o7777);
+    await handle.writeFile(bytes);
+    // open() applies the process umask even when a mode is supplied. Restore
+    // the original file's permissions before the temporary file is published.
+    await handle.chmod(mode & 0o7777);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporary, file);
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await unlink(temporary).catch(() => undefined);
+    throw error;
+  }
+}
+
+function requireAbsolutePath(req: FastifyRequest): string {
+  const value = (req.query as { path?: unknown }).path;
+  if (typeof value !== 'string' || !value || value.includes('\0')) {
+    throw new HttpProblem(400, 'path is required');
+  }
+  if (!path.isAbsolute(value)) throw new HttpProblem(400, 'path must be absolute');
+  return path.normalize(value);
+}
+
+function localFileError(error: unknown): unknown {
+  if (error instanceof HttpProblem) return error;
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'ENOENT') return new HttpProblem(404, 'local file not found');
+  if (code === 'EACCES' || code === 'EPERM') {
+    return new HttpProblem(403, 'permission denied while accessing the local file');
+  }
+  if (code === 'ELOOP') {
+    return new HttpProblem(409, 'open the symbolic link target explicitly', 'LOCAL_EDITOR_SYMLINK');
+  }
+  return error;
+}
+
+function formatBytes(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MiB`;
+}

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -658,8 +658,8 @@ export interface SftpListResponse {
   entries: SftpEntry[];
 }
 
-/** Text file opened through the remote editor. */
-export interface SftpFileResponse {
+/** UTF-8 text file opened through Monaco, regardless of backing filesystem. */
+export interface EditorFileResponse {
   path: string;
   content: string;
   size: number;
@@ -667,8 +667,8 @@ export interface SftpFileResponse {
   mode?: number;
 }
 
-/** Optimistic, text-only remote save request. */
-export interface SftpFileSaveRequest {
+/** Optimistic, text-only save request shared by local and SFTP files. */
+export interface EditorFileSaveRequest {
   content: string;
   /** Modification time returned by the read/save that produced this buffer. */
   expectedMtimeMs?: number;
@@ -676,11 +676,15 @@ export interface SftpFileSaveRequest {
   force?: boolean;
 }
 
-export interface SftpFileSaveResponse {
+export interface EditorFileSaveResponse {
   ok: true;
   size: number;
   mtimeMs?: number;
 }
+
+export type SftpFileResponse = EditorFileResponse;
+export type SftpFileSaveRequest = EditorFileSaveRequest;
+export type SftpFileSaveResponse = EditorFileSaveResponse;
 
 export type ForwardType = 'local' | 'remote' | 'dynamic';
 

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   attachTerminalFileLinks,
-  resolveRemoteFilePath,
+  resolveTerminalFilePath,
   terminalFileLinkCandidates,
 } from '../../../client/src/terminal/file-links.js';
 import { openTerminalWebLink } from '../../../client/src/terminal/web-links.js';
@@ -213,23 +213,23 @@ describe('terminal web links', () => {
   });
 });
 
-describe('remote file path resolution', () => {
+describe('terminal file path resolution', () => {
   it('normalizes absolute and current-directory-relative paths', () => {
-    expect(resolveRemoteFilePath('/srv/app/../config.toml', '/ignored')).toBe('/srv/config.toml');
-    expect(resolveRemoteFilePath('./src/../README.md', '/srv/app')).toBe('/srv/app/README.md');
-    expect(resolveRemoteFilePath('../../etc/hosts', '/srv/app')).toBe('/etc/hosts');
+    expect(resolveTerminalFilePath('/srv/app/../config.toml', '/ignored')).toBe('/srv/config.toml');
+    expect(resolveTerminalFilePath('./src/../README.md', '/srv/app')).toBe('/srv/app/README.md');
+    expect(resolveTerminalFilePath('../../etc/hosts', '/srv/app')).toBe('/etc/hosts');
   });
 
   it('resolves the current user home only when SFTP supplied it', () => {
-    expect(resolveRemoteFilePath('~/.ssh/config', '/srv/app')).toBeUndefined();
-    expect(resolveRemoteFilePath('~/.ssh/config', '/srv/app', '/home/alice')).toBe(
+    expect(resolveTerminalFilePath('~/.ssh/config', '/srv/app')).toBeUndefined();
+    expect(resolveTerminalFilePath('~/.ssh/config', '/srv/app', '/home/alice')).toBe(
       '/home/alice/.ssh/config',
     );
-    expect(resolveRemoteFilePath('~bob/.ssh/config', '/srv/app', '/home/alice')).toBeUndefined();
+    expect(resolveTerminalFilePath('~bob/.ssh/config', '/srv/app', '/home/alice')).toBeUndefined();
   });
 
   it('requires an absolute shell working directory for relative paths', () => {
-    expect(resolveRemoteFilePath('src/main.ts')).toBeUndefined();
-    expect(resolveRemoteFilePath('src/main.ts', '.')).toBeUndefined();
+    expect(resolveTerminalFilePath('src/main.ts')).toBeUndefined();
+    expect(resolveTerminalFilePath('src/main.ts', '.')).toBeUndefined();
   });
 });

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  attachTerminalFileLinks,
+  resolveRemoteFilePath,
+  terminalFileLinkCandidates,
+} from '../../../client/src/terminal/file-links.js';
+import { openTerminalWebLink } from '../../../client/src/terminal/web-links.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+interface ProvidedLink {
+  range: { start: { x: number; y: number }; end: { x: number; y: number } };
+  decorations?: { pointerCursor?: boolean; underline?: boolean };
+  activate: (event: MouseEvent, text: string) => void;
+}
+
+interface StubLinkProvider {
+  provideLinks: (
+    line: number,
+    callback: (links: ProvidedLink[] | undefined) => void,
+  ) => void;
+}
+
+function terminalWithLine(text: string): {
+  terminal: Parameters<typeof attachTerminalFileLinks>[0];
+  provider: () => StubLinkProvider;
+} {
+  const cell = {
+    chars: '',
+    getChars() {
+      return this.chars;
+    },
+    getWidth() {
+      return 1;
+    },
+  };
+  const line = {
+    isWrapped: false,
+    length: text.length + 1,
+    translateToString: () => text,
+    getCell: (index: number) => {
+      cell.chars = text[index] ?? '';
+      return cell;
+    },
+  };
+  let registered: StubLinkProvider | undefined;
+  const terminal = {
+    buffer: {
+      active: {
+        getLine: (index: number) => index === 0 ? line : undefined,
+        getNullCell: () => cell,
+      },
+    },
+    registerLinkProvider: (provider: StubLinkProvider) => {
+      registered = provider;
+      return { dispose: () => undefined };
+    },
+  } as unknown as Parameters<typeof attachTerminalFileLinks>[0];
+  return {
+    terminal,
+    provider: () => {
+      if (!registered) throw new Error('link provider was not registered');
+      return registered;
+    },
+  };
+}
+
+describe('terminal file links', () => {
+  it('finds absolute, relative, dotfile, and conventional file paths', () => {
+    expect(
+      terminalFileLinkCandidates(
+        'edit /etc/hosts ./src/App.tsx ../shared/api.ts .env Dockerfile README',
+      ).map((candidate) => candidate.path),
+    ).toEqual([
+      '/etc/hosts',
+      './src/App.tsx',
+      '../shared/api.ts',
+      '.env',
+      'Dockerfile',
+      'README',
+    ]);
+  });
+
+  it('supports quoted and shell-escaped paths with spaces', () => {
+    expect(
+      terminalFileLinkCandidates(String.raw`"/srv/my app/main.ts" './docs/user guide.md' src/a\ file.ts`).map(
+        (candidate) => candidate.path,
+      ),
+    ).toEqual(['/srv/my app/main.ts', './docs/user guide.md', 'src/a file.ts']);
+  });
+
+  it('strips compiler locations and surrounding punctuation from the linked range', () => {
+    const line = 'error: (src/main.ts:42:7), config.yaml(8,2) README.md:';
+    const candidates = terminalFileLinkCandidates(line);
+    expect(candidates.map((candidate) => candidate.path)).toEqual([
+      'src/main.ts',
+      'config.yaml',
+      'README.md',
+    ]);
+    expect(candidates.map((candidate) => line.slice(candidate.start, candidate.end))).toEqual([
+      'src/main.ts',
+      'config.yaml',
+      'README.md',
+    ]);
+  });
+
+  it('does not link URLs, flags, versions, or ordinary prose', () => {
+    expect(
+      terminalFileLinkCandidates('open https://example.test/file.txt --config v1.2.3 ordinary words')
+        .map((candidate) => candidate.path),
+    ).toEqual([]);
+  });
+
+  it('does not confuse tagged container image references with file paths', () => {
+    expect(
+      terminalFileLinkCandidates(
+        'image: ghcr.io/nokia/srlinux:latest ghcr.io/srl-labs/network-multitool:latest ghcr.io/nokia/srlinux',
+      ),
+    ).toEqual([]);
+    expect(terminalFileLinkCandidates('image: srl-labs/network-multitool:latest')).toEqual([]);
+    expect(terminalFileLinkCandidates('image: srl-labs/network-multitool:42')).toEqual([]);
+  });
+
+  it('recognizes only the regular filename in long ls output, including extensionless files', () => {
+    expect(
+      terminalFileLinkCandidates(
+        '-rw-rw-rw-.  1 root root 3.8K Jul 23 16:33 containerlab.svg',
+      ).map((candidate) => candidate.path),
+    ).toEqual(['containerlab.svg']);
+    expect(
+      terminalFileLinkCandidates(
+        '-rw-r--r--.  1 root root 406K Feb 27  2025 hist',
+      ).map((candidate) => candidate.path),
+    ).toEqual(['hist']);
+    expect(
+      terminalFileLinkCandidates(
+        'drwxr-xr-x.  5 root root  100 May  4  2024 demo',
+      ),
+    ).toEqual([]);
+    expect(
+      terminalFileLinkCandidates(
+        '-rw-r--r--. 1 root root system_u:object_r:admin_home_t:s0 928 Dec 1 2025 lic.txt',
+      ).map((candidate) => candidate.path),
+    ).toEqual(['lic.txt']);
+    expect(
+      terminalFileLinkCandidates(
+        '-rw-r--r-- 1 root root 928 2025-12-01 09:42 +0100 lic.txt',
+      ).map((candidate) => candidate.path),
+    ).toEqual(['lic.txt']);
+  });
+
+  it('underlines a detected path on hover and opens it with a plain left-click', () => {
+    const { terminal, provider } = terminalWithLine('output: src/main.ts');
+    const onOpen = vi.fn();
+    attachTerminalFileLinks(terminal, onOpen);
+    let links: ProvidedLink[] | undefined;
+    provider().provideLinks(1, (provided) => {
+      links = provided;
+    });
+    expect(links).toHaveLength(1);
+    expect(links![0]!.range).toEqual({
+      start: { x: 9, y: 1 },
+      end: { x: 19, y: 1 },
+    });
+
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    links![0]!.activate(
+      { button: 2, altKey: true, preventDefault, stopPropagation } as unknown as MouseEvent,
+      'src/main.ts',
+    );
+    expect(onOpen).not.toHaveBeenCalled();
+
+    expect(links![0]!.decorations).toEqual({ pointerCursor: true, underline: true });
+
+    links![0]!.activate(
+      { button: 0, altKey: false, preventDefault, stopPropagation } as unknown as MouseEvent,
+      'src/main.ts',
+    );
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onOpen).toHaveBeenCalledWith('src/main.ts');
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(stopPropagation).toHaveBeenCalledOnce();
+  });
+});
+
+describe('terminal web links', () => {
+  it('opens a valid web URL directly so Electron can hand it to the system browser', () => {
+    const open = vi.fn();
+    vi.stubGlobal('window', { open });
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    openTerminalWebLink(
+      { preventDefault, stopPropagation } as unknown as MouseEvent,
+      'https://google.com',
+    );
+
+    expect(open).toHaveBeenCalledWith('https://google.com/', '_blank', 'noopener');
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(stopPropagation).toHaveBeenCalledOnce();
+  });
+
+  it('ignores malformed and non-web URLs', () => {
+    const open = vi.fn();
+    vi.stubGlobal('window', { open });
+    const event = { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as MouseEvent;
+
+    openTerminalWebLink(event, 'file:///etc/passwd');
+    openTerminalWebLink(event, 'not a URL');
+
+    expect(open).not.toHaveBeenCalled();
+  });
+});
+
+describe('remote file path resolution', () => {
+  it('normalizes absolute and current-directory-relative paths', () => {
+    expect(resolveRemoteFilePath('/srv/app/../config.toml', '/ignored')).toBe('/srv/config.toml');
+    expect(resolveRemoteFilePath('./src/../README.md', '/srv/app')).toBe('/srv/app/README.md');
+    expect(resolveRemoteFilePath('../../etc/hosts', '/srv/app')).toBe('/etc/hosts');
+  });
+
+  it('resolves the current user home only when SFTP supplied it', () => {
+    expect(resolveRemoteFilePath('~/.ssh/config', '/srv/app')).toBeUndefined();
+    expect(resolveRemoteFilePath('~/.ssh/config', '/srv/app', '/home/alice')).toBe(
+      '/home/alice/.ssh/config',
+    );
+    expect(resolveRemoteFilePath('~bob/.ssh/config', '/srv/app', '/home/alice')).toBeUndefined();
+  });
+
+  it('requires an absolute shell working directory for relative paths', () => {
+    expect(resolveRemoteFilePath('src/main.ts')).toBeUndefined();
+    expect(resolveRemoteFilePath('src/main.ts', '.')).toBeUndefined();
+  });
+});

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -21,7 +21,7 @@ interface StubLinkProvider {
   ) => void;
 }
 
-function terminalWithLine(text: string): {
+function terminalWithLine(text: string, spareCells = 1): {
   terminal: Parameters<typeof attachTerminalFileLinks>[0];
   provider: () => StubLinkProvider;
 } {
@@ -36,7 +36,7 @@ function terminalWithLine(text: string): {
   };
   const line = {
     isWrapped: false,
-    length: text.length + 1,
+    length: text.length + spareCells,
     translateToString: () => text,
     getCell: (index: number) => {
       cell.chars = text[index] ?? '';
@@ -87,6 +87,18 @@ describe('terminal file links', () => {
         (candidate) => candidate.path,
       ),
     ).toEqual(['/srv/my app/main.ts', './docs/user guide.md', 'src/a file.ts']);
+  });
+
+  it('recognizes native Windows drive-letter and UNC paths without stripping separators', () => {
+    expect(
+      terminalFileLinkCandidates(
+        String.raw`C:\Users\me\foo.txt C:/Users/me/bar.txt \\server\share\baz.txt`,
+      ).map((candidate) => candidate.path),
+    ).toEqual([
+      String.raw`C:\Users\me\foo.txt`,
+      'C:/Users/me/bar.txt',
+      String.raw`\\server\share\baz.txt`,
+    ]);
   });
 
   it('strips compiler locations and surrounding punctuation from the linked range', () => {
@@ -182,6 +194,22 @@ describe('terminal file links', () => {
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(stopPropagation).toHaveBeenCalledOnce();
   });
+
+  it('keeps a link ending in the terminal last column on the current row', () => {
+    const text = 'output: src/main.ts';
+    const { terminal, provider } = terminalWithLine(text, 0);
+    attachTerminalFileLinks(terminal, vi.fn());
+    let links: ProvidedLink[] | undefined;
+
+    provider().provideLinks(1, (provided) => {
+      links = provided;
+    });
+
+    expect(links![0]!.range).toEqual({
+      start: { x: 9, y: 1 },
+      end: { x: text.length, y: 1 },
+    });
+  });
 });
 
 describe('terminal web links', () => {
@@ -231,5 +259,20 @@ describe('terminal file path resolution', () => {
   it('requires an absolute shell working directory for relative paths', () => {
     expect(resolveTerminalFilePath('src/main.ts')).toBeUndefined();
     expect(resolveTerminalFilePath('src/main.ts', '.')).toBeUndefined();
+  });
+
+  it('normalizes Windows drive-letter and UNC paths for local terminals', () => {
+    expect(
+      resolveTerminalFilePath(String.raw`C:\Users\me\..\config.toml`, undefined, undefined, 'local'),
+    ).toBe(String.raw`C:\Users\config.toml`);
+    expect(
+      resolveTerminalFilePath('src/main.ts', String.raw`C:\Users\me`, undefined, 'local'),
+    ).toBe(String.raw`C:\Users\me\src\main.ts`);
+    expect(
+      resolveTerminalFilePath(String.raw`\\server\share\dir\..\file.txt`, undefined, undefined, 'local'),
+    ).toBe(String.raw`\\server\share\file.txt`);
+    expect(
+      resolveTerminalFilePath('C:/Users/me/file.txt', '/srv/app'),
+    ).toBeUndefined();
   });
 });

--- a/tests/unit/server/local-files.test.ts
+++ b/tests/unit/server/local-files.test.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, readFile, readdir, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../../../server/src/app.js';
+import { resolveConfig } from '../../../server/src/config.js';
+import { registerLocalFileRoutes } from '../../../server/src/routes/local-files.js';
+
+let root: string;
+type RouteHandler = (request: unknown, reply: unknown) => Promise<unknown>;
+
+function captureHandlers(): { read: RouteHandler; save: RouteHandler } {
+  const gets = new Map<string, RouteHandler>();
+  const puts = new Map<string, RouteHandler>();
+  const app = {
+    get: (route: string, handler: RouteHandler) => gets.set(route, handler),
+    put: (route: string, _options: unknown, handler: RouteHandler) => puts.set(route, handler),
+  };
+  registerLocalFileRoutes(app as never);
+  return {
+    read: gets.get('/api/local-files/file')!,
+    save: puts.get('/api/local-files/file')!,
+  };
+}
+
+async function invoke(
+  handler: RouteHandler,
+  input: { path: string; body?: unknown },
+): Promise<{ status: number; body: unknown }> {
+  let status = 200;
+  let sent: unknown;
+  const reply = {
+    code(nextStatus: number) {
+      status = nextStatus;
+      return this;
+    },
+    send(body: unknown) {
+      sent = body;
+    },
+  };
+  const result = await handler({ query: { path: input.path }, body: input.body }, reply);
+  return { status, body: sent ?? result };
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), 'muxus-local-editor-test-'));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('local file editor routes', () => {
+  it('is registered behind the API bearer-token guard', async () => {
+    const token = 'local-editor-route-test-token';
+    const built = await buildApp(
+      resolveConfig({
+        token,
+        databasePath: ':memory:',
+        openBrowser: false,
+        prettyLogs: false,
+        staticRoot: '/path/that/does/not/exist',
+      }),
+    );
+    try {
+      const unauthorized = await built.app.inject({
+        method: 'GET',
+        url: `/api/local-files/file?path=${encodeURIComponent(path.join(root, 'notes.txt'))}`,
+      });
+      const registered = await built.app.inject({
+        method: 'GET',
+        url: '/api/local-files/file?path=relative.txt',
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(unauthorized.statusCode).toBe(401);
+      expect(registered.statusCode).toBe(400);
+    } finally {
+      await built.app.close();
+    }
+  });
+
+  it('reads UTF-8 text and saves it atomically without changing its bytes', async () => {
+    const file = path.join(root, 'notes.txt');
+    await writeFile(file, 'before', { mode: 0o674 });
+    const { read, save } = captureHandlers();
+
+    const opened = await invoke(read, { path: file });
+
+    expect(opened.status).toBe(200);
+    const metadata = opened.body as { content: string; mtimeMs: number; mode: number };
+    expect(metadata.content).toBe('before');
+    if (process.platform !== 'win32') expect(metadata.mode).toBe(0o674);
+
+    const saved = await invoke(save, {
+      path: file,
+      body: { content: 'https://example.test', expectedMtimeMs: metadata.mtimeMs },
+    });
+
+    expect(saved.status).toBe(200);
+    expect(await readFile(file, 'utf8')).toBe('https://example.test');
+    if (process.platform !== 'win32') expect((await stat(file)).mode & 0o7777).toBe(0o674);
+    expect((await readdir(root)).filter((name) => name.includes('.muxus-'))).toEqual([]);
+  });
+
+  it('rejects a save when the file changed after it was opened', async () => {
+    const file = path.join(root, 'config.yaml');
+    await writeFile(file, 'first');
+    const { read, save } = captureHandlers();
+    const opened = await invoke(read, { path: file });
+    const originalMtime = (opened.body as { mtimeMs: number }).mtimeMs;
+    await writeFile(file, 'external');
+    await utimes(file, new Date(), new Date(originalMtime + 5_000));
+
+    const response = await invoke(save, {
+      path: file,
+      body: { content: 'editor', expectedMtimeMs: originalMtime },
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({ code: 'LOCAL_FILE_CHANGED' });
+    expect(await readFile(file, 'utf8')).toBe('external');
+  });
+
+  it('rejects binary data, directories, and relative paths', async () => {
+    const binary = path.join(root, 'binary.dat');
+    await writeFile(binary, Buffer.from([0x61, 0x00, 0x62]));
+    const { read } = captureHandlers();
+
+    const binaryResponse = await invoke(read, { path: binary });
+    const directoryResponse = await invoke(read, { path: root });
+    const relativeResponse = await invoke(read, { path: 'notes.txt' });
+
+    expect(binaryResponse.status).toBe(415);
+    expect(directoryResponse.status).toBe(400);
+    expect(relativeResponse.status).toBe(400);
+  });
+
+  it.skipIf(process.platform === 'win32')('refuses to follow a symbolic link', async () => {
+    const target = path.join(root, 'target.txt');
+    const link = path.join(root, 'link.txt');
+    await writeFile(target, 'secret');
+    await symlink(target, link);
+    const { read } = captureHandlers();
+
+    const response = await invoke(read, { path: link });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({ code: 'LOCAL_EDITOR_SYMLINK' });
+  });
+});

--- a/tests/unit/server/local-files.test.ts
+++ b/tests/unit/server/local-files.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, readdir, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -82,7 +82,8 @@ describe('local file editor routes', () => {
 
   it('reads UTF-8 text and saves it atomically without changing its bytes', async () => {
     const file = path.join(root, 'notes.txt');
-    await writeFile(file, 'before', { mode: 0o674 });
+    await writeFile(file, 'before');
+    if (process.platform !== 'win32') await chmod(file, 0o674);
     const { read, save } = captureHandlers();
 
     const opened = await invoke(read, { path: file });


### PR DESCRIPTION
## Summary

- recognize file paths in local and SSH terminal output and open them in Monaco with a single click and hover underline
- resolve relative and home-directory paths from shell integration while avoiding directory entries, OCI image references, and other common false positives
- open web links through the system browser in both local and remote terminals
- edit remote files through SFTP and local files through an authenticated text-file endpoint with atomic saves, modification-time conflict detection, UTF-8/binary checks, symlink protection, and an 8 MiB limit
- document the terminal editor interaction and update the in-app shortcut reference

## User impact

Files listed or referenced in a terminal can be opened directly without first navigating through the SFTP browser. The same Monaco workspace and save workflow now works for both SSH and local terminal sessions.

## Validation

- `pnpm test` — 833 passed, 3 skipped
- `pnpm build`
- `pnpm lint`
- `pnpm --filter @muxus/client check:bundle`
- `git diff --check`

Closes #90