### PR TITLE
Restore terminal focus after saved commands

### DIFF
--- a/client/src/command-buttons.ts
+++ b/client/src/command-buttons.ts
@@ -1,4 +1,5 @@
 import type { CommandButton } from './state/prefs.js';
+import type { TerminalHandle } from './terminal/terminal-registry.js';
 
 const SEARCH_WORD_SEPARATOR = /\s+/;
 
@@ -20,6 +21,17 @@ export function commandButtonInput(button: CommandButton): string {
   const command = button.command.replace(/\r\n|\n/g, '\r');
   if (!button.sendEnter || command.endsWith('\r')) return command;
   return `${command}\r`;
+}
+
+/** Send a saved command and return keyboard focus to its terminal. */
+export function activateCommandButton(
+  terminal: Pick<TerminalHandle, 'focus' | 'sendInput'> | undefined,
+  button: CommandButton,
+): boolean {
+  if (!terminal) return false;
+  const sent = terminal.sendInput(commandButtonInput(button));
+  terminal.focus();
+  return sent;
 }
 
 export function newPreferenceId(prefix: string): string {

--- a/client/src/components/ActionBar.tsx
+++ b/client/src/components/ActionBar.tsx
@@ -4,7 +4,7 @@ import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
-import { commandButtonInput } from '../command-buttons.js';
+import { activateCommandButton } from '../command-buttons.js';
 import { usePrefsStore } from '../state/prefs.js';
 import { showToast } from '../state/toast.js';
 import { useTabsStore } from '../state/tabs.js';
@@ -46,7 +46,7 @@ export const ActionBar = memo(function ActionBar() {
               variant="outlined"
               disabled={!connected || !button.command}
               onClick={() => {
-                const sent = terminalHandle(activeTab?.id)?.sendInput(commandButtonInput(button));
+                const sent = activateCommandButton(terminalHandle(activeTab?.id), button);
                 if (!sent) showToast('warning', 'The active terminal is not connected.');
               }}
               sx={{ minWidth: 0, whiteSpace: 'nowrap', py: 0.25 }}

--- a/tests/unit/client/command-buttons.test.ts
+++ b/tests/unit/client/command-buttons.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  activateCommandButton,
   commandButtonInput,
   filterCommandButtons,
 } from '../../../client/src/command-buttons.js';
@@ -54,5 +55,31 @@ describe('commandButtonInput', () => {
         sendEnter: true,
       }),
     ).toBe('one\rtwo\r');
+  });
+});
+
+describe('activateCommandButton', () => {
+  it('returns focus to the terminal after sending the command', () => {
+    const events: string[] = [];
+
+    const sent = activateCommandButton(
+      {
+        sendInput: (input) => {
+          expect(input).toBe('uptime\r');
+          events.push('send');
+          return true;
+        },
+        focus: () => events.push('focus'),
+      },
+      {
+        id: 'uptime',
+        label: 'Uptime',
+        command: 'uptime',
+        sendEnter: true,
+      },
+    );
+
+    expect(sent).toBe(true);
+    expect(events).toEqual(['send', 'focus']);
   });
 });


### PR DESCRIPTION
## Summary

- return keyboard focus to the active terminal after a saved command button sends input
- add regression coverage for the send-then-focus behavior

## Root cause

Clicking a saved command left the HTML button focused. Subsequent Enter or Space key presses therefore activated the same button again and resent the command.

## User impact

After clicking a saved command, keyboard input now returns to the terminal instead of repeatedly triggering the command button.

Fixes #99.

## Validation

- full Vitest suite: 867 passed
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`