### PR TITLE
Preserve spaces when copying wrapped terminal lines

### DIFF
--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -72,6 +72,7 @@ import {
 import { openTerminalWebLink } from '../terminal/web-links.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
+import { terminalSelectionText } from '../terminal/selection-text.js';
 import { normalizeTerminalKeyboardInput } from '../terminal/keyboard-input.js';
 import {
   terminalRightClickIntent,
@@ -377,7 +378,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     if (!term) return;
     const intent = terminalRightClickIntent(
       usePrefsStore.getState().rightClickAction,
-      term.getSelection(),
+      terminalSelectionText(term),
     );
     if (intent.kind === 'menu') {
       setCtxMenu({ top: e.clientY, left: e.clientX, selection: intent.selection });
@@ -574,7 +575,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       clear: () => term.clear(),
       selectAll: () => term.selectAll(),
       hasSelection: () => term.hasSelection(),
-      getSelection: () => term.getSelection(),
+      getSelection: () => terminalSelectionText(term),
       bufferText: () => bufferText(term),
       bufferHtml: () => serialize.serializeAsHTML({ includeGlobalBackground: true }),
       persistSnapshot: async () => {
@@ -665,8 +666,20 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     // in the capture phase, and anything it declines is encoded for the shell
     // (kitty keyboard protocol included) exactly as if Muxus had no bindings.
     const onSelection = term.onSelectionChange(() => {
-      if (usePrefsStore.getState().copyOnSelect && term.hasSelection()) void copyToClipboard(term.getSelection());
+      if (usePrefsStore.getState().copyOnSelect && term.hasSelection()) {
+        void copyToClipboard(terminalSelectionText(term));
+      }
     });
+    const onNativeCopy = (event: ClipboardEvent) => {
+      if (!term.hasSelection() || !event.clipboardData) return;
+      const nativeSelection = term.getSelection();
+      const selection = terminalSelectionText(term);
+      if (selection === nativeSelection) return;
+      event.clipboardData.setData('text/plain', selection);
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    el.addEventListener('copy', onNativeCopy, { capture: true });
 
     let ws: WebSocket | undefined;
     let disposed = false;
@@ -1192,6 +1205,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       onBinary.dispose();
       onResize.dispose();
       onSelection.dispose();
+      el.removeEventListener('copy', onNativeCopy, { capture: true });
       onSearchResults.dispose();
       commandTracker.dispose();
       cwdTracker?.dispose();

--- a/client/src/terminal/selection-text.ts
+++ b/client/src/terminal/selection-text.ts
@@ -1,0 +1,75 @@
+import type { Terminal } from '@xterm/xterm';
+
+type SelectionTerminal = Pick<
+  Terminal,
+  'buffer' | 'getSelection' | 'getSelectionPosition'
+>;
+
+interface SelectionLine {
+  correct: string;
+  cached: string;
+  isWrapped: boolean;
+}
+
+/** Build xterm's normal (non-column) selection for one line-ending style. */
+function joinSelectionLines(
+  lines: readonly SelectionLine[],
+  lineEnding: '\n' | '\r\n',
+  cached: boolean,
+): string {
+  const logicalLines: string[] = [];
+  for (const line of lines) {
+    const text = (cached ? line.cached : line.correct).replaceAll('\u00a0', ' ');
+    if (line.isWrapped && logicalLines.length > 0) {
+      logicalLines[logicalLines.length - 1] += text;
+    } else {
+      logicalLines.push(text);
+    }
+  }
+  return logicalLines.join(lineEnding);
+}
+
+/**
+ * Return the selected terminal text without dropping explicit trailing spaces.
+ *
+ * xterm 6.1's line-string cache uses `trimEnd()` when an untrimmed cached line
+ * is requested with trimming enabled. That removes real spaces as well as
+ * empty cells. Selection then joins wrapped rows, changing `word 2` to
+ * `word2`. Rebuild only selections that exactly match that cache-bug shape;
+ * column selections and unrelated xterm behavior remain untouched.
+ */
+export function terminalSelectionText(term: SelectionTerminal): string {
+  const selection = term.getSelection();
+  const range = term.getSelectionPosition();
+  if (!range || range.start.y === range.end.y) return selection;
+
+  const lines: SelectionLine[] = [];
+  const buffer = term.buffer.active;
+  for (let row = range.start.y; row <= range.end.y; row += 1) {
+    const line = buffer.getLine(row);
+    if (!line) return selection;
+
+    const startColumn = row === range.start.y ? range.start.x : 0;
+    const endColumn = row === range.end.y ? range.end.x : undefined;
+    // Supplying the physical line length makes this a non-canonical request,
+    // bypassing xterm's cross-mode cache while retaining getTrimmedLength().
+    const correct = line.translateToString(
+      true,
+      startColumn,
+      endColumn ?? line.length,
+    );
+    const vulnerableCacheRequest = startColumn === 0 && endColumn === undefined;
+    lines.push({
+      correct,
+      cached: vulnerableCacheRequest ? correct.trimEnd() : correct,
+      isWrapped: row !== range.start.y && line.isWrapped,
+    });
+  }
+
+  for (const lineEnding of ['\n', '\r\n'] as const) {
+    const cached = joinSelectionLines(lines, lineEnding, true);
+    const correct = joinSelectionLines(lines, lineEnding, false);
+    if (cached !== correct && selection === cached) return correct;
+  }
+  return selection;
+}

--- a/tests/unit/client/terminal-selection.test.ts
+++ b/tests/unit/client/terminal-selection.test.ts
@@ -1,0 +1,114 @@
+import type { Terminal } from '@xterm/xterm';
+import { describe, expect, it } from 'vitest';
+import { terminalSelectionText } from '../../../client/src/terminal/selection-text.js';
+
+interface StubLine {
+  text: string;
+  isWrapped: boolean;
+}
+
+function terminalSelection(
+  lines: readonly StubLine[],
+  selection: string,
+  start = { x: 0, y: 0 },
+  end = { x: lines.at(-1)?.text.length ?? 0, y: lines.length - 1 },
+): Parameters<typeof terminalSelectionText>[0] {
+  const bufferLines = lines.map((line) => ({
+    isWrapped: line.isWrapped,
+    length: line.text.length,
+    translateToString: (
+      trimRight = false,
+      startColumn = 0,
+      endColumn = line.text.length,
+    ) => {
+      const text = line.text.slice(startColumn, endColumn);
+      if (!trimRight) return text;
+      let trimmedLength = text.length;
+      while (trimmedLength > 0 && text.charCodeAt(trimmedLength - 1) === 0) {
+        trimmedLength -= 1;
+      }
+      return text.slice(0, trimmedLength);
+    },
+  }));
+  return {
+    getSelection: () => selection,
+    getSelectionPosition: () => ({ start, end }),
+    buffer: {
+      active: {
+        getLine: (row: number) => bufferLines[row],
+      },
+    },
+  } as unknown as Pick<Terminal, 'buffer' | 'getSelection' | 'getSelectionPosition'>;
+}
+
+describe('terminal selection text', () => {
+  it('restores the explicit wrapped space from issue 100', () => {
+    const first =
+      'cfm service create vs XXXXXXXXXX alarm-priority 2 remote-mep-aging on ' +
+      'remote-mep-aging-time 300 ccm-interval ';
+    const second = '100ms alarm-time 0';
+    const term = terminalSelection(
+      [
+        { text: first, isWrapped: false },
+        { text: second, isWrapped: true },
+      ],
+      `${first.trimEnd()}${second}`,
+    );
+
+    expect(terminalSelectionText(term)).toBe(`${first}${second}`);
+  });
+
+  it('restores trailing spaces before a hard line break', () => {
+    const term = terminalSelection(
+      [
+        { text: 'abc ', isWrapped: false },
+        { text: 'def', isWrapped: false },
+      ],
+      'abc\ndef',
+    );
+
+    expect(terminalSelectionText(term)).toBe('abc \ndef');
+  });
+
+  it('preserves Windows line endings while repairing the selection', () => {
+    const term = terminalSelection(
+      [
+        { text: 'abc ', isWrapped: false },
+        { text: 'def', isWrapped: false },
+      ],
+      'abc\r\ndef',
+    );
+
+    expect(terminalSelectionText(term)).toBe('abc \r\ndef');
+  });
+
+  it('does not reinterpret a column selection across wrapped rows', () => {
+    const term = terminalSelection(
+      [
+        { text: 'abc ', isWrapped: false },
+        { text: 'def', isWrapped: true },
+      ],
+      'abc \ndef',
+    );
+
+    expect(terminalSelectionText(term)).toBe('abc \ndef');
+  });
+
+  it('does not hide unrelated differences in xterm selection output', () => {
+    const term = terminalSelection(
+      [
+        { text: 'abc ', isWrapped: false },
+        { text: 'def', isWrapped: true },
+      ],
+      'abdef',
+    );
+
+    expect(terminalSelectionText(term)).toBe('abdef');
+  });
+
+  it('leaves a single-row selection untouched', () => {
+    const term = terminalSelection([{ text: 'abc ', isWrapped: false }], 'abc');
+
+    expect(terminalSelectionText(term)).toBe('abc');
+  });
+});


### PR DESCRIPTION
## Summary

- preserve explicit trailing spaces when copied terminal output spans wrapped rows
- apply the corrected selection text to keyboard copy, copy-on-select, right-click copy, and native copy events
- add regression coverage for the command shown in issue #100, Windows line endings, hard line breaks, and column selections

## Root cause

xterm's line-string cache can use `trimEnd()` when a cached terminal row is requested for selection. That removes real trailing spaces along with empty terminal cells. When xterm then joins a wrapped row to the next row, text such as `ccm-interval 100ms` is copied as `ccm-interval100ms`.

The selection helper rebuilds only output that exactly matches this cache-bug shape, preserving other selection behavior.

Closes #100

## Validation

- full unit suite: 873 passed, 3 skipped
- focused terminal-selection tests: 6 passed
- client and test TypeScript checks
- lint
- production client build
- bundle budget check