### PR TITLE
Add synchronized multi-window workspaces

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import { BackendStatusBanner } from './components/BackendStatusBanner.js';
 import { UpdateNotification } from './components/UpdateNotification.js';
 import { useDialogStore } from './state/dialogs.js';
 import { useToastStore } from './state/toast.js';
+import type { WorkspaceInitialSelection } from './workspace-persistence.js';
 import {
   loadHostEditorDialog,
   loadFolderDialog,
@@ -105,13 +106,27 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const workspacesOpen = useUiStore((s) => s.workspacesOpen);
   const dialogOpen = useDialogStore((s) => s.queue.length > 0);
   const toastOpen = useToastStore((s) => !!s.toast);
-  const [startupReady, setStartupReady] = useState(false);
+  const [startupReady, setStartupReady] = useState(launch?.kind === 'session');
+  const [newWorkspaceId] = useState(() =>
+    launch?.kind === 'workspace' && !launch.workspaceId
+      ? (globalThis.crypto?.randomUUID?.() ??
+        `workspace-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`)
+      : undefined,
+  );
   const [osTheme, setOsTheme] = useState<'light' | 'dark'>(() =>
     window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
   );
   const finishStartup = useCallback(() => setStartupReady(true), []);
   const effectiveMode = themeMode === 'os' ? osTheme : themeMode;
   const theme = useMemo(() => buildTheme(effectiveMode), [effectiveMode]);
+  const initialWorkspace: WorkspaceInitialSelection | undefined =
+    launch?.kind === 'session'
+      ? { kind: 'blank' }
+      : launch?.kind === 'workspace'
+        ? launch.workspaceId
+          ? { kind: 'open', id: launch.workspaceId }
+          : { kind: 'new', id: newWorkspaceId!, name: launch.title }
+        : undefined;
   useLayoutEffect(() => {
     // Keep the desktop app's native window controls in sync with the theme.
     setTitleBarMode(effectiveMode);
@@ -140,7 +155,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
             <SftpWindow launch={launch} />
           </Suspense>
         ) : (
-          <AppShell persistWorkspace={!launch && startupReady} />
+          <AppShell persistWorkspace={startupReady} initialWorkspace={initialWorkspace} />
         )}
       </ErrorBoundary>
       <Suspense fallback={null}>
@@ -155,7 +170,9 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
         {logViewerOpen ? <LogViewerDialog /> : null}
         {quickLauncherOpen ? <QuickLauncherDialog /> : null}
         {workspacesOpen ? <WorkspaceDialog /> : null}
-        {!launch ? <PasswordVaultStartupUnlock onReady={finishStartup} /> : null}
+        {!launch || launch.kind === 'workspace' ? (
+          <PasswordVaultStartupUnlock onReady={finishStartup} />
+        ) : null}
         {dialogOpen ? <DialogHost /> : null}
         {toastOpen ? <ToastHost /> : null}
       </Suspense>

--- a/client/src/components/QuickLauncherDialog.tsx
+++ b/client/src/components/QuickLauncherDialog.tsx
@@ -84,7 +84,7 @@ import { useUiStore } from '../state/ui.js';
 import { useWorkspacesStore } from '../state/workspaces.js';
 import { terminalHandle } from '../terminal/terminal-registry.js';
 import { formatTimestamp } from '../time-format.js';
-import { openWorkspace } from '../workspace-persistence.js';
+import { focusOpenWorkspace, openWorkspace } from '../workspace-persistence.js';
 import {
   AuthPromptDialog,
   type AuthPromptRequest,
@@ -141,6 +141,7 @@ export function QuickLauncherDialog() {
   const workspaces = useWorkspacesStore((state) => state.workspaces);
   const activeWorkspaceId = useWorkspacesStore((state) => state.activeId);
   const workspaceBusy = useWorkspacesStore((state) => state.busy);
+  const openWorkspaceWindowCounts = useWorkspacesStore((state) => state.openWindowCounts);
   const { data: sshData, isLoading: sshLoading } = useSshConfig();
   const { data: savedData, isLoading: savedLoading } = useSavedHostProfiles();
   const { data: tunnelData, isLoading: tunnelsLoading } = useTunnels();
@@ -198,6 +199,7 @@ export function QuickLauncherDialog() {
         savedHosts,
         workspaces,
         activeWorkspaceId,
+        openWorkspaceWindowCounts,
         commands,
         localShellProfiles,
         tunnels,
@@ -210,6 +212,7 @@ export function QuickLauncherDialog() {
       activeWorkspaceId,
       commands,
       localShellProfiles,
+      openWorkspaceWindowCounts,
       forwards,
       savedHosts,
       sshHosts,
@@ -410,6 +413,9 @@ export function QuickLauncherDialog() {
         break;
       case 'workspace':
         if (result.workspace.id === activeWorkspaceId) {
+          close();
+        } else if (focusOpenWorkspace(result.workspace.id)) {
+          showToast('info', `Switched to the window showing “${result.workspace.name}”.`);
           close();
         } else if (liveCount > 0) {
           setPendingWorkspace(result.workspace);
@@ -736,6 +742,7 @@ function buildCatalogResults({
   savedHosts,
   workspaces,
   activeWorkspaceId,
+  openWorkspaceWindowCounts,
   commands,
   localShellProfiles,
   tunnels,
@@ -748,6 +755,7 @@ function buildCatalogResults({
   savedHosts: readonly SavedHostProfile[];
   workspaces: readonly WorkspaceSummary[];
   activeWorkspaceId?: string;
+  openWorkspaceWindowCounts: Readonly<Record<string, number>>;
   commands: readonly CommandButton[];
   localShellProfiles: readonly LocalShellProfileConfig[];
   tunnels: readonly TunnelRecord[];
@@ -838,6 +846,7 @@ function buildCatalogResults({
   }
 
   for (const [index, workspace] of workspaces.entries()) {
+    const otherWindowCount = openWorkspaceWindowCounts[workspace.id] ?? 0;
     results.push({
       id: `workspace:${workspace.id}`,
       kind: 'workspace',
@@ -846,6 +855,10 @@ function buildCatalogResults({
       detail:
         workspace.id === activeWorkspaceId
           ? 'Current workspace'
+          : otherWindowCount > 0
+            ? otherWindowCount === 1
+              ? 'Open in another window'
+              : `Open in ${otherWindowCount} other windows`
           : `Workspace · ${formatTimestamp(workspace.lastOpenedAt ?? workspace.updatedAt)}`,
       keywords: ['workspace', workspace.isStartup ? 'startup' : ''],
       priority: workspace.id === activeWorkspaceId ? 360 : 150,

--- a/client/src/components/WorkspaceDialog.tsx
+++ b/client/src/components/WorkspaceDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { WorkspaceSummary } from '@muxus/shared';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -22,13 +22,16 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
 import ClearIcon from '@mui/icons-material/Clear';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
 import LockOpenOutlinedIcon from '@mui/icons-material/LockOpenOutlined';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
+import RestoreOutlinedIcon from '@mui/icons-material/RestoreOutlined';
 import SaveAsOutlinedIcon from '@mui/icons-material/SaveAsOutlined';
 import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
 import SearchIcon from '@mui/icons-material/Search';
@@ -37,8 +40,11 @@ import StarBorderIcon from '@mui/icons-material/StarBorder';
 import WorkspacesOutlinedIcon from '@mui/icons-material/WorkspacesOutlined';
 import {
   deleteWorkspace,
+  focusOpenWorkspace,
   openWorkspace,
+  refreshWorkspaceCatalog,
   renameWorkspace,
+  requestWorkspacePresence,
   saveWorkspace,
   saveWorkspaceAs,
   setStartupWorkspace,
@@ -55,9 +61,11 @@ import { showErrorToast, showToast } from '../state/toast.js';
 import { useUiStore } from '../state/ui.js';
 import { useWorkspacesStore } from '../state/workspaces.js';
 import { formatTimestamp } from '../time-format.js';
+import { openAppWindow } from '../window-management.js';
 
 type NameAction =
   | { kind: 'save-as' }
+  | { kind: 'new-window' }
   | { kind: 'rename'; id: string; previousName: string };
 
 interface WorkspaceMenu {
@@ -71,6 +79,13 @@ function activityLabel(workspace: WorkspaceSummary): string {
   return `${opened ? 'Opened' : 'Updated'} ${formatTimestamp(opened ?? workspace.updatedAt)}`;
 }
 
+function nextWorkspaceName(workspaces: readonly WorkspaceSummary[]): string {
+  const names = new Set(workspaces.map((workspace) => workspace.name.trim().toLocaleLowerCase()));
+  let number = 1;
+  while (names.has(`workspace ${number}`)) number++;
+  return `Workspace ${number}`;
+}
+
 export function WorkspaceDialog() {
   const open = useUiStore((state) => state.workspacesOpen);
   const setOpen = useUiStore((state) => state.setWorkspacesOpen);
@@ -80,6 +95,8 @@ export function WorkspaceDialog() {
   const startupId = useWorkspacesStore((state) => state.startupId);
   const ready = useWorkspacesStore((state) => state.ready);
   const busy = useWorkspacesStore((state) => state.busy);
+  const error = useWorkspacesStore((state) => state.error);
+  const openWindowCounts = useWorkspacesStore((state) => state.openWindowCounts);
   const tabs = useTabsStore((state) => state.tabs);
   const reconnect = useTabsStore((state) => state.reconnect);
   const reconnectAll = useTabsStore((state) => state.reconnectAll);
@@ -104,10 +121,25 @@ export function WorkspaceDialog() {
   ).length;
   const selected = new Set(selectedIds);
   const pendingOpen = workspaces.find((workspace) => workspace.id === pendingOpenId);
+  const activeOtherWindowCount = activeId ? (openWindowCounts[activeId] ?? 0) : 0;
+  const menuWorkspaceOpenElsewhere = workspaceMenu
+    ? (openWindowCounts[workspaceMenu.workspace.id] ?? 0) > 0
+    : false;
+
+  useEffect(() => {
+    if (!open || !ready) return;
+    requestWorkspacePresence();
+    void refreshWorkspaceCatalog().catch(() => undefined);
+  }, [open, ready]);
 
   const beginSaveAs = () => {
     setNameAction({ kind: 'save-as' });
     setName(`${activeName} copy`);
+  };
+
+  const beginNewWorkspace = () => {
+    setNameAction({ kind: 'new-window' });
+    setName(nextWorkspaceName(workspaces));
   };
 
   const performSave = async () => {
@@ -133,7 +165,11 @@ export function WorkspaceDialog() {
     const trimmed = name.trim();
     if (!trimmed || !nameAction) return;
     try {
-      if (nameAction.kind === 'save-as') {
+      if (nameAction.kind === 'new-window') {
+        openAppWindow({ kind: 'workspace', title: trimmed });
+        setOpen(false);
+        showToast('info', `Creating workspace “${trimmed}” in a new window.`);
+      } else if (nameAction.kind === 'save-as') {
         await saveWorkspaceAs(trimmed);
         showToast('success', `Saved workspace “${trimmed}”.`);
       } else {
@@ -161,17 +197,61 @@ export function WorkspaceDialog() {
   const requestOpen = (id: string) => {
     setWorkspaceMenu(null);
     if (id === activeId) return;
+    const workspace = workspaces.find((candidate) => candidate.id === id);
+    if (workspace && focusOpenWorkspace(id)) {
+      setOpen(false);
+      showToast('info', `Switched to the window showing “${workspace.name}”.`);
+      return;
+    }
     if (liveCount > 0) setPendingOpenId(id);
     else void performOpen(id);
+  };
+
+  const openInNewWindow = (workspace: WorkspaceSummary) => {
+    setWorkspaceMenu(null);
+    if (focusOpenWorkspace(workspace.id)) {
+      setOpen(false);
+      showToast('info', `Switched to the window showing “${workspace.name}”.`);
+      return;
+    }
+    openAppWindow({
+      kind: 'workspace',
+      workspaceId: workspace.id,
+      title: workspace.name,
+    });
+    setOpen(false);
+  };
+
+  const performRestore = async (workspace: WorkspaceSummary) => {
+    setWorkspaceMenu(null);
+    const confirmed = await confirmAction({
+      title: `Restore “${workspace.name}” to its saved state?`,
+      description: liveCount
+        ? `This ends ${liveCount} live or connecting session${liveCount === 1 ? '' : 's'} and replaces the current layout with the locked saved layout.`
+        : 'This replaces the current layout with the locked saved layout.',
+      confirmLabel: 'Restore',
+    });
+    if (!confirmed || !(await confirmDiscardRemoteEditors(tabs.map((tab) => tab.id)))) return;
+    try {
+      const restored = await openWorkspace(workspace.id);
+      setPendingOpenId(undefined);
+      setSelectedIds([]);
+      showToast('success', `Restored workspace “${restored.name}”.`);
+    } catch (error) {
+      showErrorToast(error);
+    }
   };
 
   const performDelete = async (workspace: WorkspaceSummary) => {
     setWorkspaceMenu(null);
     setPendingOpenId(undefined);
+    const otherWindowCount = openWindowCounts[workspace.id] ?? 0;
     const confirmed = await confirmAction({
       title: `Delete workspace “${workspace.name}”?`,
       description:
-        workspace.id === activeId
+        otherWindowCount > 0
+          ? `This workspace is open in ${otherWindowCount === 1 ? 'another window' : `${otherWindowCount} other windows`}. Its saved layout will be removed; sessions in every window stay open as an unsaved workspace.`
+          : workspace.id === activeId
           ? 'The saved layout is removed and the current layout becomes unsaved. Open sessions keep running.'
           : 'The saved layout and its multi-execution groups are removed. This cannot be undone.',
       confirmLabel: 'Delete',
@@ -250,6 +330,18 @@ export function WorkspaceDialog() {
         />
       </DialogTitle>
       <DialogContent dividers sx={{ p: 0 }}>
+        {error ? (
+          <Alert severity="warning" sx={{ borderRadius: 0 }}>
+            {error}
+          </Alert>
+        ) : null}
+        {activeOtherWindowCount > 0 ? (
+          <Alert severity="warning" sx={{ borderRadius: 0 }}>
+            “{activeName}” is also open in {activeOtherWindowCount}{' '}
+            {activeOtherWindowCount === 1 ? 'other window' : 'other windows'}. Continue in one
+            window to avoid competing saves.
+          </Alert>
+        ) : null}
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           spacing={1}
@@ -271,6 +363,15 @@ export function WorkspaceDialog() {
           <Stack direction="row" useFlexGap spacing={1} sx={{ flexWrap: 'wrap' }}>
             <Button
               size="small"
+              variant="contained"
+              startIcon={<AddIcon />}
+              disabled={!ready || busy}
+              onClick={beginNewWorkspace}
+            >
+              New workspace
+            </Button>
+            <Button
+              size="small"
               startIcon={<SaveOutlinedIcon />}
               disabled={!activeWorkspace || busy}
               onClick={() => void performSave()}
@@ -285,6 +386,18 @@ export function WorkspaceDialog() {
             >
               Save as
             </Button>
+            {activeWorkspace?.isLocked ? (
+              <Tooltip title="Discard changes and reload the locked saved layout">
+                <Button
+                  size="small"
+                  startIcon={<RestoreOutlinedIcon />}
+                  disabled={busy}
+                  onClick={() => void performRestore(activeWorkspace)}
+                >
+                  Restore
+                </Button>
+              </Tooltip>
+            ) : null}
             <Tooltip
               title={
                 activeWorkspace?.isLocked
@@ -330,9 +443,9 @@ export function WorkspaceDialog() {
               fullWidth
               size="small"
               label={
-                nameAction.kind === 'save-as'
-                  ? 'New workspace name'
-                  : `Rename “${nameAction.previousName}”`
+                nameAction.kind === 'rename'
+                  ? `Rename “${nameAction.previousName}”`
+                  : 'New workspace name'
               }
               value={name}
               onChange={(event) => setName(event.target.value)}
@@ -347,7 +460,11 @@ export function WorkspaceDialog() {
                 disabled={!name.trim() || busy}
                 onClick={() => void commitNameAction()}
               >
-                {nameAction.kind === 'save-as' ? 'Save' : 'Rename'}
+                {nameAction.kind === 'new-window'
+                  ? 'Create'
+                  : nameAction.kind === 'save-as'
+                    ? 'Save'
+                    : 'Rename'}
               </Button>
               <Button onClick={() => setNameAction(null)}>Cancel</Button>
             </Stack>
@@ -442,6 +559,7 @@ export function WorkspaceDialog() {
           {visibleWorkspaces.map((workspace) => {
             const isActive = workspace.id === activeId;
             const isStartup = workspace.id === startupId;
+            const otherWindowCount = openWindowCounts[workspace.id] ?? 0;
             return (
               <ListItemButton
                 key={workspace.id}
@@ -451,6 +569,8 @@ export function WorkspaceDialog() {
                 aria-label={
                   isActive
                     ? `${workspace.name}, currently open`
+                    : otherWindowCount > 0
+                      ? `Switch to the window showing ${workspace.name}`
                     : `Open workspace ${workspace.name}`
                 }
                 sx={{
@@ -509,11 +629,48 @@ export function WorkspaceDialog() {
                           variant="outlined"
                         />
                       ) : null}
+                      {otherWindowCount > 0 ? (
+                        <Chip
+                          size="small"
+                          label={
+                            otherWindowCount === 1
+                              ? 'Open in another window'
+                              : `Open in ${otherWindowCount} other windows`
+                          }
+                          icon={<OpenInNewIcon />}
+                          color="info"
+                          variant="outlined"
+                        />
+                      ) : null}
                     </Stack>
                   }
                   secondary={activityLabel(workspace)}
                   slotProps={{ secondary: { noWrap: true } }}
                 />
+                {!isActive ? (
+                  <Tooltip
+                    title={
+                      otherWindowCount > 0
+                        ? `Switch to the window showing ${workspace.name}`
+                        : `Open ${workspace.name} in a new window`
+                    }
+                  >
+                    <IconButton
+                      size="small"
+                      aria-label={
+                        otherWindowCount > 0
+                          ? `Switch to the window showing ${workspace.name}`
+                          : `Open ${workspace.name} in a new window`
+                      }
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        openInNewWindow(workspace);
+                      }}
+                    >
+                      <OpenInNewIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                ) : null}
                 <Tooltip title={`Actions for ${workspace.name}`}>
                   <IconButton
                     size="small"
@@ -637,12 +794,27 @@ export function WorkspaceDialog() {
           open
           onClose={() => setWorkspaceMenu(null)}
         >
-          {workspaceMenu.workspace.id !== activeId ? (
+          {workspaceMenu.workspace.id !== activeId && !menuWorkspaceOpenElsewhere ? (
             <MenuItem onClick={() => requestOpen(workspaceMenu.workspace.id)}>
               <ListItemIcon>
                 <PlayArrowOutlinedIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText>Open</ListItemText>
+            </MenuItem>
+          ) : null}
+          {workspaceMenu.workspace.id !== activeId ? (
+            <MenuItem
+              disabled={busy}
+              onClick={() => openInNewWindow(workspaceMenu.workspace)}
+            >
+              <ListItemIcon>
+                <OpenInNewIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>
+                {menuWorkspaceOpenElsewhere
+                  ? 'Switch to open window'
+                  : 'Open in new window'}
+              </ListItemText>
             </MenuItem>
           ) : null}
           <MenuItem

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -34,7 +34,11 @@ declare global {
       /** Open a secondary native application window. */
       openWindow(launch: AppWindowLaunch): void;
       /** Register the saved workspace currently owned by this native window. */
-      setActiveWorkspace(workspaceId?: string): void;
+      setActiveWorkspace(
+        workspaceId?: string,
+        workspaceTitle?: string,
+        clearReloadLaunch?: boolean,
+      ): void;
       /** Bring this native window to the foreground. */
       focusWindow(): void;
       /** Subscribe to the OS close-window chord (Cmd/Ctrl+W); returns unsubscribe. */

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -33,6 +33,10 @@ declare global {
       listLocalFontFamilies(): Promise<string[] | undefined>;
       /** Open a secondary native application window. */
       openWindow(launch: AppWindowLaunch): void;
+      /** Register the saved workspace currently owned by this native window. */
+      setActiveWorkspace(workspaceId?: string): void;
+      /** Bring this native window to the foreground. */
+      focusWindow(): void;
       /** Subscribe to the OS close-window chord (Cmd/Ctrl+W); returns unsubscribe. */
       onCloseTab(callback: () => void): () => void;
       /** Subscribe to the tab-cycling chords (Ctrl+Tab & friends); backwards=true cycles left. */

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -27,7 +27,10 @@ import {
   type SplitNode,
 } from '../state/workspace-layout.js';
 import { useUiStore } from '../state/ui.js';
-import { useWorkspacePersistence } from '../workspace-persistence.js';
+import {
+  useWorkspacePersistence,
+  type WorkspaceInitialSelection,
+} from '../workspace-persistence.js';
 import { ErrorBoundary } from '../components/ErrorBoundary.js';
 import { ActionBar } from '../components/ActionBar.js';
 import { EmptyPane } from '../components/EmptyPane.js';
@@ -54,8 +57,14 @@ const RemoteEditorWorkspace = lazy(() =>
 );
 
 /** TopBar over a stable, resizable pane canvas. Hidden tabs stay mounted. */
-export function AppShell({ persistWorkspace = true }: { persistWorkspace?: boolean }) {
-  useWorkspacePersistence(persistWorkspace);
+export function AppShell({
+  persistWorkspace = true,
+  initialWorkspace,
+}: {
+  persistWorkspace?: boolean;
+  initialWorkspace?: WorkspaceInitialSelection;
+}) {
+  useWorkspacePersistence(persistWorkspace, initialWorkspace);
   const sidebarCollapsed = usePrefsStore((state) => state.sidebarCollapsed);
   const tabs = useTabsStore((state) => state.tabs);
   const root = useTabsStore((state) => state.root);

--- a/client/src/state/workspaces.ts
+++ b/client/src/state/workspaces.ts
@@ -8,6 +8,8 @@ interface WorkspacesState {
   startupId?: string;
   ready: boolean;
   busy: boolean;
+  /** Number of other application windows currently showing each workspace. */
+  openWindowCounts: Record<string, number>;
   error?: string;
 }
 
@@ -17,4 +19,5 @@ export const useWorkspacesStore = create<WorkspacesState>()(() => ({
   activeName: 'Unsaved workspace',
   ready: false,
   busy: false,
+  openWindowCounts: {},
 }));

--- a/client/src/window-management.ts
+++ b/client/src/window-management.ts
@@ -20,6 +20,17 @@ function decodeBase64Url(value: string): string {
 export function isAppWindowLaunch(value: unknown): value is AppWindowLaunch {
   if (!value || typeof value !== 'object') return false;
   const launch = value as Record<string, unknown>;
+  if (launch.kind === 'workspace') {
+    return (
+      typeof launch.title === 'string' &&
+      launch.title.length > 0 &&
+      launch.title.length <= 200 &&
+      (launch.workspaceId === undefined ||
+        (typeof launch.workspaceId === 'string' &&
+          launch.workspaceId.length > 0 &&
+          launch.workspaceId.length <= 200))
+    );
+  }
   if (launch.kind === 'session') {
     if (typeof launch.title !== 'string' || !launch.profile || typeof launch.profile !== 'object') {
       return false;

--- a/client/src/workspace-persistence.ts
+++ b/client/src/workspace-persistence.ts
@@ -380,7 +380,7 @@ export class WorkspaceRuntime {
         error: undefined,
       }));
       const nextActive = useWorkspacesStore.getState();
-      this.updateActiveWorkspace(nextActive.activeId, nextActive.activeName);
+      this.updateActiveWorkspace(nextActive.activeId, nextActive.activeName, id === activeId);
       this.sync.invalidateCatalog();
     });
   }
@@ -474,11 +474,15 @@ export class WorkspaceRuntime {
       startupId: workspaces.find((workspace) => workspace.isStartup)?.id,
       error: message,
     });
-    this.updateActiveWorkspace(undefined, 'Unsaved workspace');
+    this.updateActiveWorkspace(undefined, 'Unsaved workspace', true);
   }
 
-  private updateActiveWorkspace(id: string | undefined, name: string): void {
-    this.sync.setActiveWorkspace(id);
+  private updateActiveWorkspace(
+    id: string | undefined,
+    name: string,
+    clearReloadLaunch = false,
+  ): void {
+    this.sync.setActiveWorkspace(id, name, clearReloadLaunch);
     if (typeof document === 'undefined') return;
     if (id) document.title = `${name} — Muxus`;
     else if (document.title.endsWith(' — Muxus')) document.title = 'Muxus';

--- a/client/src/workspace-persistence.ts
+++ b/client/src/workspace-persistence.ts
@@ -11,6 +11,7 @@ import { usePrefsStore } from './state/prefs.js';
 import { useTabsStore, type SessionTab } from './state/tabs.js';
 import { serializeWorkspace } from './state/workspace-layout.js';
 import { useWorkspacesStore } from './state/workspaces.js';
+import { WorkspaceWindowSync } from './workspace-sync.js';
 import {
   PAGE_KEEPALIVE_BODY_LIMIT_BYTES,
   registerUnloadKeepalive,
@@ -27,6 +28,11 @@ interface WorkspaceSnapshot {
   multiExecGroups: WorkspaceMultiExecGroup[];
   serialized: string;
 }
+
+export type WorkspaceInitialSelection =
+  | { kind: 'blank' }
+  | { kind: 'new'; id: string; name: string }
+  | { kind: 'open'; id: string };
 
 function currentSnapshot(): WorkspaceSnapshot {
   const { root, tabs, activePaneId } = useTabsStore.getState();
@@ -72,40 +78,83 @@ export class WorkspaceRuntime {
   private unsubscribeTabs?: () => void;
   private unsubscribeMultiExec?: () => void;
   private lastSerialized = '';
+  private refreshing?: Promise<void>;
+  private refreshQueued = false;
+
+  constructor(
+    private readonly initialSelection?: WorkspaceInitialSelection,
+    private readonly sync = new WorkspaceWindowSync(),
+  ) {}
 
   async start(): Promise<void> {
     const beforeLoad = currentSnapshot().serialized;
+    let catalogChangedOnStart = false;
     try {
-      const [catalog, startup, latest] = await Promise.all([
-        apiFetch<{ workspaces: WorkspaceSummary[] }>('/api/workspaces'),
-        apiFetch<{ workspace: WorkspaceRecord | null }>('/api/workspaces/startup'),
-        apiFetch<{ workspace: WorkspaceRecord | null }>('/api/workspaces/latest'),
-      ]);
+      const catalogRequest = apiFetch<{ workspaces: WorkspaceSummary[] }>('/api/workspaces');
+      let catalog: { workspaces: WorkspaceSummary[] };
+      let workspace: WorkspaceRecord | null;
+      let persistedSource = '';
+      let restoreSavedLayout = true;
+
+      if (this.initialSelection?.kind === 'new') {
+        catalog = await catalogRequest;
+        if (this.stopped) return;
+        const snapshot = currentSnapshot();
+        workspace = await apiFetch<WorkspaceRecord>('/api/workspaces', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            id: this.initialSelection.id,
+            createIfMissing: true,
+            name: this.initialSelection.name.trim(),
+            layout: snapshot.layout,
+            multiExecGroups: snapshot.multiExecGroups,
+          }),
+        });
+        catalogChangedOnStart = true;
+        persistedSource = snapshot.serialized;
+        restoreSavedLayout = false;
+      } else if (this.initialSelection?.kind === 'open') {
+        [catalog, workspace] = await Promise.all([
+          catalogRequest,
+          apiFetch<WorkspaceRecord>(
+            `/api/workspaces/${encodeURIComponent(this.initialSelection.id)}`,
+          ),
+        ]);
+      } else if (this.initialSelection?.kind === 'blank') {
+        catalog = await catalogRequest;
+        workspace = null;
+      } else {
+        const [loadedCatalog, startup, latest] = await Promise.all([
+          catalogRequest,
+          apiFetch<{ workspace: WorkspaceRecord | null }>('/api/workspaces/startup'),
+          apiFetch<{ workspace: WorkspaceRecord | null }>('/api/workspaces/latest'),
+        ]);
+        catalog = loadedCatalog;
+        workspace = startup.workspace ?? latest.workspace;
+      }
       if (this.stopped) return;
-      const workspace = startup.workspace ?? latest.workspace;
       let summaries = catalog.workspaces;
-      let restoredSource = '';
-      let restored = false;
 
       if (workspace) {
+        persistedSource ||= JSON.stringify({
+          layout: workspace.layout,
+          multiExecGroups: workspace.multiExecGroups,
+        });
         const state = useTabsStore.getState();
         // Do not clobber a session the user opened while startup requests were in flight.
-        if (state.tabs.length === 0 && state.root.type === 'pane') {
+        if (restoreSavedLayout && state.tabs.length === 0 && state.root.type === 'pane') {
           this.restoring = true;
-          restoredSource = JSON.stringify({
-            layout: workspace.layout,
-            multiExecGroups: workspace.multiExecGroups,
-          });
           state.restore(workspace.layout, restoreOptions());
           useMultiExecStore.getState().setGroups(workspace.multiExecGroups);
           this.restoring = false;
-          restored = true;
         }
         const opened = await apiFetch<WorkspaceRecord>(
           `/api/workspaces/${encodeURIComponent(workspace.id)}/open`,
           { method: 'POST' },
         );
         if (this.stopped) return;
+        catalogChangedOnStart = true;
         summaries = mergeSummary(summaries, opened);
         useWorkspacesStore.setState({
           workspaces: summaries,
@@ -127,12 +176,11 @@ export class WorkspaceRuntime {
       }
 
       const loaded = currentSnapshot();
-      this.lastSerialized = restored && workspace?.isLocked ? restoredSource : loaded.serialized;
-      if (
-        !workspace?.isLocked &&
-        ((restored && restoredSource !== loaded.serialized) ||
-          (!restored && loaded.serialized !== beforeLoad))
-      ) {
+      this.lastSerialized = workspace?.isLocked ? persistedSource : loaded.serialized;
+      const changedSincePersist = workspace
+        ? persistedSource !== loaded.serialized
+        : loaded.serialized !== beforeLoad;
+      if (!workspace?.isLocked && changedSincePersist) {
         this.pending = loaded;
         this.schedule();
       }
@@ -146,6 +194,8 @@ export class WorkspaceRuntime {
     if (this.stopped) return;
     this.unsubscribeTabs = useTabsStore.subscribe(() => this.handleChange());
     this.unsubscribeMultiExec = useMultiExecStore.subscribe(() => this.handleChange());
+    this.startSync();
+    if (catalogChangedOnStart) this.sync.invalidateCatalog();
   }
 
   stop(): void {
@@ -154,6 +204,7 @@ export class WorkspaceRuntime {
     if (this.timer) clearTimeout(this.timer);
     this.unsubscribeTabs?.();
     this.unsubscribeMultiExec?.();
+    this.sync.stop();
   }
 
   async saveAs(name: string): Promise<WorkspaceRecord> {
@@ -273,6 +324,7 @@ export class WorkspaceRuntime {
           isStartup: candidate.id === workspace?.id,
         })),
       }));
+      this.sync.invalidateCatalog();
     });
   }
 
@@ -327,7 +379,109 @@ export class WorkspaceRuntime {
         ...(id === state.startupId ? { startupId: undefined } : {}),
         error: undefined,
       }));
+      const nextActive = useWorkspacesStore.getState();
+      this.updateActiveWorkspace(nextActive.activeId, nextActive.activeName);
+      this.sync.invalidateCatalog();
     });
+  }
+
+  async refreshCatalog(): Promise<void> {
+    if (this.stopped) return;
+    if (this.refreshing) {
+      this.refreshQueued = true;
+      return this.refreshing;
+    }
+    const refresh = (async () => {
+      do {
+        this.refreshQueued = false;
+        const catalog = await apiFetch<{ workspaces: WorkspaceSummary[] }>('/api/workspaces');
+        if (this.stopped) return;
+        this.reconcileCatalog(catalog.workspaces);
+      } while (this.refreshQueued && !this.stopped);
+    })();
+    this.refreshing = refresh;
+    try {
+      await refresh;
+    } finally {
+      if (this.refreshing === refresh) this.refreshing = undefined;
+    }
+  }
+
+  focusOpenWorkspace(id: string): boolean {
+    return this.sync.focusOpenWorkspace(id);
+  }
+
+  requestWorkspacePresence(): void {
+    this.sync.requestPresence();
+  }
+
+  private startSync(): void {
+    const { activeId, activeName } = useWorkspacesStore.getState();
+    this.updateActiveWorkspace(activeId, activeName);
+    this.sync.start({
+      onCatalogChanged: () => void this.refreshCatalog().catch(() => undefined),
+      onOpenWindowCountsChanged: (openWindowCounts) => {
+        useWorkspacesStore.setState({ openWindowCounts });
+      },
+      onWindowFocus: () => void this.refreshCatalog().catch(() => undefined),
+      onFocusRequested: () => {
+        if (typeof window === 'undefined') return;
+        if (window.muxusDesktop) window.muxusDesktop.focusWindow();
+        else window.focus();
+      },
+    });
+  }
+
+  private reconcileCatalog(workspaces: WorkspaceSummary[]): void {
+    const previous = useWorkspacesStore.getState();
+    const active = workspaces.find((workspace) => workspace.id === previous.activeId);
+    const previousActive = previous.workspaces.find(
+      (workspace) => workspace.id === previous.activeId,
+    );
+    if (previous.activeId && !active) {
+      this.detachActiveWorkspace(
+        workspaces,
+        `Workspace “${previous.activeName}” was deleted in another window. Current sessions remain open as an unsaved workspace.`,
+      );
+      return;
+    }
+
+    useWorkspacesStore.setState({
+      workspaces,
+      activeName: active?.name ?? previous.activeName,
+      startupId: workspaces.find((workspace) => workspace.isStartup)?.id,
+      error: undefined,
+    });
+    if (active) this.updateActiveWorkspace(active.id, active.name);
+    if (active?.isLocked && !previousActive?.isLocked) {
+      if (this.timer) clearTimeout(this.timer);
+      this.timer = undefined;
+      this.pending = undefined;
+    } else if (active && !active.isLocked && previousActive?.isLocked) {
+      this.handleChange();
+    }
+  }
+
+  private detachActiveWorkspace(workspaces: WorkspaceSummary[], message: string): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+    this.pending = undefined;
+    this.lastSerialized = currentSnapshot().serialized;
+    useWorkspacesStore.setState({
+      workspaces,
+      activeId: undefined,
+      activeName: 'Unsaved workspace',
+      startupId: workspaces.find((workspace) => workspace.isStartup)?.id,
+      error: message,
+    });
+    this.updateActiveWorkspace(undefined, 'Unsaved workspace');
+  }
+
+  private updateActiveWorkspace(id: string | undefined, name: string): void {
+    this.sync.setActiveWorkspace(id);
+    if (typeof document === 'undefined') return;
+    if (id) document.title = `${name} — Muxus`;
+    else if (document.title.endsWith(' — Muxus')) document.title = 'Muxus';
   }
 
   private handleChange(): void {
@@ -374,6 +528,16 @@ export class WorkspaceRuntime {
     })
       .then((saved) => this.recordActive(saved))
       .catch((error: unknown) => {
+        if (error instanceof ApiError && error.status === 404 && activeId) {
+          const state = useWorkspacesStore.getState();
+          if (state.activeId === activeId) {
+            this.detachActiveWorkspace(
+              state.workspaces.filter((workspace) => workspace.id !== activeId),
+              `Workspace “${activeName}” was deleted in another window. Current sessions remain open as an unsaved workspace.`,
+            );
+          }
+          return;
+        }
         if (error instanceof ApiError && error.body?.code === 'workspace-locked') {
           // handleChange() already recorded this snapshot as observed. Mark it dirty
           // again so unlocking requeues it even when no further edits are made.
@@ -417,6 +581,8 @@ export class WorkspaceRuntime {
       startupId: workspace.isStartup ? workspace.id : state.startupId,
       error: undefined,
     }));
+    this.updateActiveWorkspace(workspace.id, workspace.name);
+    this.sync.invalidateCatalog();
   }
 
   private recordWorkspace(workspace: WorkspaceRecord): void {
@@ -425,6 +591,7 @@ export class WorkspaceRuntime {
       startupId: workspace.isStartup ? workspace.id : state.startupId,
       error: undefined,
     }));
+    this.sync.invalidateCatalog();
   }
 
   private activeWorkspaceIsLocked(): boolean {
@@ -486,12 +653,28 @@ export const setStartupWorkspace = (id: string | null) => runtime().setStartup(i
 export const setWorkspaceLocked = (id: string, isLocked: boolean) =>
   runtime().setLocked(id, isLocked);
 export const deleteWorkspace = (id: string) => runtime().delete(id);
+export const refreshWorkspaceCatalog = () => runtime().refreshCatalog();
+export const focusOpenWorkspace = (id: string) => runtime().focusOpenWorkspace(id);
+export const requestWorkspacePresence = () => runtime().requestWorkspacePresence();
 
 /** Restore startup/latest once, then debounce the active named workspace to SQLite. */
-export function useWorkspacePersistence(enabled = true): void {
+export function useWorkspacePersistence(
+  enabled = true,
+  initialSelection?: WorkspaceInitialSelection,
+): void {
+  const initialKind = initialSelection?.kind;
+  const initialId = initialSelection?.kind === 'blank' ? undefined : initialSelection?.id;
+  const initialName = initialSelection?.kind === 'new' ? initialSelection.name : undefined;
   useEffect(() => {
     if (!enabled) return;
-    const runtime = new WorkspaceRuntime();
+    const selection: WorkspaceInitialSelection | undefined = initialKind
+      ? initialKind === 'open'
+        ? { kind: 'open', id: initialId! }
+        : initialKind === 'new'
+          ? { kind: 'new', id: initialId!, name: initialName! }
+          : { kind: 'blank' }
+      : undefined;
+    const runtime = new WorkspaceRuntime(selection);
     activeRuntime = runtime;
     const unregisterUnloadFlush = registerUnloadKeepalive(
       (maxBodyBytes) => runtime.flushOnUnload(maxBodyBytes),
@@ -503,5 +686,5 @@ export function useWorkspacePersistence(enabled = true): void {
       runtime.stop();
       if (activeRuntime === runtime) activeRuntime = undefined;
     };
-  }, [enabled]);
+  }, [enabled, initialId, initialKind, initialName]);
 }

--- a/client/src/workspace-sync.ts
+++ b/client/src/workspace-sync.ts
@@ -109,17 +109,24 @@ export class WorkspaceWindowSync {
       window.removeEventListener('storage', this.handleStorage);
       window.removeEventListener('focus', this.handleFocus);
       window.removeEventListener('pagehide', this.handlePageHide);
-      window.muxusDesktop?.setActiveWorkspace(undefined);
     }
     this.remotes.clear();
     this.publishCounts();
   }
 
-  setActiveWorkspace(workspaceId?: string): void {
+  setActiveWorkspace(
+    workspaceId?: string,
+    workspaceTitle?: string,
+    clearReloadLaunch = false,
+  ): void {
     const changed = workspaceId !== this.activeWorkspaceId;
     this.activeWorkspaceId = workspaceId;
     if (typeof window !== 'undefined') {
-      window.muxusDesktop?.setActiveWorkspace(workspaceId);
+      window.muxusDesktop?.setActiveWorkspace(
+        workspaceId,
+        workspaceTitle,
+        clearReloadLaunch,
+      );
     }
     if (changed) this.announcePresence();
   }

--- a/client/src/workspace-sync.ts
+++ b/client/src/workspace-sync.ts
@@ -1,0 +1,252 @@
+const CHANNEL_NAME = 'muxus-workspaces-v1';
+const STORAGE_KEY = 'muxus-workspaces-sync-v1';
+const HEARTBEAT_MS = 5_000;
+const PRESENCE_TTL_MS = 20_000;
+
+type WorkspaceSyncMessage =
+  | { kind: 'catalog-changed'; senderId: string }
+  | { kind: 'presence-request'; senderId: string }
+  | { kind: 'presence'; senderId: string; workspaceId?: string }
+  | { kind: 'focus'; senderId: string; targetId: string; workspaceId: string }
+  | { kind: 'goodbye'; senderId: string };
+
+interface RemotePresence {
+  workspaceId?: string;
+  lastSeen: number;
+}
+
+export interface WorkspaceSyncCallbacks {
+  onCatalogChanged: () => void;
+  onOpenWindowCountsChanged: (counts: Record<string, number>) => void;
+  onWindowFocus: () => void;
+  onFocusRequested: () => void;
+}
+
+interface SyncEnvelope {
+  nonce: string;
+  message: WorkspaceSyncMessage;
+}
+
+function randomId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
+function isWorkspaceSyncMessage(value: unknown): value is WorkspaceSyncMessage {
+  if (!value || typeof value !== 'object') return false;
+  const message = value as Record<string, unknown>;
+  if (typeof message.kind !== 'string' || typeof message.senderId !== 'string') return false;
+  if (message.kind === 'catalog-changed' || message.kind === 'presence-request' || message.kind === 'goodbye') {
+    return true;
+  }
+  if (message.kind === 'presence') {
+    return message.workspaceId === undefined || typeof message.workspaceId === 'string';
+  }
+  return (
+    message.kind === 'focus' &&
+    typeof message.targetId === 'string' &&
+    typeof message.workspaceId === 'string'
+  );
+}
+
+function defaultChannel(): BroadcastChannel | undefined {
+  if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') return undefined;
+  try {
+    return new BroadcastChannel(CHANNEL_NAME);
+  } catch {
+    return undefined;
+  }
+}
+
+/** One cross-window workspace bus. Each renderer owns exactly one instance. */
+export class WorkspaceWindowSync {
+  readonly windowId = randomId();
+  private readonly remotes = new Map<string, RemotePresence>();
+  private channel?: BroadcastChannel;
+  private callbacks?: WorkspaceSyncCallbacks;
+  private activeWorkspaceId?: string;
+  private heartbeat?: ReturnType<typeof setInterval>;
+  private started = false;
+  private lastCounts = '';
+
+  constructor(private readonly suppliedChannel?: BroadcastChannel) {}
+
+  start(callbacks: WorkspaceSyncCallbacks): void {
+    if (this.started) return;
+    this.started = true;
+    this.callbacks = callbacks;
+    this.channel = this.suppliedChannel ?? defaultChannel();
+    this.channel?.addEventListener('message', this.handleChannelMessage);
+    if (!this.channel && typeof window !== 'undefined') {
+      window.addEventListener('storage', this.handleStorage);
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('focus', this.handleFocus);
+      window.addEventListener('pagehide', this.handlePageHide);
+    }
+    if (this.channel || typeof window !== 'undefined') {
+      this.heartbeat = setInterval(() => {
+        this.removeStalePresence();
+        this.announcePresence();
+      }, HEARTBEAT_MS);
+    }
+    this.post({ kind: 'presence-request', senderId: this.windowId });
+    this.announcePresence();
+  }
+
+  stop(): void {
+    if (!this.started) return;
+    this.post({ kind: 'goodbye', senderId: this.windowId });
+    this.started = false;
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    this.heartbeat = undefined;
+    this.channel?.removeEventListener('message', this.handleChannelMessage);
+    this.channel?.close();
+    this.channel = undefined;
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('storage', this.handleStorage);
+      window.removeEventListener('focus', this.handleFocus);
+      window.removeEventListener('pagehide', this.handlePageHide);
+      window.muxusDesktop?.setActiveWorkspace(undefined);
+    }
+    this.remotes.clear();
+    this.publishCounts();
+  }
+
+  setActiveWorkspace(workspaceId?: string): void {
+    const changed = workspaceId !== this.activeWorkspaceId;
+    this.activeWorkspaceId = workspaceId;
+    if (typeof window !== 'undefined') {
+      window.muxusDesktop?.setActiveWorkspace(workspaceId);
+    }
+    if (changed) this.announcePresence();
+  }
+
+  invalidateCatalog(): void {
+    this.post({ kind: 'catalog-changed', senderId: this.windowId });
+  }
+
+  requestPresence(): void {
+    this.removeStalePresence();
+    this.post({ kind: 'presence-request', senderId: this.windowId });
+    this.announcePresence();
+  }
+
+  focusOpenWorkspace(workspaceId: string): boolean {
+    this.removeStalePresence();
+    const target = [...this.remotes.entries()]
+      .filter(([, presence]) => presence.workspaceId === workspaceId)
+      .sort((left, right) => right[1].lastSeen - left[1].lastSeen)[0];
+    if (!target) return false;
+    this.post({
+      kind: 'focus',
+      senderId: this.windowId,
+      targetId: target[0],
+      workspaceId,
+    });
+    return true;
+  }
+
+  openWindowCounts(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const presence of this.remotes.values()) {
+      if (!presence.workspaceId) continue;
+      counts[presence.workspaceId] = (counts[presence.workspaceId] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  private readonly handleChannelMessage = (event: MessageEvent<WorkspaceSyncMessage>): void => {
+    this.handleMessage(event.data);
+  };
+
+  private readonly handleStorage = (event: StorageEvent): void => {
+    if (event.key !== STORAGE_KEY || !event.newValue) return;
+    try {
+      const envelope = JSON.parse(event.newValue) as SyncEnvelope;
+      this.handleMessage(envelope.message);
+    } catch {
+      // Ignore malformed or unrelated local-storage traffic.
+    }
+  };
+
+  private readonly handleFocus = (): void => {
+    this.requestPresence();
+    this.callbacks?.onWindowFocus();
+  };
+
+  private readonly handlePageHide = (): void => {
+    this.post({ kind: 'goodbye', senderId: this.windowId });
+  };
+
+  private handleMessage(value: unknown): void {
+    if (!isWorkspaceSyncMessage(value) || value.senderId === this.windowId) return;
+    if (value.kind === 'catalog-changed') {
+      this.callbacks?.onCatalogChanged();
+      return;
+    }
+    if (value.kind === 'presence-request') {
+      this.announcePresence();
+      return;
+    }
+    if (value.kind === 'goodbye') {
+      if (this.remotes.delete(value.senderId)) this.publishCounts();
+      return;
+    }
+    if (value.kind === 'focus') {
+      if (value.targetId === this.windowId && value.workspaceId === this.activeWorkspaceId) {
+        this.callbacks?.onFocusRequested();
+      }
+      return;
+    }
+    this.remotes.set(value.senderId, {
+      workspaceId: value.workspaceId,
+      lastSeen: Date.now(),
+    });
+    this.publishCounts();
+  }
+
+  private announcePresence(): void {
+    this.post({
+      kind: 'presence',
+      senderId: this.windowId,
+      workspaceId: this.activeWorkspaceId,
+    });
+  }
+
+  private removeStalePresence(): void {
+    const cutoff = Date.now() - PRESENCE_TTL_MS;
+    let changed = false;
+    for (const [windowId, presence] of this.remotes) {
+      if (presence.lastSeen >= cutoff) continue;
+      this.remotes.delete(windowId);
+      changed = true;
+    }
+    if (changed) this.publishCounts();
+  }
+
+  private publishCounts(): void {
+    const counts = this.openWindowCounts();
+    const serialized = JSON.stringify(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+    if (serialized === this.lastCounts) return;
+    this.lastCounts = serialized;
+    this.callbacks?.onOpenWindowCountsChanged(counts);
+  }
+
+  private post(message: WorkspaceSyncMessage): void {
+    if (!this.started) return;
+    if (this.channel) {
+      this.channel.postMessage(message);
+      return;
+    }
+    if (typeof window === 'undefined') return;
+    try {
+      const envelope: SyncEnvelope = { nonce: randomId(), message };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(envelope));
+    } catch {
+      // Focus refresh remains as the final consistency fallback.
+    }
+  }
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -72,6 +72,7 @@ let primaryWindow: BrowserWindow | undefined;
 let appUrl: string | undefined;
 const managedWindows = new Set<BrowserWindow>();
 const windowLaunches = new Map<number, AppWindowLaunch>();
+const activeWorkspaceByWebContents = new Map<number, string>();
 let server: RunningServer | undefined;
 let closing: Promise<void> | undefined;
 let updateCheck: Promise<UpdateCheckResult> | undefined;
@@ -319,6 +320,7 @@ function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
   win.on('closed', () => {
     managedWindows.delete(win);
     windowLaunches.delete(webContentsId);
+    activeWorkspaceByWebContents.delete(webContentsId);
     if (primaryWindow === win) primaryWindow = undefined;
   });
   // A dead renderer looks like "the app won't start" — leave its exit trace.
@@ -437,7 +439,42 @@ ipcMain.on('muxus:open-window', (event, value: unknown) => {
   if (!isManagedWindowSender(event) || !appUrl) return;
   const launch = parseWindowLaunch(value);
   if (!launch) return;
+  if (launch.kind === 'workspace' && launch.workspaceId) {
+    const existing = [...managedWindows].find((candidate) => {
+      const webContentsId = candidate.webContents.id;
+      if (activeWorkspaceByWebContents.get(webContentsId) === launch.workspaceId) return true;
+      const pending = windowLaunches.get(webContentsId);
+      return pending?.kind === 'workspace' && pending.workspaceId === launch.workspaceId;
+    });
+    if (existing) {
+      if (existing.isMinimized()) existing.restore();
+      existing.show();
+      existing.focus();
+      return;
+    }
+  }
   createWindow(appUrl, launch);
+});
+
+ipcMain.on('muxus:active-workspace', (event, value: unknown) => {
+  if (!isManagedWindowSender(event)) return;
+  // Once the renderer reports live ownership, the boot launch is no longer a
+  // reliable description of this window (the user may switch workspaces).
+  windowLaunches.delete(event.sender.id);
+  if (value === undefined || value === null) {
+    activeWorkspaceByWebContents.delete(event.sender.id);
+    return;
+  }
+  if (typeof value !== 'string' || value.length === 0 || value.length > 200) return;
+  activeWorkspaceByWebContents.set(event.sender.id, value);
+});
+
+ipcMain.on('muxus:focus-window', (event) => {
+  const win = senderWindow(event);
+  if (!win || !managedWindows.has(win)) return;
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
 });
 
 // Steady-state writes are fire-and-forget so the renderer never blocks on
@@ -527,6 +564,20 @@ ipcMain.handle(
 function parseWindowLaunch(value: unknown): AppWindowLaunch | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const launch = value as Record<string, unknown>;
+  if (launch.kind === 'workspace') {
+    if (
+      typeof launch.title !== 'string' ||
+      launch.title.length === 0 ||
+      launch.title.length > 200 ||
+      (launch.workspaceId !== undefined &&
+        (typeof launch.workspaceId !== 'string' ||
+          launch.workspaceId.length === 0 ||
+          launch.workspaceId.length > 200))
+    ) {
+      return undefined;
+    }
+    return value as AppWindowLaunch;
+  }
   if (launch.kind === 'session') {
     if (
       typeof launch.title !== 'string' ||

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -31,6 +31,7 @@ import {
 import { importLoginShellEnvironment } from './login-shell-environment.js';
 import { initMainLog, installCrashCapture, mainLog, mainLogPath } from './main-log.js';
 import { readLocalMobaXtermSessions } from './mobaxterm.js';
+import { workspaceOwnershipUpdate } from './workspace-window-state.js';
 
 // Name first: userData (and with it the log location) derives from it.
 app.setName('Muxus');
@@ -456,18 +457,27 @@ ipcMain.on('muxus:open-window', (event, value: unknown) => {
   createWindow(appUrl, launch);
 });
 
-ipcMain.on('muxus:active-workspace', (event, value: unknown) => {
-  if (!isManagedWindowSender(event)) return;
-  // Once the renderer reports live ownership, the boot launch is no longer a
-  // reliable description of this window (the user may switch workspaces).
-  windowLaunches.delete(event.sender.id);
-  if (value === undefined || value === null) {
-    activeWorkspaceByWebContents.delete(event.sender.id);
-    return;
-  }
-  if (typeof value !== 'string' || value.length === 0 || value.length > 200) return;
-  activeWorkspaceByWebContents.set(event.sender.id, value);
-});
+ipcMain.on(
+  'muxus:active-workspace',
+  (event, value: unknown, title: unknown, clearLaunch: unknown) => {
+    if (!isManagedWindowSender(event)) return;
+    const update = workspaceOwnershipUpdate(
+      windowLaunches.get(event.sender.id),
+      value,
+      title,
+      clearLaunch,
+    );
+    if (!update.accepted) return;
+
+    if (update.reloadLaunch) windowLaunches.set(event.sender.id, update.reloadLaunch);
+    else windowLaunches.delete(event.sender.id);
+    if (!update.activeWorkspaceId) {
+      activeWorkspaceByWebContents.delete(event.sender.id);
+      return;
+    }
+    activeWorkspaceByWebContents.set(event.sender.id, update.activeWorkspaceId);
+  },
+);
 
 ipcMain.on('muxus:focus-window', (event) => {
   const win = senderWindow(event);

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -124,8 +124,17 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   openWindow(launch: AppWindowLaunch): void {
     ipcRenderer.send('muxus:open-window', launch);
   },
-  setActiveWorkspace(workspaceId?: string): void {
-    ipcRenderer.send('muxus:active-workspace', workspaceId);
+  setActiveWorkspace(
+    workspaceId?: string,
+    workspaceTitle?: string,
+    clearReloadLaunch?: boolean,
+  ): void {
+    ipcRenderer.send(
+      'muxus:active-workspace',
+      workspaceId,
+      workspaceTitle,
+      clearReloadLaunch,
+    );
   },
   focusWindow(): void {
     ipcRenderer.send('muxus:focus-window');

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -124,6 +124,12 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   openWindow(launch: AppWindowLaunch): void {
     ipcRenderer.send('muxus:open-window', launch);
   },
+  setActiveWorkspace(workspaceId?: string): void {
+    ipcRenderer.send('muxus:active-workspace', workspaceId);
+  },
+  focusWindow(): void {
+    ipcRenderer.send('muxus:focus-window');
+  },
   // Fires when the user presses the OS close-window chord (Cmd/Ctrl+W).
   // Returns an unsubscribe. The renderer closes the focused terminal tab; it
   // never closes the window from this chord.

--- a/electron/src/workspace-window-state.ts
+++ b/electron/src/workspace-window-state.ts
@@ -1,0 +1,51 @@
+import type { AppWindowLaunch } from '@muxus/shared';
+
+export interface WorkspaceOwnershipUpdate {
+  accepted: boolean;
+  activeWorkspaceId?: string;
+  reloadLaunch?: AppWindowLaunch;
+}
+
+function validWorkspaceId(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 200;
+}
+
+function validWorkspaceTitle(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 200;
+}
+
+/**
+ * Keep the secondary window's reload descriptor separate from its live
+ * workspace ownership. Session windows retain their original launch profile;
+ * workspace windows follow the workspace the user most recently selected.
+ */
+export function workspaceOwnershipUpdate(
+  reloadLaunch: AppWindowLaunch | undefined,
+  workspaceId: unknown,
+  workspaceTitle: unknown,
+  clearReloadLaunch: unknown,
+): WorkspaceOwnershipUpdate {
+  if (workspaceId === undefined || workspaceId === null) {
+    return {
+      accepted: true,
+      reloadLaunch:
+        clearReloadLaunch === true && reloadLaunch?.kind === 'workspace'
+          ? undefined
+          : reloadLaunch,
+    };
+  }
+  if (!validWorkspaceId(workspaceId)) return { accepted: false, reloadLaunch };
+
+  if (reloadLaunch?.kind !== 'workspace') {
+    return { accepted: true, activeWorkspaceId: workspaceId, reloadLaunch };
+  }
+  return {
+    accepted: true,
+    activeWorkspaceId: workspaceId,
+    reloadLaunch: {
+      kind: 'workspace',
+      workspaceId,
+      title: validWorkspaceTitle(workspaceTitle) ? workspaceTitle : reloadLaunch.title,
+    },
+  };
+}

--- a/server/src/routes/workspaces.ts
+++ b/server/src/routes/workspaces.ts
@@ -123,6 +123,7 @@ const workspaceSaveSchema = z.object({
   name: z.string().trim().min(1).max(200),
   layout: workspaceLayoutSchema,
   overwriteLocked: z.boolean().optional().default(false),
+  createIfMissing: z.boolean().optional().default(false),
   multiExecGroups: z.array(
     z.object({
       id: z.string().min(1),
@@ -135,6 +136,9 @@ const workspaceSaveSchema = z.object({
     }),
   ).default([]),
 }).superRefine((workspace, ctx) => {
+  if (workspace.createIfMissing && !workspace.id) {
+    ctx.addIssue({ code: 'custom', message: 'createIfMissing requires a workspace id' });
+  }
   const ids = new Set<string>();
   const names = new Set<string>();
   const terminalTabIds = new Set<string>();
@@ -210,8 +214,17 @@ export function registerWorkspaceRoutes(app: FastifyInstance, ctx: AppContext): 
       if (!parsed.success) {
         throw new HttpProblem(400, parsed.error.issues[0]?.message ?? 'invalid workspace');
       }
-      const { overwriteLocked, ...workspace } = parsed.data;
-      const saved = ctx.database.saveWorkspace(workspace, overwriteLocked) as WorkspaceRecord;
+      const { overwriteLocked, createIfMissing, ...workspace } = parsed.data;
+      const existing = workspace.id ? ctx.database.workspace(workspace.id) : undefined;
+      if (workspace.id && !existing && !createIfMissing) {
+        throw new HttpProblem(404, 'workspace not found', 'workspace-not-found');
+      }
+      const saved = existing && createIfMissing
+        ? (existing as WorkspaceRecord)
+        : ctx.database.saveWorkspace(
+            existing ? { ...workspace, name: existing.name } : workspace,
+            overwriteLocked,
+          ) as WorkspaceRecord;
       ctx.database.pruneTerminalSnapshots();
       return saved;
     } catch (err) {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -300,11 +300,18 @@ export interface HostOrderRequest {
 }
 
 /**
- * One extra application window requested by the renderer. Session windows
+ * One extra application window requested by the renderer. Workspace windows
+ * either create a named workspace or open an existing one; session windows
  * start a fresh shell; SFTP windows stay attached to an existing SSH
  * transport and hold their own lease for as long as the window is open.
  */
 export type AppWindowLaunch =
+  | {
+      kind: 'workspace';
+      /** Omitted when the new window should create a workspace named `title`. */
+      workspaceId?: string;
+      title: string;
+    }
   | {
       kind: 'session';
       profile: import('./ws-protocol.js').SessionProfile;

--- a/tests/unit/client/window-management.test.ts
+++ b/tests/unit/client/window-management.test.ts
@@ -7,6 +7,21 @@ import {
 } from '../../../client/src/window-management.js';
 
 describe('secondary window launch payloads', () => {
+  it('round-trips new and existing workspace launches', () => {
+    const create: AppWindowLaunch = {
+      kind: 'workspace',
+      title: 'Production EU',
+    };
+    const open: AppWindowLaunch = {
+      kind: 'workspace',
+      workspaceId: 'workspace-42',
+      title: 'Operations',
+    };
+
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(create))).toEqual(create);
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(open))).toEqual(open);
+  });
+
   it('round-trips unicode session titles and complete profiles', () => {
     const launch: AppWindowLaunch = {
       kind: 'session',
@@ -74,6 +89,10 @@ describe('secondary window launch payloads', () => {
   });
 
   it('rejects malformed or unsupported payloads', () => {
+    expect(isAppWindowLaunch({ kind: 'workspace', title: '' })).toBe(false);
+    expect(
+      isAppWindowLaunch({ kind: 'workspace', title: 'Operations', workspaceId: '' }),
+    ).toBe(false);
     expect(isAppWindowLaunch({ kind: 'session', title: 'Missing profile' })).toBe(false);
     expect(
       isAppWindowLaunch({

--- a/tests/unit/client/workspace-persistence.test.ts
+++ b/tests/unit/client/workspace-persistence.test.ts
@@ -36,6 +36,7 @@ describe('workspace persistence', () => {
       startupId: undefined,
       ready: false,
       busy: false,
+      openWindowCounts: {},
       error: undefined,
     });
   });
@@ -43,6 +44,226 @@ describe('workspace persistence', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.useRealTimers();
+  });
+
+  it('keeps a secondary session window unsaved instead of loading the startup workspace', async () => {
+    const sessionId = useTabsStore.getState().open({ kind: 'local' }, 'Independent shell');
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (path === '/api/workspaces' && (init?.method ?? 'GET') === 'GET') {
+        return json({ workspaces: [] });
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const runtime = new WorkspaceRuntime({ kind: 'blank' });
+    await runtime.start();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(useWorkspacesStore.getState()).toMatchObject({
+      activeId: undefined,
+      activeName: 'Unsaved workspace',
+      ready: true,
+    });
+    expect(useTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({ id: sessionId, title: 'Independent shell' }),
+    ]);
+
+    runtime.stop();
+  });
+
+  it('creates a named empty workspace for a new workspace window', async () => {
+    let created: WorkspaceRecord | undefined;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      if (path === '/api/workspaces' && method === 'GET') {
+        return json({ workspaces: [] });
+      }
+      if (path === '/api/workspaces' && method === 'PUT') {
+        if (typeof init?.body !== 'string') throw new Error('Expected a JSON request body');
+        const inputWorkspace = JSON.parse(init.body) as Pick<
+          WorkspaceRecord,
+          'id' | 'name' | 'layout' | 'multiExecGroups'
+        > & { createIfMissing: boolean };
+        created = {
+          id: inputWorkspace.id,
+          name: inputWorkspace.name,
+          layout: inputWorkspace.layout,
+          multiExecGroups: inputWorkspace.multiExecGroups,
+          isLocked: false,
+          isStartup: false,
+          createdAt: '2026-08-05T20:00:00Z',
+          updatedAt: '2026-08-05T20:00:00Z',
+        };
+        return json(created);
+      }
+      if (path === '/api/workspaces/new-window-workspace/open' && method === 'POST') {
+        return json(created);
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const runtime = new WorkspaceRuntime({
+      kind: 'new',
+      id: 'new-window-workspace',
+      name: 'Production EU',
+    });
+    await runtime.start();
+
+    expect(created).toMatchObject({
+      id: 'new-window-workspace',
+      name: 'Production EU',
+      layout: {
+        version: 1,
+        root: { type: 'pane', tabs: [] },
+      },
+      multiExecGroups: [],
+    });
+    const createRequest = fetchMock.mock.calls.find(
+      ([path, init]) => path === '/api/workspaces' && init?.method === 'PUT',
+    );
+    expect(JSON.parse(createRequest?.[1]?.body as string)).toMatchObject({
+      id: 'new-window-workspace',
+      createIfMissing: true,
+    });
+    expect(useWorkspacesStore.getState()).toMatchObject({
+      activeId: 'new-window-workspace',
+      activeName: 'Production EU',
+      ready: true,
+    });
+
+    runtime.stop();
+  });
+
+  it('restores a locked workspace after one of its sessions was closed', async () => {
+    const persisted: WorkspaceRecord = {
+      id: 'locked-operations',
+      name: 'Locked operations',
+      layout: {
+        version: 1,
+        root: {
+          id: 'pane-operations',
+          type: 'pane',
+          activeTabId: 'saved-shell',
+          tabs: [
+            {
+              id: 'saved-shell',
+              kind: 'terminal',
+              title: 'Saved shell',
+              profile: { kind: 'local' },
+              offerReconnect: true,
+            },
+          ],
+        },
+        activePaneId: 'pane-operations',
+      },
+      multiExecGroups: [],
+      isLocked: true,
+      isStartup: false,
+      createdAt: '2026-08-05T20:00:00Z',
+      updatedAt: '2026-08-05T20:00:00Z',
+    };
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      if (path === '/api/workspaces' && method === 'GET') {
+        return json({ workspaces: [summaryOf(persisted)] });
+      }
+      if (path === `/api/workspaces/${persisted.id}` && method === 'GET') {
+        return json(persisted);
+      }
+      if (path === `/api/workspaces/${persisted.id}/open` && method === 'POST') {
+        return json(persisted);
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const runtime = new WorkspaceRuntime({ kind: 'open', id: persisted.id });
+    await runtime.start();
+
+    useTabsStore.getState().close('saved-shell');
+    expect(useTabsStore.getState().tabs).toEqual([]);
+
+    await runtime.open(persisted.id);
+    expect(useTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({ id: 'saved-shell', title: 'Saved shell' }),
+    ]);
+
+    runtime.stop();
+  });
+
+  it('reconciles remote renames, locks, and deletions without closing live sessions', async () => {
+    let persisted: WorkspaceRecord | undefined = {
+      id: 'shared-operations',
+      name: 'Shared operations',
+      layout: {
+        version: 1,
+        root: {
+          id: 'pane-shared',
+          type: 'pane',
+          activeTabId: 'shared-shell',
+          tabs: [
+            {
+              id: 'shared-shell',
+              kind: 'terminal',
+              title: 'Shared shell',
+              profile: { kind: 'local' },
+              offerReconnect: true,
+            },
+          ],
+        },
+      },
+      multiExecGroups: [],
+      isLocked: false,
+      isStartup: false,
+      createdAt: '2026-08-05T20:00:00Z',
+      updatedAt: '2026-08-05T20:00:00Z',
+    };
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      if (path === '/api/workspaces' && method === 'GET') {
+        return json({ workspaces: persisted ? [summaryOf(persisted)] : [] });
+      }
+      if (path === '/api/workspaces/shared-operations' && method === 'GET' && persisted) {
+        return json(persisted);
+      }
+      if (path === '/api/workspaces/shared-operations/open' && method === 'POST' && persisted) {
+        return json(persisted);
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const runtime = new WorkspaceRuntime({ kind: 'open', id: 'shared-operations' });
+    await runtime.start();
+
+    persisted = { ...persisted!, name: 'Renamed elsewhere', isLocked: true };
+    await runtime.refreshCatalog();
+    expect(useWorkspacesStore.getState()).toMatchObject({
+      activeId: 'shared-operations',
+      activeName: 'Renamed elsewhere',
+      workspaces: [expect.objectContaining({ isLocked: true })],
+    });
+
+    persisted = undefined;
+    await runtime.refreshCatalog();
+    expect(useWorkspacesStore.getState()).toMatchObject({
+      activeId: undefined,
+      activeName: 'Unsaved workspace',
+      error: expect.stringContaining('deleted in another window'),
+    });
+    expect(useTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({ id: 'shared-shell', title: 'Shared shell' }),
+    ]);
+
+    runtime.stop();
   });
 
   it('only updates a locked workspace explicitly and resumes auto-save after unlock', async () => {
@@ -177,6 +398,63 @@ describe('workspace persistence', () => {
       id: persisted.id,
       overwriteLocked: true,
     });
+
+    runtime.stop();
+  });
+
+  it('detaches instead of recreating a workspace deleted before an autosave lands', async () => {
+    const persisted: WorkspaceRecord = {
+      id: 'deleted-remotely',
+      name: 'Deleted remotely',
+      layout: { version: 1, root: null },
+      multiExecGroups: [],
+      isLocked: false,
+      isStartup: true,
+      createdAt: '2026-08-03T12:00:00Z',
+      updatedAt: '2026-08-03T12:00:00Z',
+    };
+    let deleted = false;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      if (path === '/api/workspaces' && method === 'GET') {
+        return json({ workspaces: deleted ? [] : [summaryOf(persisted)] });
+      }
+      if (path === '/api/workspaces/startup' || path === '/api/workspaces/latest') {
+        return json({ workspace: persisted });
+      }
+      if (path === `/api/workspaces/${persisted.id}/open`) return json(persisted);
+      if (path === '/api/workspaces' && method === 'PUT') {
+        return deleted
+          ? json({ message: 'workspace not found', code: 'workspace-not-found' }, 404)
+          : json(persisted);
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const runtime = new WorkspaceRuntime();
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(400);
+    fetchMock.mockClear();
+    deleted = true;
+
+    useTabsStore.getState().open({ kind: 'local' }, 'Unsaved after delete');
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(useWorkspacesStore.getState()).toMatchObject({
+      activeId: undefined,
+      activeName: 'Unsaved workspace',
+      error: expect.stringContaining('deleted in another window'),
+    });
+    const failedSaves = fetchMock.mock.calls.filter(
+      ([path, init]) => path === '/api/workspaces' && init?.method === 'PUT',
+    );
+    expect(failedSaves).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(fetchMock.mock.calls.filter(
+      ([path, init]) => path === '/api/workspaces' && init?.method === 'PUT',
+    )).toHaveLength(1);
 
     runtime.stop();
   });

--- a/tests/unit/client/workspace-sync.test.ts
+++ b/tests/unit/client/workspace-sync.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  WorkspaceWindowSync,
+  type WorkspaceSyncCallbacks,
+} from '../../../client/src/workspace-sync.js';
+
+class TestBroadcastChannel {
+  static readonly instances = new Set<TestBroadcastChannel>();
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+
+  constructor(readonly name: string) {
+    TestBroadcastChannel.instances.add(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (type === 'message') this.listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (type === 'message') this.listeners.delete(listener);
+  }
+
+  postMessage(data: unknown): void {
+    for (const channel of TestBroadcastChannel.instances) {
+      if (channel === this || channel.name !== this.name) continue;
+      for (const listener of channel.listeners) listener({ data } as MessageEvent);
+    }
+  }
+
+  close(): void {
+    TestBroadcastChannel.instances.delete(this);
+    this.listeners.clear();
+  }
+}
+
+function callbacks() {
+  return {
+    onCatalogChanged: vi.fn(),
+    onOpenWindowCountsChanged: vi.fn(),
+    onWindowFocus: vi.fn(),
+    onFocusRequested: vi.fn(),
+  } satisfies WorkspaceSyncCallbacks;
+}
+
+afterEach(() => {
+  TestBroadcastChannel.instances.clear();
+  vi.useRealTimers();
+});
+
+describe('workspace window synchronization', () => {
+  it('shares catalog invalidations and active-workspace presence', () => {
+    vi.useFakeTimers();
+    const firstCallbacks = callbacks();
+    const secondCallbacks = callbacks();
+    const first = new WorkspaceWindowSync(
+      new TestBroadcastChannel('workspaces') as unknown as BroadcastChannel,
+    );
+    const second = new WorkspaceWindowSync(
+      new TestBroadcastChannel('workspaces') as unknown as BroadcastChannel,
+    );
+
+    first.setActiveWorkspace('operations');
+    first.start(firstCallbacks);
+    second.setActiveWorkspace('development');
+    second.start(secondCallbacks);
+
+    expect(first.openWindowCounts()).toEqual({ development: 1 });
+    expect(second.openWindowCounts()).toEqual({ operations: 1 });
+
+    first.invalidateCatalog();
+    expect(secondCallbacks.onCatalogChanged).toHaveBeenCalledOnce();
+
+    first.stop();
+    second.stop();
+  });
+
+  it('focuses one existing owner and removes presence when its window closes', () => {
+    vi.useFakeTimers();
+    const firstCallbacks = callbacks();
+    const secondCallbacks = callbacks();
+    const first = new WorkspaceWindowSync(
+      new TestBroadcastChannel('workspaces') as unknown as BroadcastChannel,
+    );
+    const second = new WorkspaceWindowSync(
+      new TestBroadcastChannel('workspaces') as unknown as BroadcastChannel,
+    );
+
+    first.setActiveWorkspace('operations');
+    first.start(firstCallbacks);
+    second.setActiveWorkspace('development');
+    second.start(secondCallbacks);
+
+    expect(first.focusOpenWorkspace('development')).toBe(true);
+    expect(secondCallbacks.onFocusRequested).toHaveBeenCalledOnce();
+    expect(first.focusOpenWorkspace('missing')).toBe(false);
+
+    second.stop();
+    expect(first.openWindowCounts()).toEqual({});
+    expect(firstCallbacks.onOpenWindowCountsChanged).toHaveBeenLastCalledWith({});
+
+    first.stop();
+  });
+});

--- a/tests/unit/electron/workspace-window-state.test.ts
+++ b/tests/unit/electron/workspace-window-state.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { AppWindowLaunch } from '@muxus/shared';
+import { workspaceOwnershipUpdate } from '../../../electron/src/workspace-window-state.js';
+
+describe('Electron workspace window reload state', () => {
+  it('updates a workspace window to reload its current workspace and name', () => {
+    const launch: AppWindowLaunch = {
+      kind: 'workspace',
+      workspaceId: 'original',
+      title: 'Original workspace',
+    };
+
+    expect(workspaceOwnershipUpdate(launch, 'operations', 'Operations', false)).toEqual({
+      accepted: true,
+      activeWorkspaceId: 'operations',
+      reloadLaunch: {
+        kind: 'workspace',
+        workspaceId: 'operations',
+        title: 'Operations',
+      },
+    });
+  });
+
+  it('preserves a session launch while tracking live workspace ownership', () => {
+    const launch: AppWindowLaunch = {
+      kind: 'session',
+      profile: { kind: 'local', shell: '/bin/zsh' },
+      title: 'Local shell',
+    };
+
+    expect(workspaceOwnershipUpdate(launch, undefined, 'Unsaved workspace', false)).toEqual({
+      accepted: true,
+      reloadLaunch: launch,
+    });
+    expect(workspaceOwnershipUpdate(launch, 'auto-saved', 'Workspace 1', false)).toEqual({
+      accepted: true,
+      activeWorkspaceId: 'auto-saved',
+      reloadLaunch: launch,
+    });
+  });
+
+  it('only clears a workspace launch after an explicit detach', () => {
+    const launch: AppWindowLaunch = {
+      kind: 'workspace',
+      workspaceId: 'deleted',
+      title: 'Deleted workspace',
+    };
+
+    expect(workspaceOwnershipUpdate(launch, undefined, 'Unsaved workspace', false)).toEqual({
+      accepted: true,
+      reloadLaunch: launch,
+    });
+    expect(workspaceOwnershipUpdate(launch, undefined, 'Unsaved workspace', true)).toEqual({
+      accepted: true,
+      reloadLaunch: undefined,
+    });
+    expect(workspaceOwnershipUpdate(launch, '', 'Invalid', false)).toEqual({
+      accepted: false,
+      reloadLaunch: launch,
+    });
+  });
+});

--- a/tests/unit/server/workspace-routes.test.ts
+++ b/tests/unit/server/workspace-routes.test.ts
@@ -312,6 +312,86 @@ describe('workspace routes', () => {
     expect(startup.json()).toEqual({ workspace: null });
   });
 
+  it('prevents stale windows from renaming or recreating a deleted workspace', async () => {
+    const save = await app.inject({
+      method: 'PUT',
+      url: '/api/workspaces',
+      headers: auth(),
+      payload: { name: 'Authoritative name', layout },
+    });
+    const id = save.json().id as string;
+
+    const staleLayoutSave = await app.inject({
+      method: 'PUT',
+      url: '/api/workspaces',
+      headers: auth(),
+      payload: {
+        id,
+        name: 'Stale window name',
+        layout: { version: 1, root: null },
+      },
+    });
+    expect(staleLayoutSave.statusCode).toBe(200);
+    expect(staleLayoutSave.json()).toMatchObject({
+      id,
+      name: 'Authoritative name',
+      layout: { version: 1, root: null },
+    });
+
+    await app.inject({
+      method: 'DELETE',
+      url: `/api/workspaces/${id}`,
+      headers: auth(),
+    });
+    const staleSaveAfterDelete = await app.inject({
+      method: 'PUT',
+      url: '/api/workspaces',
+      headers: auth(),
+      payload: {
+        id,
+        name: 'Stale window name',
+        layout: { version: 1, root: null },
+      },
+    });
+    expect(staleSaveAfterDelete.statusCode).toBe(404);
+    expect(staleSaveAfterDelete.json()).toEqual({
+      code: 'workspace-not-found',
+      message: 'workspace not found',
+    });
+
+    const idempotentCreate = await app.inject({
+      method: 'PUT',
+      url: '/api/workspaces',
+      headers: auth(),
+      payload: {
+        id,
+        createIfMissing: true,
+        name: 'Recreated intentionally',
+        layout: { version: 1, root: null },
+      },
+    });
+    expect(idempotentCreate.statusCode).toBe(200);
+    expect(idempotentCreate.json()).toMatchObject({ id, name: 'Recreated intentionally' });
+
+    const repeatedCreate = await app.inject({
+      method: 'PUT',
+      url: '/api/workspaces',
+      headers: auth(),
+      payload: {
+        id,
+        createIfMissing: true,
+        name: 'Must not replace the existing workspace',
+        layout,
+      },
+    });
+    expect(repeatedCreate.statusCode).toBe(200);
+    expect(repeatedCreate.json()).toMatchObject({
+      id,
+      name: 'Recreated intentionally',
+      layout: { version: 1, root: null },
+    });
+  });
+
   it('returns null when there is no latest workspace', async () => {
     const response = await app.inject({
       method: 'GET',


### PR DESCRIPTION
Closes #94.

## What changed

- Create new named workspaces in their own application windows.
- Open saved workspaces in separate windows while focusing an existing owner instead of creating duplicates.
- Enable workspace persistence and management in session windows.
- Synchronize workspace creation, rename, lock, startup selection, save, delete, and window presence across renderers.
- Show which workspaces are open elsewhere and provide direct switch-to-window actions.
- Add an explicit restore action for locked workspaces.
- Keep workspace names and native window titles synchronized.

## Reliability

Previously, each renderer kept an isolated workspace catalog and Electron did not track which window owned a workspace. That allowed stale UI, duplicate workspace windows, and competing saves.

This change adds a cross-window presence/catalog bus, Electron-level workspace ownership, focus and dialog refresh fallbacks, and server-side stale-writer protection. A deleted workspace can no longer be recreated by an older window, and a stale layout save cannot revert a newer rename. Live sessions remain open as an unsaved workspace when their saved workspace is deleted elsewhere.

## Validation

- `pnpm test` — 845 passed, 3 skipped
- `pnpm build`
- `pnpm lint`
- `git diff --check`
