### PR TITLE
Add unshifted terminal paste shortcut

### DIFF
--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -40,6 +40,7 @@ import {
 } from '../api/http.js';
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import { copyToClipboard, readFromClipboard } from '../clipboard.js';
+import { useChordLabel } from '../keymap/hints.js';
 import { loadMonacoTextEditor, loadRemoteEditorWorkspace } from '../lazy-features.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
 import { showToast } from '../state/toast.js';
@@ -270,6 +271,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const backgroundColor = usePrefsStore((s) => s.backgroundColor);
   const globalKeywordHighlights = usePrefsStore((s) => s.keywordHighlights);
   const keywordHighlightProfiles = usePrefsStore((s) => s.keywordHighlightProfiles);
+  const copyChord = useChordLabel('terminal.copy');
+  const pasteChord = useChordLabel('terminal.paste');
   const scheme = terminalScheme(schemeId);
   const terminalTheme = useMemo(
     () => themeWithColorOverrides(scheme.theme, fontColor, backgroundColor),
@@ -1466,9 +1469,11 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             <ContentCopyIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Copy</ListItemText>
-          <Typography variant="caption" color="text.secondary" sx={{ ml: 3 }}>
-            Ctrl+Shift+C
-          </Typography>
+          {copyChord ? (
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 3 }}>
+              {copyChord}
+            </Typography>
+          ) : null}
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -1480,9 +1485,11 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             <ContentPasteIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Paste</ListItemText>
-          <Typography variant="caption" color="text.secondary" sx={{ ml: 3 }}>
-            Ctrl+Shift+V
-          </Typography>
+          {pasteChord ? (
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 3 }}>
+              {pasteChord}
+            </Typography>
+          ) : null}
         </MenuItem>
         <Divider />
         <MenuItem

--- a/client/src/keymap/commands.ts
+++ b/client/src/keymap/commands.ts
@@ -283,7 +283,7 @@ export const KEY_COMMANDS: readonly KeyCommand[] = [
     id: 'terminal.paste',
     title: 'Paste into terminal',
     category: 'terminal',
-    defaultChords: ['Mod+Shift+V'],
+    defaultChords: ['Mod+V', 'Mod+Shift+V'],
     palette: false,
     run: () => {
       const handle = activeTerminal();

--- a/docs/guide/terminal.md
+++ b/docs/guide/terminal.md
@@ -80,7 +80,9 @@ expression options. Every match is marked in the scrollbar.
 
 ## Copy, paste and export
 
-- **Copy** ++ctrl+shift+c++, **paste** ++ctrl+shift+v++. *Copy on select* is optional.
+- **Copy** ++ctrl+shift+c++. **Paste** uses ++ctrl+v++ (or ++cmd+v++ on macOS), with
+  ++ctrl+shift+v++ available as the terminal-style alternative. *Copy on select* is
+  optional.
 - **Right-click** is configurable: copy-selection-otherwise-paste (the terminal
   convention), always paste, or a context menu.
 - **Select all** ++ctrl+shift+a++, **copy all output** and **clear scrollback**

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -16,9 +16,9 @@ resetting them.
 
 !!! info "`Mod` is Ctrl, or Command on macOS"
 
-    One default table serves every platform. Chords marked ++ctrl++ below are ++cmd++ on
-    macOS. A few extra Command-only chords exist on macOS where Ctrl belongs to the shell:
-    ++cmd+w++ closes a tab, and ++cmd+1++ … ++cmd+9++ select one.
+    Chords marked ++ctrl++ below are ++cmd++ on macOS. A few extra Command-only chords
+    exist on macOS where Ctrl belongs to the shell: ++cmd+w++ closes a tab, and
+    ++cmd+1++ … ++cmd+9++ select one.
 
 ## Panes
 
@@ -51,7 +51,7 @@ resetting them.
 | Command | Chord |
 | --- | --- |
 | Copy selection | ++ctrl+shift+c++ |
-| Paste | ++ctrl+shift+v++ |
+| Paste | ++ctrl+v++, ++ctrl+shift+v++ |
 | Show [saved command menu](../guide/commands.md#keyboard-menu) | ++ctrl+space++ |
 | Find in terminal | ++ctrl+shift+f++ |
 | Select all output | ++ctrl+shift+a++ |

--- a/tests/unit/client/keymap.test.ts
+++ b/tests/unit/client/keymap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildBindingIndex,
   chordsAreDefault,
@@ -19,7 +19,14 @@ import {
   parseChord,
 } from '../../../client/src/keymap/chords.js';
 import { KEY_COMMANDS, keyCommand } from '../../../client/src/keymap/commands.js';
+import { useTabsStore } from '../../../client/src/state/tabs.js';
 import { useUiStore } from '../../../client/src/state/ui.js';
+import {
+  registerTerminal,
+  type TerminalHandle,
+} from '../../../client/src/terminal/terminal-registry.js';
+
+afterEach(() => vi.unstubAllGlobals());
 
 const keyEvent = (
   key: string,
@@ -116,6 +123,33 @@ describe('default bindings', () => {
     expect(commandsForChord('Ctrl+KeyW')).toEqual([]);
     expect(commandsForChord('Alt+Digit3').map((command) => command.id)).toEqual(['tab.select.3']);
     expect(commandsForChord('Ctrl+Shift+KeyW').map((command) => command.id)).toEqual(['tab.close']);
+  });
+
+  it('binds both desktop-native and terminal-style paste chords', () => {
+    expect(commandsForChord('Ctrl+KeyV').map((command) => command.id)).toEqual([
+      'terminal.paste',
+    ]);
+    expect(commandsForChord('Ctrl+Shift+KeyV').map((command) => command.id)).toEqual([
+      'terminal.paste',
+    ]);
+    expect(commandChords(keyCommand('terminal.paste')!, { 'terminal.paste': [] })).toEqual([]);
+  });
+
+  it('routes keyboard paste through the active terminal paste pipeline', async () => {
+    const readText = vi.fn(async () => 'first line\nsecond line');
+    const paste = vi.fn();
+    vi.stubGlobal('navigator', { clipboard: { readText } });
+    const unregister = registerTerminal('paste-target', { paste } as unknown as TerminalHandle);
+    const previousActiveId = useTabsStore.getState().activeId;
+    useTabsStore.setState({ activeId: 'paste-target' });
+
+    try {
+      expect(keyCommand('terminal.paste')?.run()).toBe(true);
+      await vi.waitFor(() => expect(paste).toHaveBeenCalledWith('first line\nsecond line'));
+    } finally {
+      unregister();
+      useTabsStore.setState({ activeId: previousActiveId });
+    }
   });
 
   it('binds multi-execution to a chord of its own', () => {


### PR DESCRIPTION
Closes #97

## Summary

- add `Ctrl+V` as a default terminal paste shortcut on Windows and Linux, and `Cmd+V` on macOS
- retain `Ctrl+Shift+V` / `Cmd+Shift+V` as terminal-style alternatives
- render context-menu shortcut labels from the effective keybindings so platform defaults and user overrides stay accurate
- document the updated defaults and cover binding overrides plus terminal paste routing in unit tests

## Why

The command table only exposed the shifted terminal-style paste chord. Adding the ordinary desktop paste chord makes the focused terminal behave as users expect while keeping all keyboard paste routes on the existing terminal paste pipeline, including multiline confirmation and bracketed-paste handling.

## Validation

- `pnpm exec vitest run unit/client/keymap.test.ts`
- client and test TypeScript checks
- `pnpm lint`
- client production build
- documentation build
- Electron runtime verification of `Ctrl+V` paste on Linux