### PR TITLE
Keep terminal sessions alive across sleep

### DIFF
--- a/client/src/api/dial.ts
+++ b/client/src/api/dial.ts
@@ -4,7 +4,7 @@ import type {
   AuthPromptResult,
 } from '../components/AuthPromptDialog.js';
 import type { HostKeyRequest } from '../components/HostKeyDialog.js';
-import { wsProtocols, wsUrl } from './http.js';
+import { closeTerminalWebSocket, wsProtocols, wsUrl } from './http.js';
 
 /** Interactive hooks a shell-less dial needs from the UI. */
 export interface DialHandlers {
@@ -42,7 +42,7 @@ export function dialConnection(
       if (settled) return;
       settled = true;
       reject(new Error(message));
-      ws.close();
+      closeTerminalWebSocket(ws);
     };
 
     ws.onopen = () => {
@@ -85,7 +85,7 @@ export function dialConnection(
             })
             .then((response) => {
               if (ws.readyState !== WebSocket.OPEN) return;
-              if (response === null) ws.close();
+              if (response === null) closeTerminalWebSocket(ws);
               else ws.send(JSON.stringify({ op: 'auth-response', ...response }));
             });
           break;
@@ -96,7 +96,7 @@ export function dialConnection(
           break;
         case 'ready':
           settled = true;
-          resolve({ connId: msg.connId, close: () => ws.close() });
+          resolve({ connId: msg.connId, close: () => closeTerminalWebSocket(ws) });
           break;
         case 'exit':
           fail(msg.message || lastStatus || 'connection failed');

--- a/client/src/api/http.ts
+++ b/client/src/api/http.ts
@@ -1,5 +1,8 @@
 import type { ApiErrorBody } from '@muxus/shared';
-import { terminalWebSocketProtocols } from '@muxus/shared/ws-protocol';
+import {
+  TERMINAL_SESSION_CLOSE_REASON,
+  terminalWebSocketProtocols,
+} from '@muxus/shared/ws-protocol';
 import { reportAuthInvalid, reportBackendDown, reportBackendUp } from '../state/backend.js';
 
 let token = '';
@@ -109,4 +112,9 @@ export function wsUrl(path: string, params: Record<string, string | number | boo
 /** Handshake protocols authenticate a WebSocket without leaking into its URL. */
 export function wsProtocols(): string[] {
   return terminalWebSocketProtocols(token);
+}
+
+/** End a terminal or dial lifecycle instead of leaving it available for reattachment. */
+export function closeTerminalWebSocket(socket: WebSocket): void {
+  socket.close(1000, TERMINAL_SESSION_CLOSE_REASON);
 }

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -32,7 +32,12 @@ import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import type { AppInfo, TerminalServerMessage } from '@muxus/shared';
-import { apiFetch, wsProtocols, wsUrl } from '../api/http.js';
+import {
+  apiFetch,
+  closeTerminalWebSocket,
+  wsProtocols,
+  wsUrl,
+} from '../api/http.js';
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import { copyToClipboard, readFromClipboard } from '../clipboard.js';
 import { loadMonacoTextEditor, loadRemoteEditorWorkspace } from '../lazy-features.js';
@@ -1189,7 +1194,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         ws.onmessage = null;
         ws.onclose = null;
         ws.onerror = null;
-        ws.close();
+        closeTerminalWebSocket(ws);
       }
       term.dispose();
       searchRef.current = null;

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -84,6 +84,8 @@ import {
   CONNECTION_INTERRUPTION_GRACE_MS,
   connectionFailureReason,
   reattachCommand,
+  rendererReattachDelayMs,
+  restoreCwdCommand,
   shouldDelayConnectionLost,
   shouldWaitForTerminalOutput,
   terminalNotice,
@@ -393,6 +395,10 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     const el = containerRef.current;
     if (!el) return;
     const shouldConnect = generation > 0;
+    const reconnectCwd =
+      tab.profile.kind === 'ssh' && tab.reconnectRequest > 0
+        ? tab.terminalCwd
+        : undefined;
     if (shouldConnect) {
       updateTab(tab.id, {
         status: 'connecting',
@@ -657,10 +663,14 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
 
     let ws: WebSocket | undefined;
     let disposed = false;
-    let socketFailed = false;
     let exitMessage: TerminalExitMessage | undefined;
     let interruptionTimer: ReturnType<typeof setTimeout> | undefined;
+    let rendererReattachTimer: ReturnType<typeof setTimeout> | undefined;
+    let rendererStableTimer: ReturnType<typeof setTimeout> | undefined;
     let autoReconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let rendererReattachAttempts = 0;
+    let terminalId = tab.transferId ? tab.terminalId : undefined;
+    let pendingTransferId = tab.transferId;
     let sawAuthPrompt = false;
     let readyAt = 0;
     let snapshotDirty = false;
@@ -748,20 +758,23 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       }
     });
 
-    const openSocket = () => {
-      ws = new WebSocket(wsUrl('/ws/terminal'), wsProtocols());
-      wsRef.current = ws;
-      ws.binaryType = 'arraybuffer';
-      ws.onopen = () => {
+    const openSocket = (attachTerminalId?: string) => {
+      const socket = new WebSocket(wsUrl('/ws/terminal'), wsProtocols());
+      const attachingExistingSession = !!attachTerminalId;
+      let socketFailed = false;
+      ws = socket;
+      wsRef.current = socket;
+      socket.binaryType = 'arraybuffer';
+      socket.onopen = () => {
         // The pane is usually laid out by the time the socket opens, even when
         // it was not when the terminal mounted. Measure now so the remote PTY
         // starts at the size on screen instead of being resized a beat later.
         if (!fitted) fitted = fitTerminal();
-        ws?.send(JSON.stringify(
-          tab.transferId && tab.terminalId
+        socket.send(JSON.stringify(
+          attachTerminalId
             ? {
                 op: 'attach',
-                terminalId: tab.terminalId,
+                terminalId: attachTerminalId,
                 cols: term.cols,
                 rows: term.rows,
               }
@@ -774,7 +787,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               },
         ));
       };
-      ws.onmessage = (ev) => {
+      socket.onmessage = (ev) => {
         if (ev.data instanceof ArrayBuffer) {
           clearTransientStatus();
           notifyOutput(tab.id);
@@ -805,6 +818,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         }
         switch (ctl.op) {
           case 'session':
+            terminalId = ctl.terminalId;
             updateTab(tab.id, { terminalId: ctl.terminalId });
             break;
           case 'transfer-ready': {
@@ -873,9 +887,23 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             break;
           case 'ready': {
             ready = true;
-            readyAt = Date.now();
+            if (!attachingExistingSession || readyAt === 0) readyAt = Date.now();
+            if (!attachingExistingSession) rendererReattachAttempts = 0;
+            if (rendererStableTimer !== undefined) clearTimeout(rendererStableTimer);
+            rendererStableTimer = setTimeout(() => {
+              rendererStableTimer = undefined;
+              rendererReattachAttempts = 0;
+            }, AUTO_RECONNECT_STABLE_MS);
+            if (rendererReattachTimer !== undefined) {
+              clearTimeout(rendererReattachTimer);
+              rendererReattachTimer = undefined;
+            }
+            if (interruptionTimer !== undefined) {
+              clearTimeout(interruptionTimer);
+              interruptionTimer = undefined;
+            }
             clearTransientStatus();
-            waitingForTerminalOutput = tab.transferId
+            waitingForTerminalOutput = pendingTransferId
               ? false
               : shouldWaitForTerminalOutput(tab.profile.kind, receivedTerminalOutput);
             const sftpAvailable =
@@ -894,12 +922,18 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               ...(sftpAvailable === false ? { sftpOpen: false } : {}),
               transferId: undefined,
             });
-            if (tab.transferId) completeTabTransfer(tab.transferId);
+            if (pendingTransferId) {
+              completeTabTransfer(pendingTransferId);
+              pendingTransferId = undefined;
+            }
             const current = useTabsStore
               .getState()
               .tabs.find((candidate) => candidate.id === tab.id);
-            if (current?.profile?.kind === 'ssh' && current.reconnectMode) {
-              ws?.send(encoder.encode(reattachCommand(current.reconnectMode)));
+            if (!attachingExistingSession && current?.profile?.kind === 'ssh') {
+              const recoveryInput = current.reconnectMode
+                ? reattachCommand(current.reconnectMode)
+                : restoreCwdCommand(reconnectCwd);
+              if (recoveryInput) socket.send(encoder.encode(recoveryInput));
             }
             flushPendingInput();
             break;
@@ -919,10 +953,12 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             break;
         }
       };
-      ws.onerror = () => {
+      socket.onerror = () => {
         socketFailed = true;
       };
-      ws.onclose = (event) => {
+      socket.onclose = (event) => {
+        if (wsRef.current === socket) wsRef.current = null;
+        if (disposed) return;
         clearTransientStatus();
         const reason =
           socketFailed && !ready && !exitMessage
@@ -931,6 +967,30 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         const reasonKind = exitMessage?.reason ?? (ready ? 'disconnected' : 'failed');
         setAuthPrompt(null);
         setHostKey(null);
+
+        // Cross-window handoff intentionally replaces this renderer. The
+        // destination owns the terminal now and will retire this source tab.
+        if (event.code === 1000 && event.reason === 'terminal transferred') return;
+
+        // A renderer socket can be severed by laptop sleep while the backend
+        // PTY/channel is still healthy. Reuse its stable id before considering
+        // a replacement connection or shell.
+        if (!exitMessage && terminalId) {
+          const delay = rendererReattachDelayMs(rendererReattachAttempts);
+          if (delay !== undefined) {
+            rendererReattachAttempts += 1;
+            updateTab(tab.id, {
+              status: 'interrupted',
+              failureReason: reason,
+              disconnectReason: undefined,
+            });
+            rendererReattachTimer = setTimeout(() => {
+              rendererReattachTimer = undefined;
+              if (!disposed && terminalId) openSocket(terminalId);
+            }, delay);
+            return;
+          }
+        }
 
         const showFinalState = () => {
           // A drop after a stable stretch is a fresh incident, not one more
@@ -1030,7 +1090,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         term.write(TERMINAL_HISTORY_DIVIDER);
       }
       if (shouldConnect) {
-        openSocket();
+        openSocket(pendingTransferId ? terminalId : undefined);
       } else {
         term.write('\x1b[90m[restored session]\x1b[0m\r\n');
         term.write('\x1b[1;36mPress any key to reconnect\x1b[0m\r\n');
@@ -1121,6 +1181,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       fileLinks?.dispose();
       keywordHighlighterRef.current?.dispose();
       if (interruptionTimer !== undefined) clearTimeout(interruptionTimer);
+      if (rendererReattachTimer !== undefined) clearTimeout(rendererReattachTimer);
+      if (rendererStableTimer !== undefined) clearTimeout(rendererStableTimer);
       if (autoReconnectTimer !== undefined) clearTimeout(autoReconnectTimer);
       if (ws) {
         ws.onopen = null;

--- a/client/src/connection-recovery.ts
+++ b/client/src/connection-recovery.ts
@@ -4,11 +4,19 @@ export type ReattachMode = 'tmux' | 'screen';
 export type TerminalExitMessage = Extract<TerminalServerMessage, { op: 'exit' }>;
 export const CONNECTION_INTERRUPTION_GRACE_MS = 5_000;
 
+/** Fast local-backend retries used before opening an entirely new session. */
+export const RENDERER_REATTACH_DELAYS_MS: readonly number[] = [0, 250, 1_000, 2_000];
+
 /** Delays before each automatic reconnect attempt after a lost connection. */
 export const AUTO_RECONNECT_DELAYS_MS: readonly number[] = [2_000, 5_000, 15_000];
 
 /** Uptime after which a drop is a fresh incident with a fresh attempt budget. */
 export const AUTO_RECONNECT_STABLE_MS = 30_000;
+
+/** Delay before retrying a stable terminal id, or undefined when exhausted. */
+export function rendererReattachDelayMs(attempts: number): number | undefined {
+  return RENDERER_REATTACH_DELAYS_MS[attempts];
+}
 
 export interface AutoReconnectInput {
   /** The auto-reconnect preference. */
@@ -83,6 +91,17 @@ export function reattachCommand(mode: ReattachMode): string {
     return "if command -v tmux >/dev/null 2>&1; then tmux attach-session 2>/dev/null || tmux new-session; else printf '\\r\\nMuxus: tmux is not installed.\\r\\n'; fi\r";
   }
   return "if command -v screen >/dev/null 2>&1; then screen -xRR; else printf '\\r\\nMuxus: screen is not installed.\\r\\n'; fi\r";
+}
+
+/**
+ * Best-effort POSIX-shell cwd restoration for a replacement SSH shell. The
+ * shell integration only reports absolute Unix paths, and single-quote
+ * escaping keeps every path byte as data rather than terminal input syntax.
+ */
+export function restoreCwdCommand(cwd: string | undefined): string | undefined {
+  if (!cwd?.startsWith('/') || cwd.length > 4096 || cwd.includes('\0')) return undefined;
+  const quoted = `'${cwd.replaceAll("'", `'"'"'`)}'`;
+  return `cd -- ${quoted} 2>/dev/null || printf '\\r\\nMuxus: could not restore the previous working directory.\\r\\n'\r`;
 }
 
 /** Keep server-provided failure text from becoming terminal control input. */

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -28,7 +28,7 @@ interface TabBase {
   title: string;
   /** Live SSH connection id from `ready`; absent for local, Telnet, and serial tabs. */
   connId?: string;
-  /** Stable server-side terminal identity, including while a connection is still opening. */
+  /** Stable server-side identity for renderer reattachment, including during setup. */
   terminalId?: string;
   /** Cross-window transfer awaiting acknowledgement from the source window. */
   transferId?: string;

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -151,6 +151,20 @@ export interface ManagedConnection {
 export type ConnectionLease = TransportLease<ManagedConnection>;
 export type SshTransportHealth = 'healthy' | 'suspect';
 
+/**
+ * Translate OpenSSH keepalive settings to ssh2 without inventing a probe
+ * interval. OpenSSH's ServerAliveInterval default is zero (disabled), while
+ * ServerAliveCountMax defaults to three when an interval is explicitly set.
+ */
+export function sshKeepaliveOptions(
+  resolved: Pick<ResolvedTarget, 'serverAliveInterval' | 'serverAliveCountMax'>,
+): Required<Pick<ConnectConfig, 'keepaliveInterval' | 'keepaliveCountMax'>> {
+  return {
+    keepaliveInterval: (resolved.serverAliveInterval ?? 0) * 1000,
+    keepaliveCountMax: resolved.serverAliveCountMax ?? 3,
+  };
+}
+
 export interface MuxedConnectionLease extends TransportLease<ManagedConnection> {
   /** True when this lease multiplexes onto a pre-existing transport instead of a fresh dial. */
   reused: boolean;
@@ -549,10 +563,11 @@ export class SshConnectionManager {
         hopHealth.set(i, 'healthy');
         const transport = (client as Client & { _sock?: Duplex })._sock;
         if (transport) {
+          const keepalive = sshKeepaliveOptions(hop.resolved);
           stopHealthObservers.push(
             observeSshTransportHealth(
               transport,
-              (hop.resolved.serverAliveInterval ?? 15) * 1000,
+              keepalive.keepaliveInterval,
               (state) => updateHopHealth(i, state),
             ),
           );
@@ -762,8 +777,7 @@ export class SshConnectionManager {
       // ssh2's deadline includes time spent in UI prompts and cannot be
       // paused. An equivalent pausable deadline is installed below.
       readyTimeout: 0,
-      keepaliveInterval: (hop.resolved.serverAliveInterval ?? 15) * 1000,
-      keepaliveCountMax: hop.resolved.serverAliveCountMax ?? 3,
+      ...sshKeepaliveOptions(hop.resolved),
       ...(algorithms ? { algorithms } : {}),
       hostVerifier: (key: Buffer, verify: (valid: boolean) => void) => {
         void this.verifyHostKey(hop, key, io, runInteraction).then(verify, (err) => {

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -22,6 +22,8 @@ import {
 
 const CONNECT_TIMEOUT_MS = 30_000;
 const KEEPALIVE_MS = 30_000;
+/** Time for a renderer WebSocket to return after sleep or a network handoff. */
+export const TERMINAL_REATTACH_GRACE_MS = 15_000;
 /** Pause the upstream when the browser socket buffers more than this. */
 const BACKPRESSURE_HIGH = 4 * 1024 * 1024;
 const BACKPRESSURE_POLL_MS = 50;
@@ -46,19 +48,27 @@ export class TransferableTerminalSocket extends EventEmitter {
   readonly OPEN = 1;
   private current: WebSocket;
   private closed = false;
+  private detached = false;
+  private detachTimer: NodeJS.Timeout | undefined;
   private readonly controls = new Map<string, string>();
   private bufferingTransfer = false;
   private bufferedTransferBytes = 0;
   private readonly transferBuffer: Buffer[] = [];
 
-  constructor(readonly terminalId: string, socket: WebSocket) {
+  constructor(
+    readonly terminalId: string,
+    socket: WebSocket,
+    private readonly reattachGraceMs = TERMINAL_REATTACH_GRACE_MS,
+  ) {
     super();
     this.current = socket;
     this.bind(socket);
   }
 
   get readyState(): number {
-    return this.closed ? 3 : this.current.readyState;
+    // The facade remains writable while its renderer is detached. Binary
+    // output is buffered below and control frames are replayed on attach.
+    return this.closed ? 3 : this.OPEN;
   }
 
   get bufferedAmount(): number {
@@ -73,6 +83,9 @@ export class TransferableTerminalSocket extends EventEmitter {
   /** Move this terminal to a new renderer without emitting lifecycle close. */
   attach(socket: WebSocket, cols: number, rows: number): boolean {
     if (this.closed) return false;
+    if (this.detachTimer) clearTimeout(this.detachTimer);
+    this.detachTimer = undefined;
+    this.detached = false;
     const previous = this.current;
     this.unbind(previous);
     this.current = socket;
@@ -92,6 +105,7 @@ export class TransferableTerminalSocket extends EventEmitter {
   }
 
   send(data: string | Buffer, options?: { binary?: boolean }): void {
+    if (this.closed) return;
     if (typeof data === 'string') {
       try {
         const message = JSON.parse(data) as { op?: string };
@@ -107,10 +121,12 @@ export class TransferableTerminalSocket extends EventEmitter {
         /* ordinary text frame */
       }
     }
-    if (this.bufferingTransfer && Buffer.isBuffer(data) && options?.binary) {
-      const buffered = Buffer.from(data);
-      this.transferBuffer.push(buffered);
-      this.bufferedTransferBytes += buffered.byteLength;
+    if (
+      Buffer.isBuffer(data) &&
+      options?.binary &&
+      (this.bufferingTransfer || this.detached || this.current.readyState !== this.current.OPEN)
+    ) {
+      this.bufferTransferData(data);
       return;
     }
     if (this.current.readyState === this.current.OPEN) {
@@ -155,7 +171,19 @@ export class TransferableTerminalSocket extends EventEmitter {
     this.emit('message', data, isBinary);
   };
 
-  private readonly handleClose = (): void => this.finish();
+  private readonly handleClose = (): void => {
+    if (this.closed || this.detached) return;
+    this.detached = true;
+    if (this.reattachGraceMs <= 0) {
+      this.finish();
+      return;
+    }
+    this.detachTimer = setTimeout(() => {
+      this.detachTimer = undefined;
+      this.finish();
+    }, this.reattachGraceMs);
+    this.detachTimer.unref?.();
+  };
 
   private bind(socket: WebSocket): void {
     socket.on('message', this.handleMessage);
@@ -174,9 +202,31 @@ export class TransferableTerminalSocket extends EventEmitter {
     for (const data of buffered) socket.send(data, { binary: true });
   }
 
+  /** Keep the newest bounded tail while no renderer can apply backpressure. */
+  private bufferTransferData(data: Buffer): void {
+    let buffered = Buffer.from(data);
+    if (buffered.byteLength >= BACKPRESSURE_HIGH) {
+      this.transferBuffer.length = 0;
+      buffered = buffered.subarray(buffered.byteLength - BACKPRESSURE_HIGH);
+      this.bufferedTransferBytes = 0;
+    }
+    while (
+      this.transferBuffer.length > 0 &&
+      this.bufferedTransferBytes + buffered.byteLength > BACKPRESSURE_HIGH
+    ) {
+      const removed = this.transferBuffer.shift()!;
+      this.bufferedTransferBytes -= removed.byteLength;
+    }
+    this.transferBuffer.push(buffered);
+    this.bufferedTransferBytes += buffered.byteLength;
+  }
+
   private finish(): void {
     if (this.closed) return;
     this.closed = true;
+    this.detached = false;
+    if (this.detachTimer) clearTimeout(this.detachTimer);
+    this.detachTimer = undefined;
     this.transferBuffer.length = 0;
     this.bufferedTransferBytes = 0;
     this.unbind(this.current);
@@ -191,7 +241,11 @@ export class TransferableTerminalSocket extends EventEmitter {
  * (shell-less SSH transport for tunnels); SSH connections may interleave
  * `auth-prompt`/`host-key` round-trips before `ready`.
  */
-export function registerTerminalSocket(app: FastifyInstance, ctx: AppContext): void {
+export function registerTerminalSocket(
+  app: FastifyInstance,
+  ctx: AppContext,
+  options: { reattachGraceMs?: number } = {},
+): void {
   const sessions = new Map<string, TransferableTerminalSocket>();
   app.get('/ws/terminal', { websocket: true }, (socket) => {
     const timer = setTimeout(() => socket.close(1008, 'timed out waiting for connect'), CONNECT_TIMEOUT_MS);
@@ -228,7 +282,11 @@ export function registerTerminalSocket(app: FastifyInstance, ctx: AppContext): v
       }
 
       const terminalId = `terminal-${nanoid(16)}`;
-      const transferable = new TransferableTerminalSocket(terminalId, socket);
+      const transferable = new TransferableTerminalSocket(
+        terminalId,
+        socket,
+        options.reattachGraceMs,
+      );
       sessions.set(terminalId, transferable);
       transferable.once('close', () => sessions.delete(terminalId));
       const stableSocket = transferable as unknown as WebSocket;

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -3,7 +3,11 @@ import type { FastifyInstance } from 'fastify';
 import type { WebSocket } from 'ws';
 import { nanoid } from 'nanoid';
 import type { TerminalServerMessage } from '@muxus/shared';
-import { terminalClientMessageSchema, type TerminalClientMessage } from '@muxus/shared/ws-protocol';
+import {
+  TERMINAL_SESSION_CLOSE_REASON,
+  terminalClientMessageSchema,
+  type TerminalClientMessage,
+} from '@muxus/shared/ws-protocol';
 import type { AppContext } from '../app.js';
 import type { ConnectIo } from '../ssh/connection-manager.js';
 import {
@@ -171,8 +175,12 @@ export class TransferableTerminalSocket extends EventEmitter {
     this.emit('message', data, isBinary);
   };
 
-  private readonly handleClose = (): void => {
+  private readonly handleClose = (code: number, reason: Buffer): void => {
     if (this.closed || this.detached) return;
+    if (code === 1000 && reason.toString('utf8') === TERMINAL_SESSION_CLOSE_REASON) {
+      this.finish();
+      return;
+    }
     this.detached = true;
     if (this.reattachGraceMs <= 0) {
       this.finish();

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 export const TERMINAL_WS_PROTOCOL = 'muxus.terminal.v1';
 /** Authentication is offered as a non-selected subprotocol so it stays out of request URLs. */
 export const TERMINAL_WS_AUTH_PREFIX = 'muxus.auth.';
+/** Clean-close reason that explicitly ends the backend terminal lifecycle. */
+export const TERMINAL_SESSION_CLOSE_REASON = 'terminal session closed';
 
 /** Protocols offered by browser WebSocket clients during the HTTP upgrade. */
 export function terminalWebSocketProtocols(token: string): string[] {

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -133,7 +133,7 @@ export const terminalClientMessageSchema = z.discriminatedUnion('op', [
    * lease, forwards started on the connId) is gone.
    */
   z.object({ op: z.literal('dial'), profile: sshProfileSchema }),
-  /** Take ownership of a live terminal session from another app window. */
+  /** Attach to a live terminal after a renderer interruption or window handoff. */
   z.object({
     op: z.literal('attach'),
     terminalId: z.string().min(1).max(200),
@@ -171,7 +171,7 @@ export type TerminalClientMessage = z.infer<typeof terminalClientMessageSchema>;
 
 /** Text frames the server sends on /ws/terminal. */
 export type TerminalServerMessage =
-  /** Stable server-side terminal identity used for cross-window handoff. */
+  /** Stable server-side identity used for renderer reattachment and window handoff. */
   | { op: 'session'; terminalId: string }
   /** Outbound terminal bytes are frozen and can now be snapshotted without a gap. */
   | { op: 'transfer-ready' }

--- a/tests/unit/client/connection-recovery.test.ts
+++ b/tests/unit/client/connection-recovery.test.ts
@@ -5,6 +5,9 @@ import {
   CONNECTION_INTERRUPTION_GRACE_MS,
   connectionFailureReason,
   reattachCommand,
+  rendererReattachDelayMs,
+  RENDERER_REATTACH_DELAYS_MS,
+  restoreCwdCommand,
   shouldDelayConnectionLost,
   shouldWaitForTerminalOutput,
   terminalNotice,
@@ -99,6 +102,17 @@ describe('automatic reconnection', () => {
   });
 });
 
+describe('renderer reattachment', () => {
+  it('retries a stable backend terminal before opening a replacement shell', () => {
+    expect(
+      RENDERER_REATTACH_DELAYS_MS.map((_delay, attempts) =>
+        rendererReattachDelayMs(attempts),
+      ),
+    ).toEqual(RENDERER_REATTACH_DELAYS_MS);
+    expect(rendererReattachDelayMs(RENDERER_REATTACH_DELAYS_MS.length)).toBeUndefined();
+  });
+});
+
 describe('multiplexer reattachment', () => {
   it('attaches an existing tmux session or creates one', () => {
     const command = reattachCommand('tmux');
@@ -109,5 +123,20 @@ describe('multiplexer reattachment', () => {
 
   it('uses screen reattachment mode', () => {
     expect(reattachCommand('screen')).toContain('screen -xRR');
+  });
+});
+
+describe('working-directory restoration', () => {
+  it('quotes the last integrated cwd as shell data', () => {
+    expect(restoreCwdCommand("/srv/team's $(project)")).toBe(
+      "cd -- '/srv/team'\"'\"'s $(project)' 2>/dev/null || printf '\\r\\nMuxus: could not restore the previous working directory.\\r\\n'\r",
+    );
+  });
+
+  it('only restores bounded absolute Unix paths', () => {
+    expect(restoreCwdCommand('relative/path')).toBeUndefined();
+    expect(restoreCwdCommand('C:\\work')).toBeUndefined();
+    expect(restoreCwdCommand(`/srv/${'x'.repeat(4092)}`)).toBeUndefined();
+    expect(restoreCwdCommand('/srv/bad\0path')).toBeUndefined();
   });
 });

--- a/tests/unit/server/chain.test.ts
+++ b/tests/unit/server/chain.test.ts
@@ -9,6 +9,7 @@ import {
   findMetadataAlias,
   muxKey,
   observeSshTransportHealth,
+  sshKeepaliveOptions,
   terminalPtyOptions,
 } from '../../../server/src/ssh/connection-manager.js';
 import { loadConfigDocument } from '../../../server/src/ssh/ssh-config.js';
@@ -185,6 +186,22 @@ describe('terminalPtyOptions', () => {
 });
 
 describe('passive SSH transport health', () => {
+  it('uses OpenSSH-compatible defaults without implicit probes', () => {
+    expect(sshKeepaliveOptions({})).toEqual({
+      keepaliveInterval: 0,
+      keepaliveCountMax: 3,
+    });
+  });
+
+  it('honors explicit ServerAlive settings', () => {
+    expect(
+      sshKeepaliveOptions({ serverAliveInterval: 45, serverAliveCountMax: 7 }),
+    ).toEqual({
+      keepaliveInterval: 45_000,
+      keepaliveCountMax: 7,
+    });
+  });
+
   it('turns suspect after two silent keepalive intervals and recovers on input', () => {
     vi.useFakeTimers();
     const transport = new PassThrough();

--- a/tests/unit/server/terminal-socket-dial.test.ts
+++ b/tests/unit/server/terminal-socket-dial.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TERMINAL_SESSION_CLOSE_REASON } from '@muxus/shared/ws-protocol';
 import {
   registerTerminalSocket,
   TERMINAL_REATTACH_GRACE_MS,
@@ -15,10 +16,10 @@ class TestSocket extends EventEmitter {
   readonly send = vi.fn();
   readonly ping = vi.fn();
 
-  close(): void {
+  close(code?: number, reason?: string): void {
     if (this.readyState !== this.OPEN) return;
     this.readyState = 3;
-    this.emit('close');
+    this.emit('close', code ?? 1005, Buffer.from(reason ?? ''));
   }
 }
 
@@ -121,6 +122,21 @@ describe('transferable terminal sockets', () => {
     expect(onClose).toHaveBeenCalledOnce();
     expect(terminal.attach(new TestSocket() as never, 80, 24)).toBe(false);
   });
+
+  it('ends immediately when the renderer explicitly closes the session', () => {
+    vi.useFakeTimers();
+    const source = new TestSocket();
+    const terminal = new TransferableTerminalSocket('terminal-1', source as never);
+    const onClose = vi.fn();
+    terminal.on('close', onClose);
+
+    source.close(1000, TERMINAL_SESSION_CLOSE_REASON);
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(terminal.attach(new TestSocket() as never, 80, 24)).toBe(false);
+    vi.advanceTimersByTime(TERMINAL_REATTACH_GRACE_MS);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
 });
 
 describe('terminal socket dial mode', () => {
@@ -159,7 +175,7 @@ describe('terminal socket dial mode', () => {
       connections: { connect },
       database: { recordOpenSshConnection: vi.fn() },
     };
-    registerTerminalSocket(app as never, ctx as never, { reattachGraceMs: 0 });
+    registerTerminalSocket(app as never, ctx as never);
 
     const socket = new TestSocket();
     route(socket);
@@ -223,7 +239,7 @@ describe('terminal socket dial mode', () => {
         user: 'alice',
       }),
     );
-    destination.close();
+    destination.close(1000, TERMINAL_SESSION_CLOSE_REASON);
     expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/server/terminal-socket-dial.test.ts
+++ b/tests/unit/server/terminal-socket-dial.test.ts
@@ -1,9 +1,12 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   registerTerminalSocket,
+  TERMINAL_REATTACH_GRACE_MS,
   TransferableTerminalSocket,
 } from '../../../server/src/ws/terminal-socket.js';
+
+afterEach(() => vi.useRealTimers());
 
 class TestSocket extends EventEmitter {
   readonly OPEN = 1;
@@ -72,7 +75,51 @@ describe('transferable terminal sockets', () => {
     destination.emit('message', Buffer.from('hello'), true);
     expect(onMessage).toHaveBeenLastCalledWith(Buffer.from('hello'), true);
     destination.close();
+    expect(onClose).not.toHaveBeenCalled();
+    terminal.close();
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('retains and reattaches a session after an unexpected renderer close', () => {
+    vi.useFakeTimers();
+    const source = new TestSocket();
+    const destination = new TestSocket();
+    const terminal = new TransferableTerminalSocket('terminal-1', source as never);
+    const onClose = vi.fn();
+    terminal.on('close', onClose);
+    terminal.send(JSON.stringify({ op: 'session', terminalId: 'terminal-1' }));
+    terminal.send(JSON.stringify({ op: 'ready', connId: 'connection-1' }));
+    source.send.mockClear();
+
+    source.close();
+    terminal.send(Buffer.from('output while asleep'), { binary: true });
+    vi.advanceTimersByTime(TERMINAL_REATTACH_GRACE_MS - 1);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(terminal.attach(destination as never, 120, 40)).toBe(true);
+    expect(destination.send).toHaveBeenCalledWith(
+      Buffer.from('output while asleep'),
+      { binary: true },
+    );
+
+    vi.advanceTimersByTime(TERMINAL_REATTACH_GRACE_MS);
+    expect(onClose).not.toHaveBeenCalled();
+    terminal.close();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('ends a detached session after its reattachment grace expires', () => {
+    vi.useFakeTimers();
+    const source = new TestSocket();
+    const terminal = new TransferableTerminalSocket('terminal-1', source as never);
+    const onClose = vi.fn();
+    terminal.on('close', onClose);
+
+    source.close();
+    vi.advanceTimersByTime(TERMINAL_REATTACH_GRACE_MS);
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(terminal.attach(new TestSocket() as never, 80, 24)).toBe(false);
   });
 });
 
@@ -112,7 +159,7 @@ describe('terminal socket dial mode', () => {
       connections: { connect },
       database: { recordOpenSshConnection: vi.fn() },
     };
-    registerTerminalSocket(app as never, ctx as never);
+    registerTerminalSocket(app as never, ctx as never, { reattachGraceMs: 0 });
 
     const socket = new TestSocket();
     route(socket);


### PR DESCRIPTION
Closes #96.

## Summary

- retain local, SSH, Telnet, and serial terminal sessions during brief renderer/WebSocket interruptions and reattach them by stable terminal ID
- use OpenSSH-compatible keepalive defaults while continuing to honor explicit `ServerAliveInterval` and `ServerAliveCountMax` settings
- restore the last shell-integration working directory safely when an SSH redial must open a new shell
- keep detached output bounded and replay the newest buffered output after reattachment

## Root cause

The SSH client implicitly enabled a 15-second keepalive interval even when the user's OpenSSH configuration did not. Separately, the terminal backend tied PTY and remote-channel ownership directly to the renderer WebSocket, so a renderer interruption immediately destroyed otherwise healthy sessions.

## Impact

Ordinary laptop sleep and short renderer interruptions now preserve the existing shell whenever it remains usable. Truly closed transports continue through the existing interrupted and automatic-redial states. A replacement SSH shell restores only its previous directory and is not presented as a resumed process.

## Validation

- `pnpm test` — 861 passed, 3 skipped
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- live local PTY reattachment test: renderer terminated, detached output replayed, PID/cwd/terminal ID/connection ID unchanged
- live SSH reattachment test against a disposable OpenSSH container with the same identity and output checks