### PR TITLE
Preserve terminal selection on right click

### DIFF
--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -441,7 +441,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       // Installing a second encoder would emit printable keys twice.
       vtExtensions: { kittyKeyboard: true },
     });
-    rightClickSelectsWordDefaultRef.current = term.options.rightClickSelectsWord;
+    rightClickSelectsWordDefaultRef.current = term.options.rightClickSelectsWord ?? false;
     const fit = new FitAddon();
     fitRef.current = fit;
     termRef.current = term;

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -67,6 +67,10 @@ import { openTerminalWebLink } from '../terminal/web-links.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
 import {
+  terminalRightClickIntent,
+  XTERM_RIGHT_CLICK_OPTIONS,
+} from '../terminal/right-click.js';
+import {
   AuthPromptDialog,
   type AuthPromptRequest,
   type AuthPromptResult,
@@ -229,7 +233,11 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const [searchWord, setSearchWord] = useState(false);
   const [searchRegex, setSearchRegex] = useState(false);
   const [searchResult, setSearchResult] = useState({ resultIndex: -1, resultCount: 0 });
-  const [ctxMenu, setCtxMenu] = useState<{ top: number; left: number; hasSelection: boolean } | null>(null);
+  const [ctxMenu, setCtxMenu] = useState<{
+    top: number;
+    left: number;
+    selection: string;
+  } | null>(null);
   const [generation, setGeneration] = useState(tab.connectOnMount ? 1 : 0);
   const reconnectRequest = useTabsStore(
     (s) => s.tabs.find((candidate) => candidate.id === tab.id)?.reconnectRequest ?? 0,
@@ -346,19 +354,19 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     e.preventDefault();
     const term = termRef.current;
     if (!term) return;
-    const action = usePrefsStore.getState().rightClickAction;
-    if (action === 'menu') {
-      setCtxMenu({ top: e.clientY, left: e.clientX, hasSelection: term.hasSelection() });
+    const intent = terminalRightClickIntent(
+      usePrefsStore.getState().rightClickAction,
+      term.getSelection(),
+    );
+    if (intent.kind === 'menu') {
+      setCtxMenu({ top: e.clientY, left: e.clientX, selection: intent.selection });
       return;
     }
-    if (action === 'copy-paste') {
-      const selection = term.getSelection();
-      if (selection) {
-        void copyToClipboard(selection).then((ok) => {
-          if (ok) term.clearSelection();
-        });
-        return;
-      }
+    if (intent.kind === 'copy') {
+      void copyToClipboard(intent.selection).then((ok) => {
+        if (ok) term.clearSelection();
+      });
+      return;
     }
     pasteFromClipboard();
   };
@@ -390,6 +398,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     );
     const initialFontStack = terminalFontStack(prefs.fontFamily);
     const term = new Terminal({
+      ...XTERM_RIGHT_CLICK_OPTIONS,
       fontSize: initialFontSize,
       fontFamily: initialFontStack,
       lineHeight: prefs.lineHeight,
@@ -1357,11 +1366,12 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         anchorPosition={ctxMenu ?? undefined}
       >
         <MenuItem
-          disabled={!ctxMenu?.hasSelection}
+          disabled={!ctxMenu?.selection}
           onClick={() => {
             const term = termRef.current;
-            if (term?.hasSelection()) {
-              void copyToClipboard(term.getSelection()).then((ok) => {
+            const selection = ctxMenu?.selection;
+            if (term && selection) {
+              void copyToClipboard(selection).then((ok) => {
                 if (ok) term.clearSelection();
               });
             }

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -68,7 +68,7 @@ import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
 import {
   terminalRightClickIntent,
-  XTERM_RIGHT_CLICK_OPTIONS,
+  xtermRightClickSelectsWord,
 } from '../terminal/right-click.js';
 import {
   AuthPromptDialog,
@@ -214,6 +214,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const imageRef = useRef<ImageAddon | null>(null);
   const keywordHighlighterRef = useRef<KeywordHighlighter | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  /** xterm's native default is enabled on macOS and disabled elsewhere. */
+  const rightClickSelectsWordDefaultRef = useRef(false);
   const lastSearchRequestRef = useRef(tab.searchRequest);
   /** Per-tab zoom offset added to the preference font size. */
   const zoomRef = useRef(0);
@@ -350,6 +352,16 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   // (copy the selection when there is one, otherwise paste), always paste,
   // or a context menu. Paste goes through term.paste() so bracketed-paste
   // mode reaches the remote shell intact.
+  const prepareRightClick = () => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.rightClickSelectsWord = xtermRightClickSelectsWord(
+      rightClickSelectsWordDefaultRef.current,
+      usePrefsStore.getState().rightClickAction,
+      term.hasSelection(),
+    );
+  };
+
   const onContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
     const term = termRef.current;
@@ -398,7 +410,6 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     );
     const initialFontStack = terminalFontStack(prefs.fontFamily);
     const term = new Terminal({
-      ...XTERM_RIGHT_CLICK_OPTIONS,
       fontSize: initialFontSize,
       fontFamily: initialFontStack,
       lineHeight: prefs.lineHeight,
@@ -430,6 +441,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       // Installing a second encoder would emit printable keys twice.
       vtExtensions: { kittyKeyboard: true },
     });
+    rightClickSelectsWordDefaultRef.current = term.options.rightClickSelectsWord;
     const fit = new FitAddon();
     fitRef.current = fit;
     termRef.current = term;
@@ -1225,6 +1237,11 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     <Box sx={{ height: '100%', p: 1, pt: 0.75, minHeight: 0, position: 'relative' }}>
       <Box
         ref={containerRef}
+        onMouseDownCapture={(event) => {
+          // Firefox runs xterm's right-click handler on mousedown.
+          if (event.button === 2) prepareRightClick();
+        }}
+        onContextMenuCapture={prepareRightClick}
         onContextMenu={onContextMenu}
         sx={{
           height: '100%',

--- a/client/src/terminal/right-click.ts
+++ b/client/src/terminal/right-click.ts
@@ -1,0 +1,25 @@
+import type { RightClickAction } from '../state/prefs.js';
+
+/**
+ * xterm enables word selection on right click by default on macOS. Its native
+ * contextmenu listener runs before Muxus's React handler, so that behavior can
+ * replace an existing selection before Muxus decides whether to copy or paste.
+ */
+export const XTERM_RIGHT_CLICK_OPTIONS = {
+  rightClickSelectsWord: false,
+} as const;
+
+export type TerminalRightClickIntent =
+  | { kind: 'copy'; selection: string }
+  | { kind: 'paste' }
+  | { kind: 'menu'; selection: string };
+
+/** Resolve one right click from the selection that existed when it occurred. */
+export function terminalRightClickIntent(
+  action: RightClickAction,
+  selection: string,
+): TerminalRightClickIntent {
+  if (action === 'menu') return { kind: 'menu', selection };
+  if (action === 'copy-paste' && selection) return { kind: 'copy', selection };
+  return { kind: 'paste' };
+}

--- a/client/src/terminal/right-click.ts
+++ b/client/src/terminal/right-click.ts
@@ -1,13 +1,17 @@
 import type { RightClickAction } from '../state/prefs.js';
 
 /**
- * xterm enables word selection on right click by default on macOS. Its native
- * contextmenu listener runs before Muxus's React handler, so that behavior can
- * replace an existing selection before Muxus decides whether to copy or paste.
+ * Keep xterm's platform convention (word selection on macOS) only when it is
+ * useful to Muxus's context menu. xterm handles the native event before the
+ * React bubble handler, so every other path must suppress selection changes.
  */
-export const XTERM_RIGHT_CLICK_OPTIONS = {
-  rightClickSelectsWord: false,
-} as const;
+export function xtermRightClickSelectsWord(
+  platformDefault: boolean,
+  action: RightClickAction,
+  hasSelection: boolean,
+): boolean {
+  return platformDefault && action === 'menu' && !hasSelection;
+}
 
 export type TerminalRightClickIntent =
   | { kind: 'copy'; selection: string }

--- a/tests/unit/client/terminal-right-click.test.ts
+++ b/tests/unit/client/terminal-right-click.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import {
   terminalRightClickIntent,
-  XTERM_RIGHT_CLICK_OPTIONS,
+  xtermRightClickSelectsWord,
 } from '../../../client/src/terminal/right-click.js';
 
 describe('terminal right click', () => {
-  it('disables xterm macOS word selection so an existing selection is preserved', () => {
-    expect(XTERM_RIGHT_CLICK_OPTIONS.rightClickSelectsWord).toBe(false);
+  it('preserves the macOS word-selection convention only for an empty context menu', () => {
+    expect(xtermRightClickSelectsWord(true, 'menu', false)).toBe(true);
+    expect(xtermRightClickSelectsWord(true, 'menu', true)).toBe(false);
+    expect(xtermRightClickSelectsWord(true, 'copy-paste', false)).toBe(false);
+    expect(xtermRightClickSelectsWord(true, 'paste', false)).toBe(false);
+  });
+
+  it('keeps xterm word selection disabled on Linux and Windows', () => {
+    expect(xtermRightClickSelectsWord(false, 'menu', false)).toBe(false);
+    expect(xtermRightClickSelectsWord(false, 'menu', true)).toBe(false);
+    expect(xtermRightClickSelectsWord(false, 'copy-paste', false)).toBe(false);
+    expect(xtermRightClickSelectsWord(false, 'paste', false)).toBe(false);
   });
 
   it('copies the same existing selection regardless of the click position', () => {

--- a/tests/unit/client/terminal-right-click.test.ts
+++ b/tests/unit/client/terminal-right-click.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  terminalRightClickIntent,
+  XTERM_RIGHT_CLICK_OPTIONS,
+} from '../../../client/src/terminal/right-click.js';
+
+describe('terminal right click', () => {
+  it('disables xterm macOS word selection so an existing selection is preserved', () => {
+    expect(XTERM_RIGHT_CLICK_OPTIONS.rightClickSelectsWord).toBe(false);
+  });
+
+  it('copies the same existing selection regardless of the click position', () => {
+    const selection = 'the original\nselection';
+
+    expect(terminalRightClickIntent('copy-paste', selection)).toEqual({
+      kind: 'copy',
+      selection,
+    });
+  });
+
+  it('pastes when copy-paste mode starts without a selection', () => {
+    expect(terminalRightClickIntent('copy-paste', '')).toEqual({ kind: 'paste' });
+  });
+
+  it('always pastes in paste mode even when text is selected', () => {
+    expect(terminalRightClickIntent('paste', 'leave this selected')).toEqual({ kind: 'paste' });
+  });
+
+  it('snapshots the selection for context-menu Copy', () => {
+    expect(terminalRightClickIntent('menu', 'selected when opened')).toEqual({
+      kind: 'menu',
+      selection: 'selected when opened',
+    });
+    expect(terminalRightClickIntent('menu', '')).toEqual({ kind: 'menu', selection: '' });
+  });
+});


### PR DESCRIPTION
## Summary

- protect an existing terminal selection before xterm's native right-click handler runs
- preserve xterm's platform convention for an empty custom context menu: word selection on macOS and no word selection on Linux or Windows
- keep copy-or-paste and always-paste modes from creating a selection when they should paste
- snapshot selected text for context-menu Copy
- cover the platform policy and all configured right-click modes with regression tests

## Root cause

On macOS, xterm enables `rightClickSelectsWord` by default. Its native event listener runs before the Muxus React bubble handler, so right-clicking outside a highlighted range could replace that selection with the word under the pointer before Muxus read it.

Muxus now applies the right-click policy during event capture. This covers xterm's `mousedown` path in Firefox and its `contextmenu` path in Chromium-based browsers without preventing or stopping mouse events.

## User impact

Right-clicking anywhere in a terminal now copies the original selection in copy-or-paste mode. When no selection exists, each configured action retains its intended behavior. The macOS context menu can still select and copy the word under the pointer, while Linux and Windows retain their native xterm defaults.

## Validation

- `pnpm --filter @muxus/tests test` — 854 passed, 3 skipped
- `pnpm --filter @muxus/client build`
- `pnpm --filter @muxus/tests typecheck`
- `pnpm lint`

Fixes #95