### PR TITLE
Treat macOS numpad Enter as terminal Return

### DIFF
--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -41,6 +41,7 @@ import {
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import { copyToClipboard, readFromClipboard } from '../clipboard.js';
 import { loadMonacoTextEditor, loadRemoteEditorWorkspace } from '../lazy-features.js';
+import { IS_MAC } from '../platform.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
 import { showToast } from '../state/toast.js';
 import { broadcastTerminalInput } from '../state/multi-exec.js';
@@ -71,6 +72,7 @@ import {
 import { openTerminalWebLink } from '../terminal/web-links.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
+import { normalizeTerminalKeyboardInput } from '../terminal/keyboard-input.js';
 import {
   terminalRightClickIntent,
   xtermRightClickSelectsWord,
@@ -1114,8 +1116,17 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       return true;
     };
 
+    // onKey fires synchronously before onData and carries the DOM event that
+    // produced the encoded bytes. Keep it only long enough to normalize that
+    // one emission; protocol replies and programmatic input have no key event.
+    let inputKeyEvent: KeyboardEvent | undefined;
+    const onKey = term.onKey(({ domEvent }) => {
+      inputKeyEvent = domEvent;
+    });
     const onData = term.onData((data) => {
-      if (sendInput(data)) broadcastTerminalInput(tab.id, data);
+      const normalized = normalizeTerminalKeyboardInput(data, inputKeyEvent, IS_MAC);
+      inputKeyEvent = undefined;
+      if (sendInput(normalized)) broadcastTerminalInput(tab.id, normalized);
       else reconnectFromTerminalInput();
     });
     const onBinary = term.onBinary((data) => {
@@ -1176,6 +1187,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       unregister();
       el.removeEventListener('paste', onNativePaste, true);
       el.removeEventListener('wheel', onWheel, true);
+      onKey.dispose();
       onData.dispose();
       onBinary.dispose();
       onResize.dispose();

--- a/client/src/terminal/keyboard-input.ts
+++ b/client/src/terminal/keyboard-input.ts
@@ -1,0 +1,29 @@
+const KITTY_KEYPAD_ENTER = '\ue046';
+
+type TerminalKeyboardEvent = Pick<
+  KeyboardEvent,
+  'code' | 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'
+>;
+
+/**
+ * Work around xterm's Kitty encoder exposing KP_Enter's private-use code point
+ * on macOS when no negotiated mode encoded it as a CSI-u sequence.
+ */
+export function normalizeTerminalKeyboardInput(
+  data: string,
+  event: TerminalKeyboardEvent | undefined,
+  isMac: boolean,
+): string {
+  if (
+    isMac &&
+    data === KITTY_KEYPAD_ENTER &&
+    event?.code === 'NumpadEnter' &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  ) {
+    return '\r';
+  }
+  return data;
+}

--- a/tests/unit/client/terminal-keyboard.test.ts
+++ b/tests/unit/client/terminal-keyboard.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTerminalKeyboardInput } from '../../../client/src/terminal/keyboard-input.js';
+
+function keyEvent(
+  code: string,
+  modifiers: Partial<Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>> = {},
+) {
+  return {
+    code,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...modifiers,
+  };
+}
+
+describe('terminal keyboard input', () => {
+  it('turns the macOS KP_Enter private-use glyph into carriage return', () => {
+    expect(
+      normalizeTerminalKeyboardInput('\ue046', keyEvent('NumpadEnter'), true),
+    ).toBe('\r');
+  });
+
+  it('does not change the ordinary Return key', () => {
+    expect(normalizeTerminalKeyboardInput('\r', keyEvent('Enter'), true)).toBe('\r');
+  });
+
+  it('preserves negotiated Kitty keypad reporting', () => {
+    const kittyKeypadEnter = '\x1b[57414u';
+
+    expect(
+      normalizeTerminalKeyboardInput(kittyKeypadEnter, keyEvent('NumpadEnter'), true),
+    ).toBe(kittyKeypadEnter);
+  });
+
+  it('leaves modified, non-macOS, and non-keyboard input untouched', () => {
+    expect(
+      normalizeTerminalKeyboardInput(
+        '\ue046',
+        keyEvent('NumpadEnter', { shiftKey: true }),
+        true,
+      ),
+    ).toBe('\ue046');
+    expect(normalizeTerminalKeyboardInput('\ue046', keyEvent('NumpadEnter'), false)).toBe(
+      '\ue046',
+    );
+    expect(normalizeTerminalKeyboardInput('\ue046', undefined, true)).toBe('\ue046');
+  });
+});


### PR DESCRIPTION
## Summary

- normalize the macOS `NumpadEnter` private-use code point to carriage return in legacy terminal mode
- preserve ordinary Return and negotiated Kitty CSI-u keypad reporting
- cover the U+E046 regression and unaffected input paths with unit tests

## Root cause

The current xterm Kitty keyboard encoder can emit the `KP_Enter` private-use code point (U+E046) directly when extended Kitty reporting is not active. That raw character then reaches the local or remote terminal session instead of submitting the line.

The shared terminal input path now associates xterm's encoded data with its originating DOM keyboard event and only rewrites the exact unmodified macOS `NumpadEnter`/U+E046 combination.

## Validation

- `pnpm --filter @muxus/tests test` — 866 passed, 3 skipped
- `pnpm --filter @muxus/client typecheck`
- `pnpm --filter @muxus/tests typecheck`
- `pnpm lint`
- `pnpm --filter @muxus/client build`

Closes #98