### PR TITLE
Add focus mode

### DIFF
--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -20,7 +20,7 @@ declare global {
         setItem(name: string, value: string): void;
         removeItem(name: string): void;
       };
-      setTitleBarOverlay(options: { color: string; symbolColor: string }): void;
+      setTitleBarOverlay(options: { color: string; symbolColor: string; height: number }): void;
       /** Scale the whole window natively (the interface zoom preference). */
       setZoomFactor(factor: number): void;
       getAppInfo(): Promise<AppInfo | undefined>;

--- a/client/src/keymap/commands.ts
+++ b/client/src/keymap/commands.ts
@@ -419,6 +419,18 @@ export const KEY_COMMANDS: readonly KeyCommand[] = [
     },
   },
   {
+    id: 'app.focus-mode',
+    title: 'Toggle focus mode',
+    category: 'app',
+    defaultChords: ['Mod+Shift+B'],
+    keywords: ['distraction free', 'zen', 'fullscreen', 'hide chrome'],
+    run: () => {
+      const ui = useUiStore.getState();
+      ui.setFocusMode(!ui.focusMode);
+      return true;
+    },
+  },
+  {
     id: 'app.settings',
     title: 'Open settings',
     category: 'app',

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -56,7 +56,7 @@ const RemoteEditorWorkspace = lazy(() =>
   loadRemoteEditorWorkspace().then((module) => ({ default: module.RemoteEditorWorkspace })),
 );
 
-/** TopBar over a stable, resizable pane canvas. Hidden tabs stay mounted. */
+/** App chrome over a stable, resizable pane canvas. Hidden tabs stay mounted. */
 export function AppShell({
   persistWorkspace = true,
   initialWorkspace,
@@ -70,31 +70,36 @@ export function AppShell({
   const root = useTabsStore((state) => state.root);
   const activePaneId = useTabsStore((state) => state.activePaneId);
   const zoomedPaneId = useTabsStore((state) => state.zoomedPaneId);
+  const focusMode = useUiStore((state) => state.focusMode);
   const forwardingOpen = useUiStore((state) => state.forwardingOpen);
   const setHostEditor = useUiStore((state) => state.setHostEditor);
 
   return (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <Box
+      data-focus-mode={focusMode ? 'true' : 'false'}
+      sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+    >
       <TopBar />
-      <ActionBar />
+      {focusMode ? null : <ActionBar />}
       <Box sx={{ flex: 1, display: 'flex', minHeight: 0 }}>
-        {!sidebarCollapsed && <SessionSidebar />}
+        {focusMode || sidebarCollapsed ? null : <SessionSidebar />}
         <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
           <PaneCanvas
             root={root}
             tabs={tabs}
             activePaneId={activePaneId}
             zoomedPaneId={zoomedPaneId}
+            hideChrome={focusMode}
             onAddHost={() => setHostEditor({ mode: 'new' })}
           />
         </Box>
-        {forwardingOpen && (
+        {forwardingOpen && !focusMode ? (
           <ErrorBoundary label="The forwarding panel">
             <Suspense fallback={null}>
               <ForwardingPanel />
             </Suspense>
           </ErrorBoundary>
-        )}
+        ) : null}
       </Box>
     </Box>
   );
@@ -111,12 +116,14 @@ function PaneCanvas({
   tabs,
   activePaneId,
   zoomedPaneId,
+  hideChrome,
   onAddHost,
 }: {
   root: PaneNode;
   tabs: TerminalTab[];
   activePaneId: string;
   zoomedPaneId: string | null;
+  hideChrome: boolean;
   onAddHost: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -166,7 +173,14 @@ function PaneCanvas({
       for (const [, element] of tabRefs.current) {
         const paneId = element.dataset.paneId;
         const rect = paneId ? rects.get(paneId) : undefined;
-        if (rect) positionBox(element, rect, paneId === zoomedPaneId, layout.tabStripHeight);
+        if (rect) {
+          positionBox(
+            element,
+            rect,
+            paneId === zoomedPaneId,
+            hideChrome ? 0 : layout.tabStripHeight,
+          );
+        }
       }
       for (const divider of flat.dividers) {
         const element = dividerRefs.current.get(divider.splitId);
@@ -177,7 +191,7 @@ function PaneCanvas({
         if (rect) positionBox(element, rect, false, 0);
       }
     },
-    [zoomedPaneId],
+    [hideChrome, zoomedPaneId],
   );
 
   useLayoutEffect(() => {
@@ -197,6 +211,7 @@ function PaneCanvas({
           tabNumberById={tabNumberById}
           empty={!occupiedPaneIds.has(pane.id)}
           focused={pane.id === activePaneId}
+          hideChrome={hideChrome}
           opacity={paneFocusOpacity(
             highlightedPaneIds.has(pane.id),
             dimInactivePanes,
@@ -385,6 +400,7 @@ function PaneChrome({
   tabNumberById,
   empty,
   focused,
+  hideChrome,
   opacity,
   zoomed,
   onAddHost,
@@ -394,6 +410,7 @@ function PaneChrome({
   tabNumberById: ReadonlyMap<string, number>;
   empty: boolean;
   focused: boolean;
+  hideChrome: boolean;
   opacity: number;
   zoomed: boolean;
   onAddHost: () => void;
@@ -417,12 +434,14 @@ function PaneChrome({
         ...(zoomed ? { bgcolor: 'background.default' } : {}),
       }}
     >
-      <TabStrip
-        paneId={pane.id}
-        tabNumberById={tabNumberById}
-        focused={focused}
-        zoomed={zoomed}
-      />
+      {hideChrome ? null : (
+        <TabStrip
+          paneId={pane.id}
+          tabNumberById={tabNumberById}
+          focused={focused}
+          zoomed={zoomed}
+        />
+      )}
       {empty && (
         <Box sx={{ flex: 1, minHeight: 0 }}>
           <EmptyPane onAddHost={onAddHost} />

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode, useState } from 'react';
+import { memo, type ReactNode, useLayoutEffect, useState } from 'react';
 import AppBar from '@mui/material/AppBar';
 import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
@@ -15,12 +15,14 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import BrightnessAutoOutlinedIcon from '@mui/icons-material/BrightnessAutoOutlined';
 import BoltOutlinedIcon from '@mui/icons-material/BoltOutlined';
+import CenterFocusStrongOutlinedIcon from '@mui/icons-material/CenterFocusStrongOutlined';
 import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
 import DeleteSweepOutlinedIcon from '@mui/icons-material/DeleteSweepOutlined';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import FullscreenExitOutlinedIcon from '@mui/icons-material/FullscreenExitOutlined';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import KeyboardAltOutlinedIcon from '@mui/icons-material/KeyboardAltOutlined';
 import LightModeOutlinedIcon from '@mui/icons-material/LightModeOutlined';
@@ -41,6 +43,7 @@ import ZoomOutIcon from '@mui/icons-material/ZoomOut';
 import { useForwards } from '../api/queries.js';
 import { copyToClipboard } from '../clipboard.js';
 import { layout } from '../theme.js';
+import { setTitleBarHeight } from '../titlebar-overlay.js';
 import { useChordLabel } from '../keymap/hints.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
 import { showToast } from '../state/toast.js';
@@ -72,6 +75,8 @@ export const TopBar = memo(function TopBar() {
   const mode = usePrefsStore((s) => s.themeMode);
   const sidebarCollapsed = usePrefsStore((s) => s.sidebarCollapsed);
   const setPrefs = usePrefsStore((s) => s.set);
+  const focusMode = useUiStore((s) => s.focusMode);
+  const setFocusMode = useUiStore((s) => s.setFocusMode);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
   const setCommandButtonsOpen = useUiStore((s) => s.setCommandButtonsOpen);
   const setShortcutsOpen = useUiStore((s) => s.setShortcutsOpen);
@@ -90,6 +95,7 @@ export const TopBar = memo(function TopBar() {
   const terminalReady = !!activeTab?.profile;
   const [terminalMenu, setTerminalMenu] = useState<HTMLElement | null>(null);
   const [appearanceMenu, setAppearanceMenu] = useState<HTMLElement | null>(null);
+  const focusModeChord = useChordLabel('app.focus-mode');
   const sidebarChord = useChordLabel('app.sidebar');
   const findChord = useChordLabel('terminal.find');
   const selectAllChord = useChordLabel('terminal.select-all');
@@ -102,8 +108,17 @@ export const TopBar = memo(function TopBar() {
 
   const handle = () => terminalHandle(activeTab?.id);
   const closeMenu = () => setTerminalMenu(null);
+  const toggleFocusMode = () => {
+    setTerminalMenu(null);
+    setAppearanceMenu(null);
+    setFocusMode(!focusMode);
+  };
   const currentAppearance =
     APPEARANCE_OPTIONS.find((option) => option.mode === mode) ?? SYSTEM_APPEARANCE;
+
+  useLayoutEffect(() => {
+    setTitleBarHeight(focusMode ? layout.focusTopBarHeight : layout.topBarHeight);
+  }, [focusMode]);
 
   return (
     <AppBar position="static" color="transparent" sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -116,18 +131,23 @@ export const TopBar = memo(function TopBar() {
         variant="dense"
         sx={{
           gap: 1.5,
-          minHeight: layout.topBarHeight,
           WebkitAppRegion: 'drag',
-          // double the specificity: MUI's responsive gutter rule wins otherwise
+          // Double the specificity so MUI's responsive height and gutter rules
+          // cannot make the compact focus-mode titlebar grow again.
           '&&': {
+            minHeight: focusMode ? layout.focusTopBarHeight : layout.topBarHeight,
             pl: 'calc(env(titlebar-area-x, 0px) + 16px)',
             pr: 'calc(100vw - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100vw) + 16px)',
           },
           '& button, & input, & a, & [role="button"]': {
             WebkitAppRegion: 'no-drag',
           },
+          ...(focusMode
+            ? { '& > :not([data-focus-mode-control])': { display: 'none' } }
+            : {}),
         }}
       >
+        <Box data-focus-mode-control sx={{ flex: 1, display: focusMode ? 'block' : 'none' }} />
         <Tooltip title={withChord(sidebarCollapsed ? 'Show hosts' : 'Hide hosts', sidebarChord)}>
           <IconButton size="small" aria-label="Toggle hosts sidebar" onClick={() => setPrefs({ sidebarCollapsed: !sidebarCollapsed })} sx={{ mr: 0.5 }}>
             <MenuIcon fontSize="small" />
@@ -244,6 +264,21 @@ export const TopBar = memo(function TopBar() {
             onClick={() => setSettingsOpen(true)}
           >
             <SettingsOutlinedIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={withChord(focusMode ? 'Exit focus mode' : 'Enter focus mode', focusModeChord)}>
+          <IconButton
+            data-focus-mode-control
+            size="small"
+            aria-label={focusMode ? 'Exit focus mode' : 'Enter focus mode'}
+            color={focusMode ? 'primary' : 'default'}
+            onClick={toggleFocusMode}
+          >
+            {focusMode ? (
+              <FullscreenExitOutlinedIcon fontSize="small" />
+            ) : (
+              <CenterFocusStrongOutlinedIcon fontSize="small" />
+            )}
           </IconButton>
         </Tooltip>
       </Toolbar>

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -108,15 +108,17 @@ export const TopBar = memo(function TopBar() {
 
   const handle = () => terminalHandle(activeTab?.id);
   const closeMenu = () => setTerminalMenu(null);
-  const toggleFocusMode = () => {
-    setTerminalMenu(null);
-    setAppearanceMenu(null);
-    setFocusMode(!focusMode);
-  };
+  const toggleFocusMode = () => setFocusMode(!focusMode);
   const currentAppearance =
     APPEARANCE_OPTIONS.find((option) => option.mode === mode) ?? SYSTEM_APPEARANCE;
 
   useLayoutEffect(() => {
+    // Focus mode can be entered through the global shortcut while a portaled
+    // menu is open. Clear both anchors before paint for every entry path.
+    if (focusMode) {
+      setTerminalMenu(null);
+      setAppearanceMenu(null);
+    }
     setTitleBarHeight(focusMode ? layout.focusTopBarHeight : layout.topBarHeight);
   }, [focusMode]);
 

--- a/client/src/state/ui.ts
+++ b/client/src/state/ui.ts
@@ -24,6 +24,8 @@ export type FolderDialogState =
   | { mode: 'move-host'; hostKey: string; hostName: string; currentPath: string };
 
 interface UiState {
+  /** Temporary distraction-free presentation; saved visibility preferences stay untouched. */
+  focusMode: boolean;
   settingsOpen: boolean;
   commandButtonMenuOpen: boolean;
   commandButtonsOpen: boolean;
@@ -42,6 +44,7 @@ interface UiState {
   forwardingOpen: boolean;
   /** Diagnostic log viewer (settings → debug). */
   logViewerOpen: boolean;
+  setFocusMode: (active: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
   setCommandButtonMenuOpen: (open: boolean) => void;
   setCommandButtonsOpen: (open: boolean) => void;
@@ -58,6 +61,7 @@ interface UiState {
 }
 
 export const useUiStore = create<UiState>()((set) => ({
+  focusMode: false,
   settingsOpen: false,
   commandButtonMenuOpen: false,
   commandButtonsOpen: false,
@@ -71,6 +75,7 @@ export const useUiStore = create<UiState>()((set) => ({
   folderDialog: false,
   forwardingOpen: false,
   logViewerOpen: false,
+  setFocusMode: (focusMode) => set({ focusMode }),
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
   setCommandButtonMenuOpen: (commandButtonMenuOpen) => set({ commandButtonMenuOpen }),
   setCommandButtonsOpen: (commandButtonsOpen) => set({ commandButtonsOpen }),

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -26,6 +26,8 @@ declare module '@mui/material/styles' {
 export const layout = {
   /** TopBar toolbar height; the Electron titlebar overlay uses the same value. */
   topBarHeight: 52,
+  /** Minimal draggable titlebar retained while focus mode hides application chrome. */
+  focusTopBarHeight: 32,
   /** Session sidebar width. */
   sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
   /** Tab strip height under the top bar. */

--- a/client/src/titlebar-overlay.ts
+++ b/client/src/titlebar-overlay.ts
@@ -1,4 +1,4 @@
-import { titleBarColors } from './theme.js';
+import { layout, titleBarColors } from './theme.js';
 
 type TitleBarMode = 'light' | 'dark';
 
@@ -9,6 +9,7 @@ export type TitleBarDimmer = {
 };
 
 let currentMode: TitleBarMode = 'light';
+let currentHeight: number = layout.topBarHeight;
 const backdropOpacities = new Map<object, number>();
 let lastApplied: string | undefined;
 
@@ -22,14 +23,19 @@ function applyTitleBarOverlay() {
   const dim = backdropOpacities.size ? Math.max(...backdropOpacities.values()) : 0;
   const colors = titleBarColors(currentMode, { dim });
   if (transparentBackground) colors.color = '#00000000';
-  const key = `${colors.color}|${colors.symbolColor}`;
+  const key = `${colors.color}|${colors.symbolColor}|${currentHeight}`;
   if (key === lastApplied) return;
   lastApplied = key;
-  window.muxusDesktop?.setTitleBarOverlay(colors);
+  window.muxusDesktop?.setTitleBarOverlay({ ...colors, height: currentHeight });
 }
 
 export function setTitleBarMode(mode: TitleBarMode) {
   currentMode = mode;
+  applyTitleBarOverlay();
+}
+
+export function setTitleBarHeight(height: number) {
+  currentHeight = height;
   applyTitleBarOverlay();
 }
 

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -381,16 +381,23 @@ ipcMain.on('muxus:close-window', (event) => {
   senderWindow(event)?.close();
 });
 
-const overlayColorsByWindow = new WeakMap<BrowserWindow, { color: string; symbolColor: string }>();
+interface TitleBarOverlayOptions {
+  color: string;
+  symbolColor: string;
+  height: number;
+}
+
+const overlayOptionsByWindow = new WeakMap<BrowserWindow, TitleBarOverlayOptions>();
 
 /** Repaint the native overlay, sized to the window's current scale. */
-function applyTitleBarOverlay(win: BrowserWindow, colors: { color: string; symbolColor: string }): void {
+function applyTitleBarOverlay(win: BrowserWindow, options: TitleBarOverlayOptions): void {
   if (isMac) return;
-  overlayColorsByWindow.set(win, colors);
+  overlayOptionsByWindow.set(win, options);
   try {
     win.setTitleBarOverlay({
-      ...colors,
-      height: Math.round(TITLEBAR_HEIGHT * win.webContents.getZoomFactor()),
+      color: options.color,
+      symbolColor: options.symbolColor,
+      height: Math.round(options.height * win.webContents.getZoomFactor()),
     });
   } catch {
     /* overlay not supported in this environment */
@@ -401,9 +408,22 @@ ipcMain.on('muxus:set-titlebar-overlay', (event, options: unknown) => {
   if (isMac) return;
   const win = senderWindow(event);
   if (!win) return;
-  const { color, symbolColor } = (options ?? {}) as { color?: unknown; symbolColor?: unknown };
-  if (typeof color !== 'string' || typeof symbolColor !== 'string') return;
-  applyTitleBarOverlay(win, { color, symbolColor });
+  const { color, symbolColor, height } = (options ?? {}) as {
+    color?: unknown;
+    symbolColor?: unknown;
+    height?: unknown;
+  };
+  if (
+    typeof color !== 'string' ||
+    typeof symbolColor !== 'string' ||
+    typeof height !== 'number' ||
+    !Number.isFinite(height) ||
+    height < 24 ||
+    height > 200
+  ) {
+    return;
+  }
+  applyTitleBarOverlay(win, { color, symbolColor, height });
 });
 
 // Interface scale, driven by the preference rather than a zoom accelerator.
@@ -411,8 +431,8 @@ ipcMain.on('muxus:set-zoom-factor', (event, value: unknown) => {
   const win = senderWindow(event);
   if (!win || typeof value !== 'number' || !Number.isFinite(value)) return;
   win.webContents.setZoomFactor(Math.min(2, Math.max(0.5, value)));
-  const colors = overlayColorsByWindow.get(win);
-  if (colors) applyTitleBarOverlay(win, colors);
+  const options = overlayOptionsByWindow.get(win);
+  if (options) applyTitleBarOverlay(win, options);
 });
 
 // One sync call, at preload time only: the boot snapshot the bridge serves

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -99,7 +99,7 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
       ipcRenderer.send('muxus:state:remove-item', name);
     },
   },
-  setTitleBarOverlay(options: { color: string; symbolColor: string }) {
+  setTitleBarOverlay(options: { color: string; symbolColor: string; height: number }) {
     ipcRenderer.send('muxus:set-titlebar-overlay', options);
   },
   setZoomFactor(factor: number) {

--- a/tests/unit/client/keymap.test.ts
+++ b/tests/unit/client/keymap.test.ts
@@ -135,6 +135,17 @@ describe('default bindings', () => {
     useUiStore.getState().setCommandButtonMenuOpen(false);
   });
 
+  it('toggles focus mode with its default chord', () => {
+    useUiStore.getState().setFocusMode(false);
+    const commands = commandsForChord('Mod+Shift+B');
+
+    expect(commands.map((command) => command.id)).toEqual(['app.focus-mode']);
+    expect(commands[0]?.run()).toBe(true);
+    expect(useUiStore.getState().focusMode).toBe(true);
+    expect(commands[0]?.run()).toBe(true);
+    expect(useUiStore.getState().focusMode).toBe(false);
+  });
+
   it('gives every direction its own split, focus, and move-tab chord', () => {
     for (const direction of ['left', 'right', 'up', 'down'] as const) {
       expect(commandChords(keyCommand(`pane.split.${direction}`)!).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- add a transient focus mode available from the top bar, command palette, and `Ctrl/Cmd+Shift+B`
- hide the command bar, host and forwarding sidebars, and pane tab chrome without unmounting terminal sessions
- retain a compact 32px draggable title bar with a visible exit control and synchronized native window controls
- keep pane zoom independent so focus mode can show either the full split layout or only the active pane

Closes #107

## Validation

- `pnpm --filter @muxus/tests exec vitest run unit/client` (501 tests)
- `pnpm --filter @muxus/client build`
- `pnpm --filter @muxus/electron typecheck`
- changed-file lint with warnings denied
- client bundle budget check