### PR TITLE
Add database-backed SSH hosts

### DIFF
--- a/client/src/components/DataTransferSection.tsx
+++ b/client/src/components/DataTransferSection.tsx
@@ -483,6 +483,15 @@ function RestoreReviewDialog({
   const connectionCount =
     pending.document.data.sshHosts.length +
     pending.document.data.savedHosts.length;
+  const proxyCommandCount =
+    pending.document.data.sshHosts.filter(
+      (host) => !!host.options.proxyCommand?.trim(),
+    ).length +
+    pending.document.data.savedHosts.filter(
+      (host) =>
+        host.profile.kind === 'ssh' &&
+        !!host.profile.proxyCommand?.trim(),
+    ).length;
   const categories = [
     {
       key: 'preferences' as const,
@@ -673,6 +682,14 @@ function RestoreReviewDialog({
           This is a merge: items that are not in the file are never deleted.
           Active terminal sessions are not interrupted.
         </Alert>
+        {selection.connections && proxyCommandCount > 0 ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {proxyCommandCount}{' '}
+            {proxyCommandCount === 1 ? 'connection contains' : 'connections contain'} a
+            ProxyCommand. Muxus does not run it during restore, but it will run as a local
+            shell command when that connection is opened. Restore only backups you trust.
+          </Alert>
+        ) : null}
         {error ? (
           <Alert severity="error" sx={{ mb: 2 }}>
             {error} Some items may already have been restored; it is safe to

--- a/client/src/components/HostEditorDialog.tsx
+++ b/client/src/components/HostEditorDialog.tsx
@@ -7,9 +7,14 @@ import HighlightOutlinedIcon from '@mui/icons-material/HighlightOutlined';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import KeyOutlinedIcon from '@mui/icons-material/KeyOutlined';
 import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
-import { useSessionLoggingPolicy } from '../api/queries.js';
+import type { SavedHostProfile } from '@muxus/shared';
+import { useSessionLoggingPolicy, useSshConfig, useSshKeys } from '../api/queries.js';
 import { useSaveSessionLoggingPolicy } from '../api/session-history.js';
-import { useSshConfig, useSshKeys } from '../api/queries.js';
+import {
+  useDeleteHostProfile,
+  useSaveHostProfile,
+  useUpdateHostProfileMetadata,
+} from '../api/profiles.js';
 import {
   fetchHostPreview,
   useDeleteHost,
@@ -17,7 +22,7 @@ import {
   useUpsertHost,
 } from '../api/ssh-config.js';
 import { confirmDeleteHost, shortenSshPath } from '../host-actions.js';
-import { connectTarget } from '../session-actions.js';
+import { connectSavedHost, connectTarget } from '../session-actions.js';
 import {
   hostSessionLoggingDraft,
   sessionLoggingPolicyInput,
@@ -28,8 +33,10 @@ import { AuthSection } from './host-editor/AuthSection.js';
 import {
   blankDraft,
   draftFromEntry,
+  draftFromSavedSshProfile,
   draftProblem,
   draftToRequest,
+  draftToSavedSshInput,
   identityAgentForDetection,
   type HostDraft,
 } from './host-editor/draft.js';
@@ -55,7 +62,10 @@ type Section =
   | 'highlighting'
   | 'advanced';
 type OpenState = Exclude<HostEditorState, false>;
-type SshEditorState = Extract<OpenState, { mode: 'new' | 'duplicate' | 'edit' }>;
+type SshEditorState = Extract<
+  OpenState,
+  { mode: 'new' | 'duplicate' | 'edit' | 'duplicate-profile' | 'edit-profile' }
+>;
 
 export function HostEditorDialog() {
   const state = useUiStore((s) => s.hostEditor);
@@ -141,21 +151,36 @@ function initialSshDraft(state: OpenState): HostDraft {
   if (state.mode === 'edit' || state.mode === 'duplicate') {
     return draftFromEntry(state.entry, state.mode === 'duplicate');
   }
+  if (
+    (state.mode === 'edit-profile' || state.mode === 'duplicate-profile') &&
+    state.entry.profile.kind === 'ssh'
+  ) {
+    return draftFromSavedSshProfile(
+      state.entry,
+      state.mode === 'duplicate-profile',
+    );
+  }
   return blankDraft();
 }
 
 function initialNativeDraft(state: OpenState): NativeHostDraft {
-  if (state.mode === 'edit-profile' || state.mode === 'duplicate-profile') {
-    return nativeDraftFromProfile(state.entry, state.mode === 'duplicate-profile');
+  if (
+    (state.mode === 'edit-profile' || state.mode === 'duplicate-profile') &&
+    state.entry.profile.kind !== 'ssh'
+  ) {
+    return nativeDraftFromProfile(
+      state.entry,
+      state.mode === 'duplicate-profile',
+    );
   }
   return blankNativeDraft(state.mode === 'new' ? state.prefillTarget : undefined);
 }
 
 /**
- * The Host block editor — Muxus's session editor. Everything here reads and
- * writes ~/.ssh/config: general addressing, authentication (key picker with
- * agent awareness), direct/ProxyJump/ProxyCommand routing, port forwards with
- * the live tunnel diagram, and free-form options with an exact preview.
+ * The SSH editor persists either a standard OpenSSH Host block or a
+ * self-contained Muxus database profile. Both paths share the same explicit
+ * addressing, authentication, routing, forwarding, logging, and presentation
+ * controls; only OpenSSH storage exposes raw ssh_config options.
  */
 function SshHostEditorContent({
   state,
@@ -168,6 +193,11 @@ function SshHostEditorContent({
 }) {
   const setState = useUiStore((s) => s.setHostEditor);
   const { data: config } = useSshConfig();
+  const editingProfile =
+    (state.mode === 'edit-profile' || state.mode === 'duplicate-profile') &&
+    state.entry.profile.kind === 'ssh'
+      ? state.entry
+      : undefined;
   const inheritedIdentityAgent =
     state.mode === 'edit' && state.entry.options.identityAgent === undefined
       ? state.entry.resolved.identityAgent
@@ -175,7 +205,11 @@ function SshHostEditorContent({
   const detectedIdentityAgent = identityAgentForDetection(draft, inheritedIdentityAgent);
   const { data: keys } = useSshKeys(true, detectedIdentityAgent);
   const loggingPolicyKey =
-    state.mode === 'edit' ? `ssh:${state.entry.alias}` : '*';
+    state.mode === 'edit'
+      ? `ssh:${state.entry.alias}`
+      : state.mode === 'edit-profile'
+        ? `profile:${state.entry.id}`
+        : '*';
   const { data: loggingPolicy } = useSessionLoggingPolicy(loggingPolicyKey);
 
   const [section, setSection] = useState<Section>('general');
@@ -183,6 +217,7 @@ function SshHostEditorContent({
   const [previewError, setPreviewError] = useState<string | null>(null);
   const connectAfter = useRef(false);
   const savedAlias = useRef('');
+  const savedProfile = useRef<SavedHostProfile | undefined>(undefined);
 
   const editing = state.mode === 'edit' ? state.entry : undefined;
   const previousAlias = editing?.alias;
@@ -190,13 +225,27 @@ function SshHostEditorContent({
   const close = () => setState(false);
   const finish = () => {
     close();
+    if (!connectAfter.current) return;
+    if (draft.storage === 'muxus') {
+      if (savedProfile.current) connectSavedHost(savedProfile.current);
+      return;
+    }
     const alias = draft.aliasText.trim().split(/\s+/)[0];
-    if (connectAfter.current && alias) connectTarget(alias);
+    if (alias) connectTarget(alias);
   };
   const saveLoggingPolicy = useSaveSessionLoggingPolicy(finish);
   const updateMetadata = useUpdateSshMetadata(() => {
     saveLoggingPolicy.mutate({
       profileKey: `ssh:${savedAlias.current}`,
+      policy: draft.sessionLogging.inherit
+        ? null
+        : sessionLoggingPolicyInput(draft.sessionLogging),
+    });
+  });
+  const updateProfileMetadata = useUpdateHostProfileMetadata((profile) => {
+    savedProfile.current = profile;
+    saveLoggingPolicy.mutate({
+      profileKey: `profile:${profile.id}`,
       policy: draft.sessionLogging.inherit
         ? null
         : sessionLoggingPolicyInput(draft.sessionLogging),
@@ -222,7 +271,28 @@ function SshHostEditorContent({
       },
     });
   });
+  const saveProfile = useSaveHostProfile((profile) => {
+    savedProfile.current = profile;
+    const highlights = draft.keywordHighlights;
+    updateProfileMetadata.mutate({
+      id: profile.id,
+      patch: {
+        displayName: draft.displayName.trim() || null,
+        group: draft.group.trim() || null,
+        color: draft.color ?? null,
+        disableSftp: draft.disableSftp,
+        consoleCompatibility: draft.consoleCompatibility,
+        keywordHighlights:
+          highlights.inheritGlobal &&
+          !highlights.profileId &&
+          highlights.rules.length === 0
+            ? null
+            : highlights,
+      },
+    });
+  });
   const deleteHost = useDeleteHost(close);
+  const deleteProfile = useDeleteHostProfile(close);
 
   const loading = draft.sessionLogging.loaded ? null : 'Loading session logging settings…';
   const problem = loading ? null : draftProblem(draft);
@@ -235,7 +305,8 @@ function SshHostEditorContent({
         ...current,
         sessionLogging: hostSessionLoggingDraft(
           loggingPolicy,
-          state.mode !== 'edit' || !loggingPolicy.overridden,
+          (state.mode !== 'edit' && state.mode !== 'edit-profile') ||
+            !loggingPolicy.overridden,
         ),
       };
     });
@@ -243,7 +314,7 @@ function SshHostEditorContent({
 
   // Live preview of the exact block text, rendered by the server (debounced).
   useEffect(() => {
-    if (problem) return;
+    if (problem || draft.storage !== 'openssh') return;
     const timer = setTimeout(() => {
       fetchHostPreview(draftToRequest(draft, previousAlias))
         .then((text) => {
@@ -258,10 +329,30 @@ function SshHostEditorContent({
   const set = (patch: Partial<HostDraft>) => setDraft((d) => ({ ...d, ...patch }));
   const save = (connect: boolean) => {
     connectAfter.current = connect;
+    if (draft.storage === 'muxus') {
+      saveProfile.mutate(
+        draftToSavedSshInput(
+          draft,
+          state.mode === 'edit-profile'
+            ? editingProfile?.id
+            : savedProfile.current?.id,
+        ),
+      );
+      return;
+    }
     upsert.mutate(draftToRequest(draft, previousAlias));
   };
 
-  const title = state.mode === 'edit' ? `Edit ${state.entry.alias}` : state.mode === 'duplicate' ? `Duplicate ${state.entry.alias}` : 'Add host';
+  const title =
+    state.mode === 'edit'
+      ? `Edit ${state.entry.alias}`
+      : state.mode === 'duplicate'
+        ? `Duplicate ${state.entry.alias}`
+        : state.mode === 'edit-profile'
+          ? `Edit ${state.entry.name}`
+          : state.mode === 'duplicate-profile'
+            ? `Duplicate ${state.entry.name}`
+            : 'Add host';
 
   const sections: EditorSectionDef<Section>[] = [
     { value: 'general', label: 'General', icon: <DnsOutlinedIcon fontSize="small" /> },
@@ -301,7 +392,11 @@ function SshHostEditorContent({
   return (
     <EditorShell
       title={title}
-      storage={`Saved to ${shortenSshPath(draft.file || config?.path || '~/.ssh/config')}`}
+      storage={
+        draft.storage === 'muxus'
+          ? 'Saved in Muxus app data — ssh_config is unchanged'
+          : `Saved to ${shortenSshPath(draft.file || config?.path || '~/.ssh/config')}`
+      }
       typeKind={state.mode === 'new' ? 'ssh' : undefined}
       onTypeChange={
         state.mode === 'new'
@@ -313,7 +408,13 @@ function SshHostEditorContent({
       onSection={setSection}
       problem={problem}
       loading={loading}
-      busy={upsert.isPending || updateMetadata.isPending || saveLoggingPolicy.isPending}
+      busy={
+        upsert.isPending ||
+        updateMetadata.isPending ||
+        saveProfile.isPending ||
+        updateProfileMetadata.isPending ||
+        saveLoggingPolicy.isPending
+      }
       onDelete={
         state.mode === 'edit'
           ? () => {
@@ -322,13 +423,28 @@ function SshHostEditorContent({
                 if (confirmed) deleteHost.mutate(alias);
               });
             }
-          : undefined
+          : state.mode === 'edit-profile' && editingProfile
+            ? () => {
+                void confirmDeleteHost({ name: editingProfile.name }).then(
+                  (confirmed) => {
+                    if (confirmed) deleteProfile.mutate(editingProfile.id);
+                  },
+                );
+              }
+            : undefined
       }
-      deletePending={deleteHost.isPending}
+      deletePending={deleteHost.isPending || deleteProfile.isPending}
       onClose={close}
       onSave={save}
     >
-      {section === 'general' && <GeneralSection draft={draft} set={set} config={config} />}
+      {section === 'general' && (
+        <GeneralSection
+          draft={draft}
+          set={set}
+          config={config}
+          canChooseStorage={state.mode === 'new'}
+        />
+      )}
       {section === 'auth' && <AuthSection draft={draft} set={set} keys={keys} />}
       {section === 'route' && <RouteSection draft={draft} set={set} config={config} />}
       {section === 'forwards' && <ForwardsSection draft={draft} set={set} />}
@@ -348,7 +464,15 @@ function SshHostEditorContent({
           onChange={(keywordHighlights) => set({ keywordHighlights })}
         />
       )}
-      {section === 'advanced' && <AdvancedSection draft={draft} set={set} preview={preview} previewError={previewError} />}
+      {section === 'advanced' && (
+        <AdvancedSection
+          draft={draft}
+          set={set}
+          preview={preview}
+          previewError={previewError}
+          configBacked={draft.storage === 'openssh'}
+        />
+      )}
     </EditorShell>
   );
 }

--- a/client/src/components/SessionImportDialog.tsx
+++ b/client/src/components/SessionImportDialog.tsx
@@ -39,6 +39,7 @@ import {
 import type {
   ImportedSession,
   ImportedSessionParseResult,
+  ImportedSshStorage,
   SkippedImportedSession,
 } from '../session-import.js';
 import { errorDetails, showToast } from '../state/toast.js';
@@ -88,7 +89,10 @@ export function SessionImportDialog<T extends ImportedSession>({
   reviewNotice: string;
   privacyNotice: string;
   parse: (content: string) => ImportedSessionParseResult<T>;
-  connections: (sessions: readonly T[]) => PortableConnections;
+  connections: (
+    sessions: readonly T[],
+    sshStorage: ImportedSshStorage,
+  ) => PortableConnections;
   autoSource?: AutoImportSource;
 }) {
   const queryClient = useQueryClient();
@@ -98,6 +102,7 @@ export function SessionImportDialog<T extends ImportedSession>({
   const [pending, setPending] = useState<PendingImport<T> | null>(null);
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
   const [conflicts, setConflicts] = useState<TransferConflictStrategy>('keep');
+  const [sshStorage, setSshStorage] = useState<ImportedSshStorage>('muxus');
   const [search, setSearch] = useState('');
   const [busy, setBusy] = useState<'detect' | 'file' | 'import' | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -111,11 +116,14 @@ export function SessionImportDialog<T extends ImportedSession>({
     [savedProfiles?.profiles],
   );
   const isConflict = useCallback(
-    (session: ImportedSession) =>
-      session.kind === 'ssh'
-        ? existingAliases.has(session.alias)
-        : existingProfileIds.has(session.profileId),
-    [existingAliases, existingProfileIds],
+    (session: T) => {
+      const converted = connections([session], sshStorage);
+      const profile = converted.savedHosts[0];
+      if (profile) return existingProfileIds.has(profile.id);
+      const sshHost = converted.sshHosts[0];
+      return sshHost ? existingAliases.has(sshHost.alias) : false;
+    },
+    [connections, existingAliases, existingProfileIds, sshStorage],
   );
   const conflictingSessions = useMemo(
     () => pending?.parsed.sessions.filter(isConflict) ?? [],
@@ -128,6 +136,8 @@ export function SessionImportDialog<T extends ImportedSession>({
       searchableSessionValues(session).some((value) => value?.toLowerCase().includes(needle)),
     );
   }, [pending, search]);
+  const hasSshSessions =
+    pending?.parsed.sessions.some((session) => session.kind === 'ssh') ?? false;
 
   const review = (content: string, source: string) => {
     const parsed = parse(content);
@@ -183,7 +193,10 @@ export function SessionImportDialog<T extends ImportedSession>({
     setBusy('import');
     setError(null);
     try {
-      const result = await restoreImportedConnections(connections(included), conflicts);
+      const result = await restoreImportedConnections(
+        connections(included, sshStorage),
+        conflicts,
+      );
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['ssh-config'] }),
         queryClient.invalidateQueries({ queryKey: ['saved-host-profiles'] }),
@@ -257,6 +270,35 @@ export function SessionImportDialog<T extends ImportedSession>({
                 </Typography>
                 <SkippedSessionList sessions={pending.parsed.skippedSessions} />
               </Alert>
+            ) : null}
+
+            {hasSshSessions ? (
+              <FormControl>
+                <FormLabel>Store imported SSH hosts in</FormLabel>
+                <RadioGroup
+                  row
+                  value={sshStorage}
+                  onChange={(event) =>
+                    setSshStorage(event.target.value as ImportedSshStorage)
+                  }
+                >
+                  <FormControlLabel
+                    value="muxus"
+                    control={<Radio />}
+                    label="Muxus app data only"
+                  />
+                  <FormControlLabel
+                    value="openssh"
+                    control={<Radio />}
+                    label="OpenSSH config"
+                  />
+                </RadioGroup>
+                <Typography variant="caption" color="text.secondary">
+                  {sshStorage === 'muxus'
+                    ? 'SSH connection settings stay in the Muxus database; ssh_config is not changed.'
+                    : 'Creates standard Host blocks that also work with ssh in any terminal.'}
+                </Typography>
+              </FormControl>
             ) : null}
 
             <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -280,7 +280,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   );
   const { data: sshConfig } = useSshConfig(tab.profile.kind === 'ssh' && tab.profile.useConfig !== false);
   const savedProfileId =
-    tab.profile.kind === 'telnet' || tab.profile.kind === 'serial'
+    tab.profile.kind === 'ssh' ||
+    tab.profile.kind === 'telnet' ||
+    tab.profile.kind === 'serial'
       ? tab.profile.profileId
       : undefined;
   const { data: savedHosts } = useSavedHostProfiles(!!savedProfileId);

--- a/client/src/components/host-editor/AdvancedSection.tsx
+++ b/client/src/components/host-editor/AdvancedSection.tsx
@@ -29,11 +29,13 @@ export function AdvancedSection({
   set,
   preview,
   previewError,
+  configBacked = true,
 }: {
   draft: HostDraft;
   set: (patch: Partial<HostDraft>) => void;
   preview: string;
   previewError: string | null;
+  configBacked?: boolean;
 }) {
   const sshAlgorithms = useAppInfo().data?.sshAlgorithms;
   const legacyState = legacyPresetState(draft.extras);
@@ -72,101 +74,111 @@ export function AdvancedSection({
         </Typography>
       </Stack>
 
-      <Stack spacing={1}>
-        <Typography variant="body2" color="text.secondary">
-          Additional ssh_config options. Applied options are used by Muxus; others are preserved
-          for OpenSSH.
-        </Typography>
-        {draft.extras.map((e, i) => {
-          const keyword = e.keyword.trim().toLowerCase();
-          const unsupported = unsupportedEntries(e.keyword, e.value, sshAlgorithms);
-          return (
-            <Stack key={i} direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
-              <TextField
-                label="Option"
-                value={e.keyword}
-                onChange={(ev) => update(i, { keyword: ev.target.value })}
-                sx={{ width: 180, flexShrink: 0 }}
-              />
-              <TextField
-                label="Value"
-                value={e.value}
-                onChange={(ev) => update(i, { value: ev.target.value })}
-                fullWidth
-                error={unsupported.length > 0}
-                helperText={
-                  unsupported.length
-                    ? `Skipped when connecting — not supported by the SSH engine: ${unsupported.join(', ')}`
-                    : undefined
-                }
-              />
-              <Box sx={{ width: 62, flexShrink: 0, display: 'flex', justifyContent: 'center', pt: 1.25 }}>
-                {keyword &&
-                  (DIAL_TIME_KEYWORDS.has(keyword) ? (
-                    <Tooltip title="Muxus applies this option when connecting.">
-                      <Chip size="small" label="applied" color="success" variant="outlined" sx={{ height: 18, fontSize: 10 }} />
-                    </Tooltip>
-                  ) : (
-                    <Tooltip title="Kept in the config for OpenSSH — Muxus does not use this option.">
-                      <Chip size="small" label="kept" variant="outlined" sx={{ height: 18, fontSize: 10, color: 'text.secondary' }} />
-                    </Tooltip>
-                  ))}
-              </Box>
-              <IconButton size="small" aria-label="Remove option" sx={{ mt: 0.75 }} onClick={() => set({ extras: draft.extras.filter((_, j) => j !== i) })}>
-                <DeleteOutlineIcon fontSize="small" />
-              </IconButton>
-            </Stack>
-          );
-        })}
-        <Stack direction="row" spacing={1}>
-          <Button size="small" startIcon={<AddIcon />} onClick={() => set({ extras: [...draft.extras, { keyword: '', value: '' }] })}>
-            Add option
-          </Button>
-          <Tooltip
-            title={
-              legacyState === 'conflict'
-                ? 'An algorithm list uses a removal (-) policy the preset will not rewrite. Adjust the lists manually.'
-                : 'Adds the key exchange, host key and cipher options old console servers and network gear need. Merged into the modern defaults, so current hosts keep working.'
-            }
-          >
-            <span>
-              <Button
-                size="small"
-                startIcon={<SettingsEthernetIcon />}
-                disabled={legacyState === 'enabled' || legacyState === 'conflict'}
-                onClick={() => set({ extras: applyLegacyPreset(draft.extras) })}
-              >
-                Legacy device algorithms
-              </Button>
-            </span>
-          </Tooltip>
+      {configBacked ? (
+        <Stack spacing={1}>
+          <Typography variant="body2" color="text.secondary">
+            Additional ssh_config options. Applied options are used by Muxus; others are
+            preserved for OpenSSH.
+          </Typography>
+          {draft.extras.map((e, i) => {
+            const keyword = e.keyword.trim().toLowerCase();
+            const unsupported = unsupportedEntries(e.keyword, e.value, sshAlgorithms);
+            return (
+              <Stack key={i} direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+                <TextField
+                  label="Option"
+                  value={e.keyword}
+                  onChange={(ev) => update(i, { keyword: ev.target.value })}
+                  sx={{ width: 180, flexShrink: 0 }}
+                />
+                <TextField
+                  label="Value"
+                  value={e.value}
+                  onChange={(ev) => update(i, { value: ev.target.value })}
+                  fullWidth
+                  error={unsupported.length > 0}
+                  helperText={
+                    unsupported.length
+                      ? `Skipped when connecting — not supported by the SSH engine: ${unsupported.join(', ')}`
+                      : undefined
+                  }
+                />
+                <Box sx={{ width: 62, flexShrink: 0, display: 'flex', justifyContent: 'center', pt: 1.25 }}>
+                  {keyword &&
+                    (DIAL_TIME_KEYWORDS.has(keyword) ? (
+                      <Tooltip title="Muxus applies this option when connecting.">
+                        <Chip size="small" label="applied" color="success" variant="outlined" sx={{ height: 18, fontSize: 10 }} />
+                      </Tooltip>
+                    ) : (
+                      <Tooltip title="Kept in the config for OpenSSH — Muxus does not use this option.">
+                        <Chip size="small" label="kept" variant="outlined" sx={{ height: 18, fontSize: 10, color: 'text.secondary' }} />
+                      </Tooltip>
+                    ))}
+                </Box>
+                <IconButton size="small" aria-label="Remove option" sx={{ mt: 0.75 }} onClick={() => set({ extras: draft.extras.filter((_, j) => j !== i) })}>
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Stack>
+            );
+          })}
+          <Stack direction="row" spacing={1}>
+            <Button size="small" startIcon={<AddIcon />} onClick={() => set({ extras: [...draft.extras, { keyword: '', value: '' }] })}>
+              Add option
+            </Button>
+            <Tooltip
+              title={
+                legacyState === 'conflict'
+                  ? 'An algorithm list uses a removal (-) policy the preset will not rewrite. Adjust the lists manually.'
+                  : 'Adds the key exchange, host key and cipher options old console servers and network gear need. Merged into the modern defaults, so current hosts keep working.'
+              }
+            >
+              <span>
+                <Button
+                  size="small"
+                  startIcon={<SettingsEthernetIcon />}
+                  disabled={legacyState === 'enabled' || legacyState === 'conflict'}
+                  onClick={() => set({ extras: applyLegacyPreset(draft.extras) })}
+                >
+                  Legacy device algorithms
+                </Button>
+              </span>
+            </Tooltip>
+          </Stack>
         </Stack>
-      </Stack>
+      ) : null}
 
-      <Stack spacing={0.75}>
+      {configBacked ? (
+        <Stack spacing={0.75}>
+          <Typography variant="body2" color="text.secondary">
+            This is written to the config:
+          </Typography>
+          <Box
+            component="pre"
+            sx={{
+              m: 0,
+              p: 1.5,
+              borderRadius: 1,
+              border: 1,
+              borderColor: previewError ? 'error.main' : 'divider',
+              bgcolor: 'action.hover',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: 12,
+              lineHeight: 1.6,
+              overflowX: 'auto',
+              minHeight: 72,
+              whiteSpace: 'pre',
+            }}
+          >
+            {previewError ?? preview ?? ''}
+          </Box>
+        </Stack>
+      ) : (
         <Typography variant="body2" color="text.secondary">
-          This is written to the config:
+          Raw ssh_config options are only available when a host is stored in OpenSSH
+          config. The connection settings in the other sections are stored directly by
+          Muxus.
         </Typography>
-        <Box
-          component="pre"
-          sx={{
-            m: 0,
-            p: 1.5,
-            borderRadius: 1,
-            border: 1,
-            borderColor: previewError ? 'error.main' : 'divider',
-            bgcolor: 'action.hover',
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: 12,
-            lineHeight: 1.6,
-            overflowX: 'auto',
-            minHeight: 72,
-            whiteSpace: 'pre',
-          }}
-        >
-          {previewError ?? preview ?? ''}
-        </Box>
-      </Stack>
+      )}
     </Stack>
   );
 }

--- a/client/src/components/host-editor/AuthSection.tsx
+++ b/client/src/components/host-editor/AuthSection.tsx
@@ -67,7 +67,20 @@ export function AuthSection({
             <Labeled title="Agent & default keys" sub="OpenSSH order: SSH agent first, then ~/.ssh/id_* files" />
           }
         />
-        <FormControlLabel value="key" control={<Radio size="small" />} label={<Labeled title="Specific key file" sub="Writes IdentityFile — exactly these keys are offered" />} />
+        <FormControlLabel
+          value="key"
+          control={<Radio size="small" />}
+          label={
+            <Labeled
+              title="Specific key file"
+              sub={
+                draft.storage === 'openssh'
+                  ? 'Writes IdentityFile — exactly these keys are offered'
+                  : 'Exactly these keys are offered for this Muxus connection'
+              }
+            />
+          }
+        />
         <FormControlLabel
           value="password"
           control={<Radio size="small" />}
@@ -159,7 +172,10 @@ export function AuthSection({
             <Box>
               <Typography variant="body2">User certificates</Typography>
               <Typography variant="caption" color="text.secondary">
-                Writes CertificateFile. Each certificate is matched to its private key above.
+                {draft.storage === 'openssh'
+                  ? 'Writes CertificateFile. '
+                  : 'Each saved certificate is used with this Muxus connection. '}
+                Each certificate is matched to its private key above.
               </Typography>
             </Box>
             {draft.certificateFiles.map((file, i) => (
@@ -230,10 +246,12 @@ export function AuthSection({
               ...(identityAgentMode === 'none' ? { forwardAgent: false } : {}),
             });
           }}
-          helperText={agentSourceHelp(draft.identityAgentMode)}
+          helperText={agentSourceHelp(draft.identityAgentMode, draft.storage === 'openssh')}
           fullWidth
         >
-          <MenuItem value="default">Use SSH configuration</MenuItem>
+          <MenuItem value="default">
+            {draft.storage === 'openssh' ? 'Use SSH configuration' : 'Default environment agent'}
+          </MenuItem>
           <MenuItem value="environment">SSH_AUTH_SOCK environment agent</MenuItem>
           <MenuItem value="custom">Custom socket or environment variable</MenuItem>
           <MenuItem value="none">Do not use an agent</MenuItem>
@@ -283,11 +301,18 @@ export function AuthSection({
               strictHostKeyChecking: e.target.value as StrictHostKeyCheckingMode,
             })
           }
-          helperText={hostVerificationHelp(draft.strictHostKeyChecking)}
+          helperText={hostVerificationHelp(
+            draft.strictHostKeyChecking,
+            draft.storage === 'openssh',
+          )}
           fullWidth
         >
-          <MenuItem value="inherit">Use SSH configuration</MenuItem>
-          <MenuItem value="ask">Ask before trusting a new host</MenuItem>
+          <MenuItem value="inherit">
+            {draft.storage === 'openssh' ? 'Use SSH configuration' : 'Ask before trusting'}
+          </MenuItem>
+          {draft.storage === 'openssh' ? (
+            <MenuItem value="ask">Ask before trusting a new host</MenuItem>
+          ) : null}
           <MenuItem value="accept-new">Trust new hosts automatically</MenuItem>
           <MenuItem value="yes">Require a saved host key</MenuItem>
           <MenuItem value="no">Disable strict checking (no)</MenuItem>
@@ -297,7 +322,10 @@ export function AuthSection({
   );
 }
 
-function hostVerificationHelp(value: StrictHostKeyCheckingMode): string {
+function hostVerificationHelp(
+  value: StrictHostKeyCheckingMode,
+  configBacked: boolean,
+): string {
   switch (value) {
     case 'yes':
       return 'Refuses hosts whose key is not already saved.';
@@ -308,11 +336,13 @@ function hostVerificationHelp(value: StrictHostKeyCheckingMode): string {
     case 'ask':
       return 'Prompts before saving a first-contact key and whenever a saved key changes.';
     default:
-      return 'Inherits StrictHostKeyChecking; the normal default is to ask.';
+      return configBacked
+        ? 'Inherits StrictHostKeyChecking; the normal default is to ask.'
+        : 'Prompts before saving a first-contact key and whenever a saved key changes.';
   }
 }
 
-function agentSourceHelp(mode: IdentityAgentMode): string {
+function agentSourceHelp(mode: IdentityAgentMode, configBacked: boolean): string {
   switch (mode) {
     case 'environment':
       return 'Overrides inherited agent settings and reads SSH_AUTH_SOCK when connecting.';
@@ -321,7 +351,9 @@ function agentSourceHelp(mode: IdentityAgentMode): string {
     case 'none':
       return 'Disables agent authentication and agent forwarding for this host.';
     default:
-      return 'Inherits the normal SSH configuration and environment.';
+      return configBacked
+        ? 'Inherits the normal SSH configuration and environment.'
+        : 'Uses the agent from SSH_AUTH_SOCK and the normal default key files.';
   }
 }
 

--- a/client/src/components/host-editor/EditorShell.tsx
+++ b/client/src/components/host-editor/EditorShell.tsx
@@ -116,7 +116,18 @@ export function EditorShell<S extends string>({
               />
             ))}
           </Tabs>
-          <Box sx={{ flex: 1, minWidth: 0, overflowY: 'auto', pt: 0.5, pr: 0.5, pb: 1 }}>
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflowY: 'auto',
+              // Outlined fields float their labels above the input border.
+              // Keep that first label inside the scroll container's clip area.
+              pt: 1.5,
+              pr: 0.5,
+              pb: 1,
+            }}
+          >
             {children}
           </Box>
         </Stack>

--- a/client/src/components/host-editor/ForwardsSection.tsx
+++ b/client/src/components/host-editor/ForwardsSection.tsx
@@ -23,7 +23,9 @@ export function ForwardsSection({ draft, set }: { draft: HostDraft; set: (patch:
       <Divider />
       {draft.forwards.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
-          No forwards configured. Rules added here are written to the Host block and start with every connection.
+          {draft.storage === 'openssh'
+            ? 'No forwards configured. Rules added here are written to the Host block and start with every connection.'
+            : 'No forwards configured. Rules added here are stored in Muxus and start with every connection.'}
         </Typography>
       ) : (
         <Stack spacing={0.75}>

--- a/client/src/components/host-editor/GeneralSection.tsx
+++ b/client/src/components/host-editor/GeneralSection.tsx
@@ -27,10 +27,12 @@ export function GeneralSection({
   draft,
   set,
   config,
+  canChooseStorage = false,
 }: {
   draft: HostDraft;
   set: (patch: Partial<HostDraft>) => void;
   config: SshConfigResponse | undefined;
+  canChooseStorage?: boolean;
 }) {
   const [newFileName, setNewFileName] = useState('');
   const rootPath = config?.path ?? '~/.ssh/config';
@@ -46,17 +48,43 @@ export function GeneralSection({
   };
 
   const primary = draftAliases(draft)[0];
+  const configBacked = draft.storage === 'openssh';
 
   return (
     <Stack spacing={2}>
+      {canChooseStorage ? (
+        <TextField
+          select
+          label="Save host in"
+          value={draft.storage}
+          onChange={(event) =>
+            set({ storage: event.target.value as HostDraft['storage'] })
+          }
+          helperText={
+            configBacked
+              ? 'Writes a standard Host block that also works with ssh in any terminal.'
+              : 'Keeps this connection in the Muxus database and does not change ssh_config.'
+          }
+          fullWidth
+        >
+          <MenuItem value="muxus">Muxus app data only</MenuItem>
+          <MenuItem value="openssh">OpenSSH config</MenuItem>
+        </TextField>
+      ) : null}
       <Stack direction="row" spacing={1.5}>
         <TextField
-          label="Alias"
+          label={configBacked ? 'Alias' : 'Name'}
           value={draft.aliasText}
           onChange={(e) => set({ aliasText: e.target.value })}
           required
           fullWidth
-          helperText={primary ? `Connect with: ssh ${primary}` : 'The name you connect as — also works in any terminal'}
+          helperText={
+            configBacked
+              ? primary
+                ? `Connect with: ssh ${primary}`
+                : 'The name you connect as — also works in any terminal'
+              : 'How this host appears in Muxus'
+          }
         />
       </Stack>
       <Stack direction="row" spacing={1.5}>
@@ -64,7 +92,8 @@ export function GeneralSection({
           label="HostName"
           value={draft.hostname}
           onChange={(e) => set({ hostname: e.target.value })}
-          placeholder="defaults to the alias"
+          placeholder={configBacked ? 'defaults to the alias' : 'router.example.com'}
+          required={!configBacked}
           fullWidth
         />
         <TextField
@@ -76,51 +105,55 @@ export function GeneralSection({
         />
       </Stack>
       <TextField label="User" value={draft.user} onChange={(e) => set({ user: e.target.value })} placeholder="current user" fullWidth />
-      <TextField
-        label="Description"
-        value={draft.description}
-        onChange={(e) => set({ description: e.target.value })}
-        placeholder="shown in the host list"
-        helperText="Stored as a # comment above the Host block"
-        fullWidth
-        multiline
-        maxRows={3}
-      />
-      <Stack spacing={1}>
+      {configBacked ? (
         <TextField
-          select
-          label="Config file"
-          value={selectValue}
-          onChange={(e) => {
-            const v = e.target.value;
-            if (v === NEW_FILE) applyNewFile(newFileName || 'group');
-            else set({ file: v === rootPath ? '' : v });
-          }}
+          label="Description"
+          value={draft.description}
+          onChange={(e) => set({ description: e.target.value })}
+          placeholder="shown in the host list"
+          helperText="Stored as a # comment above the Host block"
           fullWidth
-        >
-          {[rootPath, ...files.filter((f) => f !== rootPath)].map((f) => (
-            <MenuItem key={f} value={f === rootPath ? rootPath : f}>
-              {shortenPath(f)}
-            </MenuItem>
-          ))}
-          <MenuItem value={NEW_FILE}>New group file…</MenuItem>
-        </TextField>
-        {selectValue === NEW_FILE && (
-          <>
-            <TextField
-              label="Group name"
-              value={newFileName}
-              onChange={(e) => applyNewFile(e.target.value)}
-              placeholder="work"
-              fullWidth
-            />
-            <Typography variant="caption" color="text.secondary">
-              Creates {shortenPath(draft.file || `${sshDir}config.d/…`)} and adds an Include to your config — the sidebar groups hosts by
-              file.
-            </Typography>
-          </>
-        )}
-      </Stack>
+          multiline
+          maxRows={3}
+        />
+      ) : null}
+      {configBacked ? (
+        <Stack spacing={1}>
+          <TextField
+            select
+            label="Config file"
+            value={selectValue}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === NEW_FILE) applyNewFile(newFileName || 'group');
+              else set({ file: v === rootPath ? '' : v });
+            }}
+            fullWidth
+          >
+            {[rootPath, ...files.filter((f) => f !== rootPath)].map((f) => (
+              <MenuItem key={f} value={f === rootPath ? rootPath : f}>
+                {shortenPath(f)}
+              </MenuItem>
+            ))}
+            <MenuItem value={NEW_FILE}>New group file…</MenuItem>
+          </TextField>
+          {selectValue === NEW_FILE ? (
+            <>
+              <TextField
+                label="Group name"
+                value={newFileName}
+                onChange={(e) => applyNewFile(e.target.value)}
+                placeholder="work"
+                fullWidth
+              />
+              <Typography variant="caption" color="text.secondary">
+                Creates {shortenPath(draft.file || `${sshDir}config.d/…`)} and adds
+                an Include to your config — the sidebar groups hosts by file.
+              </Typography>
+            </>
+          ) : null}
+        </Stack>
+      ) : null}
 
       <Divider />
       <Stack spacing={1.5}>
@@ -135,11 +168,13 @@ export function GeneralSection({
           label="After connecting"
           value={draft.remoteCommandMode}
           onChange={(e) => set({ remoteCommandMode: e.target.value as RemoteCommandMode })}
-          helperText={remoteCommandHelp(draft.remoteCommandMode)}
+          helperText={remoteCommandHelp(draft.remoteCommandMode, configBacked)}
           fullWidth
         >
-          <MenuItem value="inherit">Use SSH configuration</MenuItem>
-          <MenuItem value="shell">Open a login shell</MenuItem>
+          <MenuItem value="inherit">
+            {configBacked ? 'Use SSH configuration' : 'Open a login shell'}
+          </MenuItem>
+          {configBacked ? <MenuItem value="shell">Open a login shell</MenuItem> : null}
           <MenuItem value="command">Run a startup command</MenuItem>
         </TextField>
         {draft.remoteCommandMode === 'command' ? (
@@ -157,11 +192,17 @@ export function GeneralSection({
           label="Terminal allocation (TTY)"
           value={draft.requestTty}
           onChange={(e) => set({ requestTty: e.target.value as RequestTtyMode })}
-          helperText={requestTtyHelp(draft.requestTty, draft.remoteCommandMode)}
+          helperText={requestTtyHelp(
+            draft.requestTty,
+            draft.remoteCommandMode,
+            configBacked,
+          )}
           fullWidth
         >
-          <MenuItem value="inherit">Use SSH configuration</MenuItem>
-          <MenuItem value="auto">Automatic</MenuItem>
+          <MenuItem value="inherit">
+            {configBacked ? 'Use SSH configuration' : 'Automatic'}
+          </MenuItem>
+          {configBacked ? <MenuItem value="auto">Automatic</MenuItem> : null}
           <MenuItem value="yes">Always allocate a terminal</MenuItem>
           <MenuItem value="no">Do not allocate a terminal</MenuItem>
           <MenuItem value="force">Force terminal allocation</MenuItem>
@@ -170,17 +211,20 @@ export function GeneralSection({
 
       <Divider />
       <Typography variant="caption" color="text.secondary">
-        Display name, group and color are local to Muxus — they never touch your
-        ssh config.
+        {configBacked
+          ? 'Display name, group and color are local to Muxus — they never touch your ssh config.'
+          : 'Group and color are stored with this connection in Muxus app data.'}
       </Typography>
-      <TextField
-        label="Display name"
-        value={draft.displayName}
-        onChange={(e) => set({ displayName: e.target.value })}
-        placeholder={primary ?? 'the alias'}
-        helperText="Optional — only changes how this host appears in Muxus."
-        fullWidth
-      />
+      {configBacked ? (
+        <TextField
+          label="Display name"
+          value={draft.displayName}
+          onChange={(e) => set({ displayName: e.target.value })}
+          placeholder={primary ?? 'the alias'}
+          helperText="Optional — only changes how this host appears in Muxus."
+          fullWidth
+        />
+      ) : null}
       <FolderPathField
         value={draft.group}
         onChange={(group: string) => set({ group })}
@@ -191,18 +235,24 @@ export function GeneralSection({
   );
 }
 
-function remoteCommandHelp(mode: RemoteCommandMode): string {
+function remoteCommandHelp(mode: RemoteCommandMode, configBacked: boolean): string {
   switch (mode) {
     case 'shell':
       return 'Explicitly disables an inherited RemoteCommand and opens the normal shell.';
     case 'command':
       return 'Runs one command after authentication instead of opening the normal shell.';
     default:
-      return 'Uses any RemoteCommand inherited from matching SSH configuration.';
+      return configBacked
+        ? 'Uses any RemoteCommand inherited from matching SSH configuration.'
+        : 'Opens the server’s default login shell.';
   }
 }
 
-function requestTtyHelp(value: RequestTtyMode, commandMode: RemoteCommandMode): string {
+function requestTtyHelp(
+  value: RequestTtyMode,
+  commandMode: RemoteCommandMode,
+  configBacked: boolean,
+): string {
   switch (value) {
     case 'auto':
       return commandMode === 'command'
@@ -215,6 +265,11 @@ function requestTtyHelp(value: RequestTtyMode, commandMode: RemoteCommandMode): 
     case 'no':
       return 'Runs without a terminal.';
     default:
+      if (!configBacked) {
+        return commandMode === 'command'
+          ? 'Runs startup commands without a terminal unless you choose another setting.'
+          : 'Allocates a terminal for a login shell.';
+      }
       return commandMode === 'command'
         ? 'Inherits RequestTTY; SSH normally runs startup commands without a terminal.'
         : 'Inherits RequestTTY; SSH normally allocates a terminal for a login shell.';

--- a/client/src/components/host-editor/RouteSection.tsx
+++ b/client/src/components/host-editor/RouteSection.tsx
@@ -71,12 +71,30 @@ export function RouteSection({
         <FormControlLabel
           value="jump"
           control={<Radio size="small" />}
-          label={<Labeled title="Jump hosts" sub="Writes ProxyJump — connect through one or more SSH bastions" />}
+          label={
+            <Labeled
+              title="Jump hosts"
+              sub={
+                draft.storage === 'openssh'
+                  ? 'Writes ProxyJump — connect through one or more SSH bastions'
+                  : 'Connect through one or more SSH bastions'
+              }
+            />
+          }
         />
         <FormControlLabel
           value="command"
           control={<Radio size="small" />}
-          label={<Labeled title="Proxy command" sub="Writes ProxyCommand — use a command's stdin/stdout as the transport" />}
+          label={
+            <Labeled
+              title="Proxy command"
+              sub={
+                draft.storage === 'openssh'
+                  ? "Writes ProxyCommand — use a command's stdin/stdout as the transport"
+                  : "Use a command's stdin/stdout as the transport"
+              }
+            />
+          }
         />
       </RadioGroup>
 

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -295,11 +295,9 @@ export function draftToSavedSshInput(
       forwards: draft.forwards.length > 0 ? draft.forwards : undefined,
       passwordOnly: draft.authMode === 'password' || undefined,
       remoteCommand:
-        draft.remoteCommandMode === 'shell'
-          ? 'none'
-          : draft.remoteCommandMode === 'command'
-            ? text(draft.remoteCommand)
-            : undefined,
+        draft.remoteCommandMode === 'command'
+          ? text(draft.remoteCommand)
+          : undefined,
       requestTty: draft.requestTty === 'inherit' ? undefined : draft.requestTty,
       strictHostKeyChecking:
         draft.strictHostKeyChecking === 'inherit'

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -2,6 +2,8 @@ import type {
   ConfigForward,
   HostKeywordHighlightConfig,
   HostUpsertRequest,
+  SavedHostProfile,
+  SavedHostProfileInput,
   SshHostEntry,
 } from '@muxus/shared';
 import {
@@ -17,6 +19,8 @@ export type StrictHostKeyCheckingMode = 'inherit' | 'yes' | 'no' | 'accept-new' 
 
 /** Everything the editor form holds, in form-friendly shapes (ports as text). */
 export interface HostDraft {
+  /** Whether Muxus owns the connection or writes an OpenSSH Host block. */
+  storage: 'openssh' | 'muxus';
   /** Space-separated aliases for the Host line (usually one). */
   aliasText: string;
   description: string;
@@ -60,6 +64,7 @@ export function blankDraft(prefillTarget = ''): HostDraft {
   const target = prefillTarget.trim();
   const parsed = /[@:]/.test(target) ? parseHostTarget(target) : undefined;
   return {
+    storage: 'openssh',
     aliasText: parsed?.host ?? target,
     description: '',
     displayName: '',
@@ -100,6 +105,7 @@ export function draftFromEntry(entry: SshHostEntry, duplicate: boolean): HostDra
   const identityAgent = identityAgentDraft(o.identityAgent);
   const remoteCommand = remoteCommandDraft(o.remoteCommand);
   return {
+    storage: 'openssh',
     aliasText: duplicate ? `${entry.alias}-copy` : entry.aliases.join(' '),
     description: entry.description ?? '',
     displayName: duplicate ? '' : (entry.metadata?.displayName ?? ''),
@@ -144,6 +150,63 @@ export function draftFromEntry(entry: SshHostEntry, duplicate: boolean): HostDra
   };
 }
 
+/** Build the SSH form from a Muxus-owned database profile. */
+export function draftFromSavedSshProfile(
+  saved: SavedHostProfile,
+  duplicate: boolean,
+): HostDraft {
+  if (saved.profile.kind !== 'ssh') {
+    throw new Error('saved host is not an SSH profile');
+  }
+  const profile = saved.profile;
+  const identityAgent = identityAgentDraft(profile.identityAgent);
+  const remoteCommand = remoteCommandDraft(profile.remoteCommand);
+  return {
+    storage: 'muxus',
+    aliasText: duplicate ? `${saved.name} copy` : saved.name,
+    description: '',
+    displayName: duplicate ? '' : (saved.metadata.displayName ?? ''),
+    group: saved.metadata.group ?? '',
+    color: saved.metadata.color,
+    disableSftp: saved.metadata.disableSftp ?? false,
+    consoleCompatibility: saved.metadata.consoleCompatibility ?? false,
+    file: '',
+    hostname: profile.target,
+    user: profile.user ?? '',
+    port: profile.port?.toString() ?? '',
+    authMode:
+      profile.passwordOnly
+        ? 'password'
+        : (profile.identityFiles?.length || profile.certificateFiles?.length)
+          ? 'key'
+          : 'default',
+    identityFiles: profile.identityFiles ?? [],
+    certificateFiles: profile.certificateFiles ?? [],
+    identitiesOnly: profile.identitiesOnly ?? false,
+    identityAgentMode: identityAgent.mode,
+    identityAgent: identityAgent.value,
+    forwardAgent: profile.forwardAgent ?? false,
+    routeMode: profile.proxyCommand
+      ? 'command'
+      : profile.proxyJump?.length
+        ? 'jump'
+        : 'direct',
+    proxyJump: profile.proxyJump ?? [],
+    proxyCommand: profile.proxyCommand ?? '',
+    forwards: profile.forwards ?? [],
+    remoteCommandMode: remoteCommand.mode,
+    remoteCommand: remoteCommand.value,
+    requestTty: profile.requestTty ?? 'inherit',
+    strictHostKeyChecking: profile.strictHostKeyChecking ?? 'inherit',
+    extras: [],
+    keywordHighlights: saved.metadata.keywordHighlights ?? {
+      inheritGlobal: true,
+      rules: [],
+    },
+    sessionLogging: blankHostSessionLoggingDraft(),
+  };
+}
+
 export function draftAliases(draft: HostDraft): string[] {
   return draft.aliasText.trim().split(/\s+/).filter(Boolean);
 }
@@ -151,10 +214,20 @@ export function draftAliases(draft: HostDraft): string[] {
 const ALIAS_RE = /^[^\s#*?!]+$/;
 
 export function draftProblem(draft: HostDraft): string | null {
+  if (draft.storage === 'muxus') {
+    if (!draft.aliasText.trim()) return 'A name is required — it labels this host in Muxus.';
+    if (draft.aliasText.trim().length > 200) return 'The host name must be 200 characters or fewer.';
+    if (!draft.hostname.trim()) return 'Enter a hostname or IP address.';
+    if (draft.extras.length > 0) {
+      return 'Additional ssh_config options require OpenSSH config storage.';
+    }
+  }
   const aliases = draftAliases(draft);
-  if (!aliases.length) return 'An alias is required — it is what you connect as.';
-  for (const a of aliases) {
-    if (!ALIAS_RE.test(a)) return `"${a}" is not a valid alias (no spaces, wildcards or "!").`;
+  if (draft.storage === 'openssh') {
+    if (!aliases.length) return 'An alias is required — it is what you connect as.';
+    for (const a of aliases) {
+      if (!ALIAS_RE.test(a)) return `"${a}" is not a valid alias (no spaces, wildcards or "!").`;
+    }
   }
   if (draft.port && !portOk(draft.port)) return 'Port must be 1–65535.';
   if (draft.authMode === 'key' && !draft.identityFiles.some((f) => f.trim())) return 'Pick at least one key file, or switch the auth mode.';
@@ -178,6 +251,62 @@ export function draftProblem(draft: HostDraft): string | null {
     return 'Every highlighting rule needs a keyword.';
   }
   return null;
+}
+
+/** Serialize a database-backed SSH host without involving ssh_config. */
+export function draftToSavedSshInput(
+  draft: HostDraft,
+  existingId?: string,
+): SavedHostProfileInput {
+  const text = (value: string) => value.trim() || undefined;
+  return {
+    id: existingId,
+    name: draft.aliasText.trim(),
+    profile: {
+      kind: 'ssh',
+      target: draft.hostname.trim(),
+      useConfig: false,
+      user: text(draft.user),
+      port: draft.port ? Number(draft.port) : undefined,
+      identityFiles:
+        draft.authMode === 'key'
+          ? draft.identityFiles.map((file) => file.trim()).filter(Boolean)
+          : undefined,
+      certificateFiles:
+        draft.authMode === 'key'
+          ? draft.certificateFiles.map((file) => file.trim()).filter(Boolean)
+          : undefined,
+      identitiesOnly: draft.authMode === 'key' ? true : undefined,
+      identityAgent:
+        draft.identityAgentMode === 'environment'
+          ? 'SSH_AUTH_SOCK'
+          : draft.identityAgentMode === 'none'
+            ? 'none'
+            : draft.identityAgentMode === 'custom'
+              ? text(draft.identityAgent)
+              : undefined,
+      forwardAgent: draft.forwardAgent || undefined,
+      proxyJump:
+        draft.routeMode === 'jump' && draft.proxyJump.length > 0
+          ? draft.proxyJump
+          : undefined,
+      proxyCommand:
+        draft.routeMode === 'command' ? text(draft.proxyCommand) : undefined,
+      forwards: draft.forwards.length > 0 ? draft.forwards : undefined,
+      passwordOnly: draft.authMode === 'password' || undefined,
+      remoteCommand:
+        draft.remoteCommandMode === 'shell'
+          ? 'none'
+          : draft.remoteCommandMode === 'command'
+            ? text(draft.remoteCommand)
+            : undefined,
+      requestTty: draft.requestTty === 'inherit' ? undefined : draft.requestTty,
+      strictHostKeyChecking:
+        draft.strictHostKeyChecking === 'inherit'
+          ? undefined
+          : draft.strictHostKeyChecking,
+    },
+  };
 }
 
 function portOk(v: string): boolean {

--- a/client/src/components/host-editor/native-draft.ts
+++ b/client/src/components/host-editor/native-draft.ts
@@ -60,13 +60,15 @@ export function nativeDraftFromProfile(saved: SavedHostProfile, duplicate: boole
   if (saved.profile.kind === 'telnet') {
     draft.host = saved.profile.host;
     draft.port = String(saved.profile.port);
-  } else {
+  } else if (saved.profile.kind === 'serial') {
     draft.path = saved.profile.path;
     draft.baudRate = String(saved.profile.baudRate);
     draft.dataBits = saved.profile.dataBits;
     draft.stopBits = saved.profile.stopBits;
     draft.parity = saved.profile.parity;
     draft.flowControl = saved.profile.flowControl;
+  } else {
+    throw new Error('saved host is not a Telnet or serial profile');
   }
   return draft;
 }

--- a/client/src/components/sidebar/host-details.ts
+++ b/client/src/components/sidebar/host-details.ts
@@ -7,7 +7,25 @@ import type { ManagedHost } from '../../managed-hosts.js';
  */
 export function hostDetailLines(host: ManagedHost): string[] {
   const lines: string[] = [];
-  if (host.kind !== 'ssh') return lines;
+  if (host.kind === 'profile') {
+    const profile = host.entry.profile;
+    if (profile.kind !== 'ssh') return lines;
+    if (profile.proxyJump?.length) lines.push(`via ${profile.proxyJump.join(' → ')}`);
+    if (profile.identityFiles?.length) {
+      lines.push(
+        `Key ${profile.identityFiles.map((file) => file.split(/[\\/]/).pop()).join(', ')}`,
+      );
+    }
+    if (profile.passwordOnly) lines.push('Password authentication');
+    if (host.entry.metadata.consoleCompatibility) lines.push('Console compatibility');
+    else if (host.entry.metadata.disableSftp) lines.push('SFTP disabled');
+    if (profile.forwards?.length) {
+      lines.push(
+        `${profile.forwards.length} port forward${profile.forwards.length > 1 ? 's' : ''} on connect`,
+      );
+    }
+    return lines;
+  }
   if (host.entry.description) lines.push(host.entry.description);
   const resolved = host.entry.resolved;
   if (!resolved) return lines;

--- a/client/src/components/sidebar/host-sftp-action.ts
+++ b/client/src/components/sidebar/host-sftp-action.ts
@@ -1,15 +1,21 @@
 import type { ManagedHost } from '../../managed-hosts.js';
-import { connectHost } from '../../session-actions.js';
+import { connectManagedHost } from '../../session-actions.js';
 import { useTabsStore } from '../../state/tabs.js';
 
 /** Whether the host context menu may offer the SSH-backed file browser. */
 export function managedHostSupportsSftp(
   host: ManagedHost,
-): host is Extract<ManagedHost, { kind: 'ssh' }> {
+): boolean {
+  if (host.kind === 'ssh') {
+    return (
+      host.entry.metadata?.disableSftp !== true &&
+      host.entry.metadata?.consoleCompatibility !== true
+    );
+  }
   return (
-    host.kind === 'ssh' &&
-    host.entry.metadata?.disableSftp !== true &&
-    host.entry.metadata?.consoleCompatibility !== true
+    host.entry.profile.kind === 'ssh' &&
+    host.entry.metadata.disableSftp !== true &&
+    host.entry.metadata.consoleCompatibility !== true
   );
 }
 
@@ -23,18 +29,25 @@ export function openManagedHostSftp(host: ManagedHost): string | undefined {
 
   const state = useTabsStore.getState();
   const matching = state.tabs.filter(
-    (tab) =>
-      tab.profile?.kind === 'ssh' &&
-      tab.profile.target === host.entry.alias &&
-      (tab.status === 'connecting' || tab.status === 'connected') &&
-      tab.sftpAvailable !== false,
+    (tab) => {
+      if (tab.profile?.kind !== 'ssh') return false;
+      const sameHost =
+        host.kind === 'ssh'
+          ? !tab.profile.profileId && tab.profile.target === host.entry.alias
+          : tab.profile.profileId === host.entry.id;
+      return (
+        sameHost &&
+        (tab.status === 'connecting' || tab.status === 'connected') &&
+        tab.sftpAvailable !== false
+      );
+    },
   );
   const reusable =
     matching.find((tab) => tab.id === state.activeId && !!tab.connId) ??
     matching.find((tab) => !!tab.connId) ??
     matching.find((tab) => tab.id === state.activeId) ??
     matching[0];
-  const id = reusable?.id ?? connectHost(host.entry);
+  const id = reusable?.id ?? connectManagedHost(host);
   const next = useTabsStore.getState();
   next.update(id, { sftpOpen: true });
   next.activate(id);

--- a/client/src/components/sidebar/useLiveHostCounts.ts
+++ b/client/src/components/sidebar/useLiveHostCounts.ts
@@ -15,7 +15,9 @@ export function useLiveHostCounts(): Map<string, LiveCounts> {
       if (!tab.profile) continue;
       const key =
         tab.profile.kind === 'ssh'
-          ? `ssh:${tab.profile.target}`
+          ? tab.profile.profileId
+            ? `profile:${tab.profile.profileId}`
+            : `ssh:${tab.profile.target}`
           : tab.profile.kind === 'telnet' || tab.profile.kind === 'serial'
             ? tab.profile.profileId && `profile:${tab.profile.profileId}`
             : undefined;

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -1,5 +1,6 @@
 import type {
   FolderAuthSettings,
+  FolderSettingsRecord,
   FolderSettingsResponse,
   HostBlockOptions,
   HostUpsertRequest,
@@ -229,13 +230,46 @@ export async function createBackupDocument(
 }
 
 export async function createOpenSshExport(): Promise<string> {
-  const { hosts } = await apiFetch<SshConfigResponse>('/api/ssh/config');
+  const [{ hosts }, saved, folderSettings] = await Promise.all([
+    apiFetch<SshConfigResponse>('/api/ssh/config'),
+    apiFetch<SavedHostProfilesResponse>('/api/profiles'),
+    apiFetch<FolderSettingsResponse>('/api/folders/settings'),
+  ]);
+  const usedAliases = new Set(hosts.flatMap((host) => host.aliases));
+  const nativeSshHosts = saved.profiles.flatMap((profile) => {
+    if (profile.profile.kind !== 'ssh') return [];
+    const inherited = savedProfileFolderDefaults(
+      profile.metadata.group,
+      folderSettings.folders,
+    );
+    const base = openSshExportAlias(profile.name, profile.profile.target);
+    let alias = base;
+    let suffix = 2;
+    while (usedAliases.has(alias)) alias = `${base}-${suffix++}`;
+    usedAliases.add(alias);
+    return [
+      {
+        aliases: [alias],
+        description: inherited.hasPassword
+          ? 'Exported from Muxus app data. Shared folder password omitted.'
+          : 'Exported from Muxus app data.',
+        options: portableSavedSshOptions(profile, inherited.auth),
+      },
+    ];
+  });
   const blocks = await Promise.all(
-    hosts.map((host) =>
-      fetchHostPreview({
+    [
+      ...hosts.map((host) => ({
         aliases: host.aliases,
         description: host.description,
         options: portableSshOptions(host),
+      })),
+      ...nativeSshHosts,
+    ].map((host) =>
+      fetchHostPreview({
+        aliases: host.aliases,
+        description: host.description,
+        options: host.options,
       }),
     ),
   );
@@ -248,6 +282,78 @@ export async function createOpenSshExport(): Promise<string> {
     ...blocks.map((block) => block.trim()),
     '',
   ].join('\n\n');
+}
+
+function portableSavedSshOptions(
+  profile: SavedHostProfile,
+  inherited: FolderAuthSettings,
+): HostBlockOptions {
+  if (profile.profile.kind !== 'ssh') return {};
+  const saved = profile.profile;
+  return {
+    hostname: saved.target,
+    user: saved.user ?? inherited.user,
+    port: saved.port ?? inherited.port,
+    identityFiles: saved.identityFiles ?? inherited.identityFiles,
+    certificateFiles: saved.certificateFiles,
+    identitiesOnly: saved.identitiesOnly ?? inherited.identitiesOnly,
+    identityAgent: saved.identityAgent ?? inherited.identityAgent,
+    forwardAgent: saved.forwardAgent ?? inherited.forwardAgent,
+    proxyJump: saved.proxyJump,
+    proxyCommand: saved.proxyCommand,
+    forwards: saved.forwards,
+    passwordOnly: saved.passwordOnly,
+    remoteCommand: saved.remoteCommand,
+    requestTty: saved.requestTty,
+    strictHostKeyChecking: saved.strictHostKeyChecking,
+  };
+}
+
+/** Materialize the non-secret defaults the saved profile inherits in Muxus. */
+function savedProfileFolderDefaults(
+  group: string | undefined,
+  folders: readonly FolderSettingsRecord[],
+): { auth: FolderAuthSettings; hasPassword: boolean } {
+  const parts = (group ?? '')
+    .replace(/\\/g, '/')
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return { auth: {}, hasPassword: false };
+
+  const byPath = new Map(
+    folders.map((folder) => [folder.path.toLocaleLowerCase(), folder]),
+  );
+  const auth: FolderAuthSettings = {};
+  let hasPassword = false;
+  for (let length = parts.length; length > 0; length--) {
+    const folder = byPath.get(parts.slice(0, length).join('/').toLocaleLowerCase());
+    if (!folder) continue;
+    hasPassword ||= folder.hasPassword;
+    if (auth.user === undefined) auth.user = folder.auth.user;
+    if (auth.port === undefined) auth.port = folder.auth.port;
+    if (auth.identityFiles === undefined) auth.identityFiles = folder.auth.identityFiles;
+    if (auth.identitiesOnly === undefined) auth.identitiesOnly = folder.auth.identitiesOnly;
+    if (auth.identityAgent === undefined) auth.identityAgent = folder.auth.identityAgent;
+    if (auth.forwardAgent === undefined) auth.forwardAgent = folder.auth.forwardAgent;
+  }
+  return { auth, hasPassword };
+}
+
+function openSshExportAlias(name: string, target: string): string {
+  return (
+    name
+      .trim()
+      .replace(/[\s#*?!]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 240) ||
+    target
+      .trim()
+      .replace(/[\s#*?!]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 240) ||
+    'muxus-host'
+  );
 }
 
 export function saveTransferDocument(
@@ -817,7 +923,9 @@ function validateConnections(data: Record<string, unknown>): void {
         nonEmptyString(host.id) &&
         nonEmptyString(host.name) &&
         isRecord(host.profile) &&
-        (host.profile.kind === 'telnet' || host.profile.kind === 'serial') &&
+        (host.profile.kind === 'ssh' ||
+          host.profile.kind === 'telnet' ||
+          host.profile.kind === 'serial') &&
         isRecord(host.metadata),
     ) ||
     !data.hostOrder.every(

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -37,7 +37,8 @@ import {
 import { isFolderIconId } from './components/sidebar/folder-icons.js';
 
 export const BACKUP_FORMAT = 'muxus-backup';
-export const TRANSFER_VERSION = 1;
+export const TRANSFER_VERSION = 2;
+const LEGACY_TRANSFER_VERSION = 1;
 export const MAX_TRANSFER_FILE_BYTES = 20 * 1024 * 1024;
 
 const JSON_HEADERS = { 'content-type': 'application/json' };
@@ -125,22 +126,32 @@ export type PortableHistorySettings = Omit<
   'storageLocation'
 >;
 
+export interface MuxusBackupData extends PortableConnections {
+  preferences: BackupPreferences;
+  tunnels: TunnelRecord[];
+  loggingPolicies: BackupLoggingPolicy[];
+  historySettings: PortableHistorySettings;
+  /** Absent in backups from before folder credentials existed. */
+  folderSettings?: PortableFolderSettings[];
+}
+
 export interface MuxusBackupV1 {
+  format: typeof BACKUP_FORMAT;
+  version: typeof LEGACY_TRANSFER_VERSION;
+  createdAt: string;
+  appVersion?: string;
+  data: MuxusBackupData;
+}
+
+export interface MuxusBackupV2 {
   format: typeof BACKUP_FORMAT;
   version: typeof TRANSFER_VERSION;
   createdAt: string;
   appVersion?: string;
-  data: PortableConnections & {
-    preferences: BackupPreferences;
-    tunnels: TunnelRecord[];
-    loggingPolicies: BackupLoggingPolicy[];
-    historySettings: PortableHistorySettings;
-    /** Absent in backups from before folder credentials existed. */
-    folderSettings?: PortableFolderSettings[];
-  };
+  data: MuxusBackupData;
 }
 
-export type TransferDocument = MuxusBackupV1;
+export type TransferDocument = MuxusBackupV1 | MuxusBackupV2;
 export type TransferConflictStrategy = 'keep' | 'replace';
 
 export interface RestoreSelection {
@@ -185,7 +196,7 @@ export async function fetchDataSummary(): Promise<DataSummary> {
 
 export async function createBackupDocument(
   appVersion?: string,
-): Promise<MuxusBackupV1> {
+): Promise<MuxusBackupV2> {
   const snapshot = await fetchBaseSnapshot();
   const profileKeys = [
     '*',
@@ -385,7 +396,10 @@ export function parseTransferDocument(text: string): TransferDocument {
     throw new Error('This file is not valid JSON.');
   }
   if (!isRecord(parsed)) throw new Error('This is not a Muxus transfer file.');
-  if (parsed.version !== TRANSFER_VERSION) {
+  if (
+    parsed.version !== LEGACY_TRANSFER_VERSION &&
+    parsed.version !== TRANSFER_VERSION
+  ) {
     throw new Error(
       typeof parsed.version === 'number'
         ? `Muxus transfer version ${parsed.version} is not supported.`
@@ -402,7 +416,7 @@ export function parseTransferDocument(text: string): TransferDocument {
   ) {
     throw new Error('The Muxus transfer file is incomplete.');
   }
-  validateConnections(parsed.data);
+  validateConnections(parsed.data, parsed.version);
   validateBackupData(parsed.data);
   return parsed as unknown as TransferDocument;
 }
@@ -900,7 +914,10 @@ function validFolderStyles(value: unknown): value is Record<string, FolderStyle>
   );
 }
 
-function validateConnections(data: Record<string, unknown>): void {
+function validateConnections(
+  data: Record<string, unknown>,
+  version: TransferDocument['version'],
+): void {
   if (
     !boundedArray(data.sshHosts, 10_000) ||
     !boundedArray(data.savedHosts, 10_000) ||
@@ -923,9 +940,9 @@ function validateConnections(data: Record<string, unknown>): void {
         nonEmptyString(host.id) &&
         nonEmptyString(host.name) &&
         isRecord(host.profile) &&
-        (host.profile.kind === 'ssh' ||
-          host.profile.kind === 'telnet' ||
-          host.profile.kind === 'serial') &&
+        (host.profile.kind === 'telnet' ||
+          host.profile.kind === 'serial' ||
+          (version >= 2 && host.profile.kind === 'ssh')) &&
         isRecord(host.metadata),
     ) ||
     !data.hostOrder.every(

--- a/client/src/managed-hosts.ts
+++ b/client/src/managed-hosts.ts
@@ -183,6 +183,13 @@ export function managedHostCopyCommand(host: ManagedHost): { label: string; text
     return { label: 'Copy ssh command', text: `ssh ${host.entry.alias}` };
   }
   const profile = host.entry.profile;
+  if (profile.kind === 'ssh') {
+    const target = profile.user ? `${profile.user}@${profile.target}` : profile.target;
+    return {
+      label: 'Copy ssh command',
+      text: `ssh${profile.port ? ` -p ${profile.port}` : ''} ${target}`,
+    };
+  }
   return profile.kind === 'telnet'
     ? { label: 'Copy telnet command', text: `telnet ${profile.host} ${profile.port}` }
     : { label: 'Copy device path', text: profile.path };

--- a/client/src/managed-hosts.ts
+++ b/client/src/managed-hosts.ts
@@ -1,4 +1,9 @@
-import type { ManagedHostRef, SavedHostProfile, SshHostEntry } from '@muxus/shared';
+import type {
+  ManagedHostRef,
+  SavedHostProfile,
+  SshHostEntry,
+  SshProfile,
+} from '@muxus/shared';
 import {
   groupHosts,
   hostAddress,
@@ -184,15 +189,73 @@ export function managedHostCopyCommand(host: ManagedHost): { label: string; text
   }
   const profile = host.entry.profile;
   if (profile.kind === 'ssh') {
-    const target = profile.user ? `${profile.user}@${profile.target}` : profile.target;
     return {
       label: 'Copy ssh command',
-      text: `ssh${profile.port ? ` -p ${profile.port}` : ''} ${target}`,
+      text: savedSshCopyCommand(profile),
     };
   }
   return profile.kind === 'telnet'
     ? { label: 'Copy telnet command', text: `telnet ${profile.host} ${profile.port}` }
     : { label: 'Copy device path', text: profile.path };
+}
+
+/** Render a self-contained profile as a pasteable OpenSSH command. */
+function savedSshCopyCommand(profile: SshProfile): string {
+  const args = ['ssh'];
+  if (profile.port) args.push('-p', String(profile.port));
+  for (const file of profile.identityFiles ?? []) args.push('-i', file);
+  for (const file of profile.certificateFiles ?? []) {
+    args.push('-o', `CertificateFile=${file}`);
+  }
+  if (profile.identitiesOnly !== undefined) {
+    args.push('-o', `IdentitiesOnly=${profile.identitiesOnly ? 'yes' : 'no'}`);
+  }
+  if (profile.identityAgent) {
+    args.push('-o', `IdentityAgent=${profile.identityAgent}`);
+  }
+  if (profile.forwardAgent) args.push('-A');
+  if (profile.proxyJump?.length) args.push('-J', profile.proxyJump.join(','));
+  if (profile.proxyCommand) {
+    args.push('-o', `ProxyCommand=${profile.proxyCommand}`);
+  }
+  if (profile.passwordOnly) {
+    args.push(
+      '-o',
+      'PubkeyAuthentication=no',
+      '-o',
+      'PreferredAuthentications=keyboard-interactive,password',
+    );
+  }
+  for (const forward of profile.forwards ?? []) {
+    if (forward.type === 'dynamic') {
+      args.push('-D', String(forward.bindPort));
+      continue;
+    }
+    const option = forward.type === 'local' ? '-L' : '-R';
+    args.push(
+      option,
+      `${forward.bindPort}:${forward.targetHost}:${forward.targetPort}`,
+    );
+  }
+  if (profile.requestTty === 'no') args.push('-T');
+  if (profile.requestTty === 'yes') args.push('-t');
+  if (profile.requestTty === 'force') args.push('-tt');
+  if (profile.requestTty === 'auto') args.push('-o', 'RequestTTY=auto');
+  if (profile.strictHostKeyChecking) {
+    args.push(
+      '-o',
+      `StrictHostKeyChecking=${profile.strictHostKeyChecking}`,
+    );
+  }
+  args.push(profile.user ? `${profile.user}@${profile.target}` : profile.target);
+  if (profile.remoteCommand) args.push(profile.remoteCommand);
+  return args.map(shellArgument).join(' ');
+}
+
+function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./~-]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function compareManagedHosts(a: ManagedHost, b: ManagedHost): number {

--- a/client/src/mobaxterm-import.ts
+++ b/client/src/mobaxterm-import.ts
@@ -3,8 +3,10 @@ import {
   cleanImportName,
   importedConnections,
   normalizeImportFolder,
+  stableImportId,
   type SkippedImportedSession,
   type ImportedSessionParseResult,
+  type ImportedSshStorage,
   type ImportedSshSession,
   uniqueImportAlias,
 } from './session-import.js';
@@ -95,7 +97,10 @@ export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
     const alias = uniqueImportAlias(name, host, aliases, 'mobaxterm-host');
     aliases.add(alias);
     sessions.push({
-      id: `${lineIndex}:${alias}`,
+      id: stableImportId(
+        'mobaxterm-session',
+        `${currentFolder ?? ''}\0${alias}`,
+      ),
       kind: 'ssh',
       name,
       alias,
@@ -120,6 +125,7 @@ export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
 /** Convert reviewed MobaXterm rows into the existing portable restore pipeline. */
 export function mobaXtermConnections(
   sessions: readonly MobaXtermSession[],
+  sshStorage: ImportedSshStorage = 'openssh',
 ): PortableConnections {
-  return importedConnections(sessions, 'MobaXterm');
+  return importedConnections(sessions, 'MobaXterm', sshStorage);
 }

--- a/client/src/saved-hosts.ts
+++ b/client/src/saved-hosts.ts
@@ -6,9 +6,18 @@ export function savedHostDisplayName(profile: SavedHostProfile): string {
 }
 
 export function savedHostAddress(profile: SavedHostProfile): string {
-  return profile.profile.kind === 'telnet'
-    ? `${profile.profile.host}:${profile.profile.port}`
-    : `${profile.profile.path} · ${profile.profile.baudRate} baud`;
+  const connection = profile.profile;
+  if (connection.kind === 'ssh') {
+    const target = connection.user
+      ? `${connection.user}@${connection.target}`
+      : connection.target;
+    return connection.port && connection.port !== 22
+      ? `${target}:${connection.port}`
+      : target;
+  }
+  return connection.kind === 'telnet'
+    ? `${connection.host}:${connection.port}`
+    : `${connection.path} · ${connection.baudRate} baud`;
 }
 
 /** Everything a search may look at, lower-cased once per profile. */

--- a/client/src/securecrt-import.ts
+++ b/client/src/securecrt-import.ts
@@ -8,6 +8,7 @@ import {
   type ImportedSerialSession,
   type ImportedSession,
   type ImportedSessionParseResult,
+  type ImportedSshStorage,
   type ImportedSshSession,
   uniqueImportAlias,
 } from './session-import.js';
@@ -194,8 +195,13 @@ export function parseSecureCrtSessions(text: string): SecureCrtParseResult {
 
 export function secureCrtConnections(
   sessions: readonly SecureCrtSession[],
+  sshStorage: ImportedSshStorage = 'openssh',
 ): PortableConnections {
-  return importedConnections(sessions as readonly ImportedSession[], 'SecureCRT');
+  return importedConnections(
+    sessions as readonly ImportedSession[],
+    'SecureCRT',
+    sshStorage,
+  );
 }
 
 function directElements(parent: Element, tagName: string): Element[] {

--- a/client/src/session-import.ts
+++ b/client/src/session-import.ts
@@ -40,6 +40,7 @@ export interface ImportedSerialSession extends ImportedSessionBase {
 }
 
 export type ImportedSession = ImportedSshSession | ImportedSerialSession;
+export type ImportedSshStorage = 'openssh' | 'muxus';
 
 export interface SkippedImportedSession {
   /** Stable inside one parsed file and used as the React list key. */
@@ -62,6 +63,7 @@ export interface ImportedSessionParseResult<T extends ImportedSession = Imported
 export function importedConnections(
   sessions: readonly ImportedSession[],
   sourceName: string,
+  sshStorage: ImportedSshStorage = 'openssh',
 ): PortableConnections {
   const sshHosts: PortableSshHost[] = [];
   const savedHosts: PortableSavedHost[] = [];
@@ -72,6 +74,25 @@ export function importedConnections(
       ...(session.folder ? { group: session.folder } : {}),
     };
     if (session.kind === 'ssh') {
+      if (sshStorage === 'muxus') {
+        savedHosts.push({
+          id: stableImportId(
+            `${sourceName.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-ssh`,
+            session.id,
+          ),
+          name: session.name,
+          profile: {
+            kind: 'ssh',
+            target: session.host,
+            useConfig: false,
+            ...(session.username ? { user: session.username } : {}),
+            ...(session.port === 22 ? {} : { port: session.port }),
+            ...(session.authMode === 'password' ? { passwordOnly: true } : {}),
+          },
+          metadata: session.folder ? { group: session.folder } : {},
+        });
+        continue;
+      }
       const options: HostBlockOptions = {
         hostname: session.host,
         ...(session.username ? { user: session.username } : {}),

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -6,14 +6,15 @@ icon: lucide/circle-help
 
 ### Does Muxus change my `~/.ssh/config`?
 
-Only on request. Adding, editing or deleting a host rewrites that block and nothing else,
-atomically, leaving a `.muxus.bak` of the previous contents. Folders, colours and
-workspaces are stored in Muxus's own database.
+Only when you choose **OpenSSH config** storage. A new SSH host can instead be saved in
+**Muxus app data only**, and MobaXterm/SecureCRT imports offer the same choice. OpenSSH
+edits rewrite that block and nothing else, atomically, leaving a `.muxus.bak` of the
+previous contents.
 
 ### Will `ssh` on the command line still work?
 
-Yes. Muxus writes standard OpenSSH blocks, appends to `known_hosts`, and reads the agent.
-Anything added in Muxus is usable by `ssh`, `scp` and `rsync`.
+Yes for hosts stored in OpenSSH config. Muxus-only database hosts are intentionally private
+to the app and do not appear to `ssh`, `scp` or `rsync`.
 
 ### Do I need to import my hosts?
 
@@ -39,8 +40,9 @@ as a single-user local tool. Do not put it behind a reverse proxy.
 ### Where is my data?
 
 The application database is in the platform data directory (`~/.local/share/muxus/`,
-`~/Library/Application Support/Muxus/`, `%APPDATA%\Muxus\`). Connection settings are in
-`~/.ssh/config`. See the [CLI reference](../reference/cli.md#data-locations).
+`~/Library/Application Support/Muxus/`, `%APPDATA%\Muxus\`). Muxus-only host settings are
+stored there; OpenSSH-backed hosts remain in `~/.ssh/config`. See the
+[CLI reference](../reference/cli.md#data-locations).
 
 ### Are my passwords stored anywhere?
 

--- a/docs/guide/adding-hosts.md
+++ b/docs/guide/adding-hosts.md
@@ -4,9 +4,15 @@ icon: lucide/square-pen
 
 # Adding & editing hosts
 
-The host editor writes plain OpenSSH. Every field it exposes becomes part of a `Host` block
-in the configuration file. The attributes Muxus adds on top (display name, folder, colour,
-highlighting, logging policy) are stored in its own database.
+The SSH editor lets you choose where a new host lives:
+
+- **Muxus app data only** keeps a self-contained SSH profile in the local database and
+  does not change `~/.ssh/config`.
+- **OpenSSH config** writes a standard `Host` block that also works with `ssh`, `scp`
+  and `rsync` outside Muxus.
+
+Presentation attributes such as folder, colour, highlighting and logging policy always
+live in the Muxus database.
 
 Open the editor with **+** at the top of the sidebar, from a host's **Edit host** menu
 entry, or by pressing ++enter++ on a search that matched nothing.
@@ -19,7 +25,8 @@ entry, or by pressing ++enter++ on a search that matched nothing.
 
 !!! info "What a save rewrites"
 
-    Saving rewrites **only that block**. Comments, ordering, `Match` blocks and every other
+    This applies only to hosts stored in OpenSSH config. Saving rewrites **only that block**.
+    Comments, ordering, `Match` blocks and every other
     host in the file are left untouched. The write is atomic, and the previous contents are
     kept next to it as `<file>.muxus.bak`.
 
@@ -27,6 +34,7 @@ entry, or by pressing ++enter++ on a search that matched nothing.
 
 | Field | Writes |
 | --- | --- |
+| **Save host in** | Selects Muxus app data or an OpenSSH configuration file for a new SSH host. |
 | **Alias** | The `Host` line. Several aliases separated by spaces are accepted; the first one names the session. |
 | **HostName** | `HostName`. Empty means the alias is used as the hostname, as in OpenSSH. |
 | **Port** | `Port`, omitted when it is 22. |
@@ -123,8 +131,8 @@ panel shows the **exact block** that will be written.
 
 ## Saving
 
-The footer offers **Save** and **Save & connect**. The second writes the block and opens a
-session to it immediately.
+The footer offers **Save** and **Save & connect**. The second persists the selected storage
+type and opens a session immediately.
 
-Duplicating a host copies every field into a new block with a fresh alias. Deleting a host
-removes only its block from the file it lives in.
+Duplicating a host keeps its storage type. Deleting an OpenSSH host removes only its block;
+deleting a Muxus-only host removes only its database profile.

--- a/docs/guide/hosts.md
+++ b/docs/guide/hosts.md
@@ -5,7 +5,7 @@ icon: lucide/server
 # Your hosts
 
 The sidebar lists every concrete `Host` block in the OpenSSH configuration, including files
-pulled in with `Include`, together with the Telnet and serial hosts stored by Muxus.
+pulled in with `Include`, together with SSH, Telnet and serial hosts stored by Muxus.
 
 Muxus does not import the configuration. It reads `~/.ssh/config` directly and writes edits
 back to the same file in place.
@@ -17,20 +17,21 @@ Muxus. On Windows, **Find sessions** reads bookmarks from the current user's loc
 MobaXterm installation. On every platform, you can choose `MobaXterm.ini`, `.mxtsessions`,
 `.mobaconf` or a text export instead.
 
-The review lists every detected SSH session and flags aliases that already exist. Choose
-which sessions to include and whether existing aliases should be kept or replaced. Muxus
+The review lists every detected SSH session. Choose whether SSH hosts should stay in Muxus
+app data only or be written as OpenSSH `Host` blocks, then select which sessions to include
+and whether matching hosts should be kept or replaced. Muxus
 preserves the display name, host, port, username, password-vs-key authentication intent and
 the `SubRep` folder hierarchy.
 
-Passwords and private key files are not copied. They remain outside `ssh_config`; Muxus
+Passwords and private key files are not copied. Muxus
 uses your SSH agent or asks for credentials when you connect.
 
 ## Import from SecureCRT
 
 In SecureCRT, choose **Tools → Export Settings**, include **Sessions**, and save the XML
 export. Then open **Settings → Backup & data → SecureCRT import** in Muxus and choose that
-file. The review preserves nested folders and lets you select individual sessions or keep
-and replace aliases that already exist.
+file. The review preserves nested folders, offers Muxus-only or OpenSSH storage for SSH
+sessions, and lets you select individual sessions or keep and replace matching hosts.
 
 Muxus imports SSH names, hosts, ports, usernames and password-vs-key authentication intent.
 Serial sessions include their device path, baud rate, data bits, stop bits, parity and flow
@@ -44,7 +45,7 @@ SecureCRT settings are never imported.
 <figure markdown="span">
   ![The hosts sidebar with folders and colours](../assets/screenshots/sidebar.png#only-light){ .shadow }
   ![The hosts sidebar with folders and colours](../assets/screenshots/sidebar-dark.png#only-dark){ .shadow }
-  <figcaption>Folders, colours, icons and live-session dots are stored by Muxus. The connection details come from OpenSSH.</figcaption>
+  <figcaption>Folders, colours, icons and live-session dots are stored by Muxus. SSH connection details can come from OpenSSH or a Muxus-only profile.</figcaption>
 </figure>
 
 ## Host rows
@@ -88,11 +89,11 @@ A folder can hold shared SSH defaults — username, port, a private key and a pa
 that every host inside it inherits. Open **Rename, move & style…** and fill in the
 **Shared SSH credentials** section.
 
-Precedence is always: the host's own settings first, then anything in `ssh_config`
-(including `Host *` blocks), then the nearest folder, then its parents. A folder never
-overrides something you configured on the host or in `ssh_config` — it only fills the
-gaps, so one folder entry can carry the login for a whole lab while individual hosts
-still override it by setting their own user or key.
+Precedence is always: the host's own settings first, then the nearest folder, then its
+parents. OpenSSH-backed hosts also use anything resolved from `ssh_config` (including
+`Host *` blocks) before consulting the folder. Muxus-only hosts do not read final-host
+settings from `ssh_config`; only named `ProxyJump` hops can still resolve there. A folder
+therefore fills gaps without replacing a value configured directly on the host.
 
 The shared password is kept in the encrypted [password vault](settings.md) and is tried
 automatically when a host falls back to password login; a password remembered for the

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -149,11 +149,16 @@ Telnet/serial hosts, workspaces, tunnels and preferences. **Restore a backup** m
 back in; items absent from the file are not deleted.
 
 **Export OpenSSH** writes the SSH hosts out as a standard `ssh_config` for use with another
-client. Muxus-only settings remain in the backup.
+client. Non-secret shared folder defaults are copied into each affected host block so the
+export remains usable outside Muxus. Folder and host passwords are omitted; other
+Muxus-only settings remain in the backup.
 
 !!! info "What a backup excludes"
 
     Private key files, passwords and recorded session history are never part of a backup.
+
+    A backup can contain a saved SSH `ProxyCommand`. Restoring it does not run the command,
+    but opening that connection later does. Restore backups only from sources you trust.
 
 ## Debug
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,18 +47,18 @@ The terminal is a current one: kitty graphics, so `kitten icat`, yazi previews a
 matplotlib render inline over SSH, plus the kitty keyboard protocol, bundled Nerd Font
 coverage and fifteen colour schemes.
 
-Hosts come from `~/.ssh/config` — Muxus reads it, resolves it, and writes edits back into
-it, so the list is the same one `ssh` uses. Folders, colours, workspaces and history go in
-a local database, because OpenSSH has no field for them.
+Muxus reads every host from `~/.ssh/config`, while also letting you keep selected SSH hosts
+in its local database without changing OpenSSH. Folders, colours, workspaces and history
+use the same local database.
 
 <div class="grid cards" markdown>
 
--   :material-file-cog-outline: **Your ssh config, not ours**
+-   :material-file-cog-outline: **OpenSSH or Muxus-only**
 
     ---
 
-    Every `Host` block appears in the sidebar, including the files pulled in with
-    `Include`. Edits are written back in place, atomically, with a `.muxus.bak`.
+    Every `Host` block appears in the sidebar, including files pulled in with `Include`.
+    New and imported SSH hosts can instead stay entirely in Muxus app data.
 
     [:octicons-arrow-right-24: Your hosts](guide/hosts.md)
 

--- a/docs/install/desktop.md
+++ b/docs/install/desktop.md
@@ -107,7 +107,8 @@ The desktop app keeps its data in Electron's per-app directory:
 | :material-linux: Linux | `~/.config/Muxus/muxus.sqlite3` |
 
 Session history, when enabled, is stored alongside it or at the location set in
-[Settings](../guide/settings.md). SSH connection settings still come from `~/.ssh/config`.
+[Settings](../guide/settings.md). OpenSSH-backed settings still come from
+`~/.ssh/config`; hosts saved as **Muxus app data only** live in this database.
 Passwords you explicitly choose to remember are encrypted in the application database by
 the password vault. The raw vault key is never stored in this directory; the default
 never-prompt policy uses the OS credential store. See the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,8 +46,9 @@ build uses Electron's per-app directory:
 | macOS | `~/Library/Application Support/Muxus/muxus.sqlite3` | `~/Library/Application Support/Muxus/muxus.sqlite3` |
 | Windows | `%APPDATA%\Muxus\muxus.sqlite3` | `%APPDATA%\Muxus\muxus.sqlite3` |
 
-Connection settings are not stored there; they remain in `~/.ssh/config`. Moving between
-the two builds is done with [backup and restore](../guide/settings.md#backup-data).
+Muxus-only SSH, Telnet and serial connection settings are stored there; OpenSSH-backed
+hosts remain in `~/.ssh/config`. Moving between the two builds is done with
+[backup and restore](../guide/settings.md#backup-data).
 
 ## Workspace scripts
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -35,7 +35,7 @@ and history.
 ## What is stored, and what is refused
 
 The local SQLite database holds folders, colours, display names, sidebar order, workspaces,
-saved tunnels, saved Telnet/serial hosts, per-host highlighting and logging policy,
+saved tunnels, Muxus-only SSH/Telnet/serial hosts, per-host highlighting and logging policy,
 connection timestamps, and—only when the user opts in—encrypted SSH passwords. It is
 created `0600` in a `0700` directory.
 
@@ -44,8 +44,11 @@ Objects whose field names include `password`, `passphrase`, `secret`, `token` or
 `privateKey` are refused at those persistence boundaries. The dedicated password-vault
 tables are the only place credential ciphertext can be written.
 
-Connection settings are not in the database. They remain in
-[`~/.ssh/config`](ssh-config.md).
+OpenSSH-backed connection settings remain in [`~/.ssh/config`](ssh-config.md). When a user
+explicitly chooses **Muxus only**, the SSH profile is stored in the database instead. A
+saved `ProxyCommand` is executable configuration: restoring a backup does not execute it,
+but opening that connection later does, so portable backups must be treated as trusted
+configuration rather than passive data.
 
 ## Password vault
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,7 +8,10 @@ import fastifyStatic from '@fastify/static';
 import { TERMINAL_WS_PROTOCOL } from '@muxus/shared/ws-protocol';
 import type { ServerConfig } from './config.js';
 import { SshConnectionManager } from './ssh/connection-manager.js';
-import { folderAuthResolver } from './ssh/folder-auth.js';
+import {
+  folderAuthResolver,
+  savedProfileFolderAuthResolver,
+} from './ssh/folder-auth.js';
 import { ForwardManager } from './forwards/forward-manager.js';
 import { registerAppRoutes } from './routes/app.js';
 import { registerSshRoutes } from './routes/ssh.js';
@@ -93,9 +96,17 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   await vault.initialize();
   const connections = new SshConnectionManager(app.log, {
     vault,
+    savedSshProfile: (id) => {
+      const profile = database.savedHostProfile(id)?.profile;
+      return profile?.kind === 'ssh' ? profile : undefined;
+    },
     folderAuth: folderAuthResolver(database),
+    profileFolderAuth: savedProfileFolderAuthResolver(database),
     disableSftpForHost: (alias) => database.sftpDisabledForAlias(alias),
     consoleCompatibilityForHost: (alias) => database.consoleCompatibilityForAlias(alias),
+    disableSftpForProfile: (id) => database.sftpDisabledForSavedHost(id),
+    consoleCompatibilityForProfile: (id) =>
+      database.consoleCompatibilityForSavedHost(id),
   });
   const forwards = new ForwardManager(connections, app.log);
   const historySettings = database.sessionHistorySettings();

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -611,7 +611,9 @@ export function assertSecretFree(value: unknown, location = 'config'): void {
       words.some((word, index) => word === 'private' && words[index + 1] === 'key');
     const referenceOnly =
       ['path', 'file', 'filename', 'ref', 'reference', 'id'].includes(words.at(-1) ?? '');
-    if (sensitive && !referenceOnly) {
+    // This is an authentication policy flag, not password material.
+    const safePolicy = key === 'passwordOnly' && typeof child === 'boolean';
+    if (sensitive && !referenceOnly && !safePolicy) {
       throw new Error(
         `${location}.${key} must not be stored in profile or workspace data; use the encrypted password vault`,
       );
@@ -689,6 +691,19 @@ export class MuxusDatabase {
     return row ? optionalString(row.group_name) : undefined;
   }
 
+  /** The sidebar folder a Muxus-owned host lives in. */
+  groupForSavedHost(id: string): string | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT groups.name AS group_name
+        FROM connection_profiles AS profiles
+        LEFT JOIN connection_groups AS groups ON groups.id = profiles.group_id
+        WHERE profiles.id = ? AND profiles.kind = 'ssh'
+      `)
+      .get(id);
+    return optionalString(row?.group_name);
+  }
+
   /** Whether this OpenSSH alias must avoid SFTP and Unix shell probing. */
   sftpDisabledForAlias(alias: string): boolean {
     const row = this.metadataByAlias.get(alias);
@@ -698,6 +713,28 @@ export class MuxusDatabase {
   /** Whether this OpenSSH alias needs the stricter console session shape. */
   consoleCompatibilityForAlias(alias: string): boolean {
     const row = this.metadataByAlias.get(alias);
+    return Number(row?.console_compatibility) === 1;
+  }
+
+  /** Whether one Muxus-owned host must avoid SFTP and shell probing. */
+  sftpDisabledForSavedHost(id: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT disable_sftp FROM connection_profiles
+         WHERE id = ? AND kind = 'ssh'`,
+      )
+      .get(id);
+    return Number(row?.disable_sftp) === 1;
+  }
+
+  /** Whether one Muxus-owned host needs the stricter console session shape. */
+  consoleCompatibilityForSavedHost(id: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT console_compatibility FROM connection_profiles
+         WHERE id = ? AND kind = 'ssh'`,
+      )
+      .get(id);
     return Number(row?.console_compatibility) === 1;
   }
 
@@ -752,7 +789,7 @@ export class MuxusDatabase {
   /**
    * Persist one complete visual group order across both host sources. Rows
    * for OpenSSH hosts are created lazily so even otherwise-unmodified hosts
-   * can participate in sorting; saved Telnet/serial hosts must already exist.
+   * can participate in sorting; Muxus-owned hosts must already exist.
    */
   reorderManagedHosts(refs: readonly ManagedHostRef[]): void {
     const keys = refs.map((ref) => (ref.kind === 'ssh' ? `ssh:${ref.alias}` : `profile:${ref.id}`));
@@ -763,7 +800,7 @@ export class MuxusDatabase {
     this.db.exec('BEGIN IMMEDIATE');
     try {
       const savedExists = this.db.prepare(
-        `SELECT id FROM connection_profiles WHERE id = ? AND kind IN ('serial', 'telnet')`,
+        `SELECT id FROM connection_profiles WHERE id = ? AND kind IN ('ssh', 'serial', 'telnet')`,
       );
       const update = this.db.prepare(`
         UPDATE connection_profiles
@@ -1121,7 +1158,7 @@ export class MuxusDatabase {
         SELECT profiles.*, groups.name AS group_name
         FROM connection_profiles AS profiles
         LEFT JOIN connection_groups AS groups ON groups.id = profiles.group_id
-        WHERE profiles.kind IN ('serial', 'telnet')
+        WHERE profiles.kind IN ('ssh', 'serial', 'telnet')
         ORDER BY profiles.sort_order, profiles.name COLLATE NOCASE
       `)
       .all()
@@ -1131,6 +1168,9 @@ export class MuxusDatabase {
   saveSavedHostProfile(input: SavedHostProfileInput): SavedHostProfile {
     requireNonEmpty(input.name, 'name');
     const kind = input.profile.kind;
+    if (kind === 'ssh' && input.profile.useConfig !== false) {
+      throw new Error('Muxus-owned SSH profiles must set useConfig to false');
+    }
     const { kind: _kind, profileId: _profileId, ...config } = input.profile;
     assertSecretFree(config, 'profile.config');
     const id = input.id ?? nanoid();
@@ -1138,7 +1178,7 @@ export class MuxusDatabase {
       .prepare(`SELECT kind FROM connection_profiles WHERE id = ?`)
       .get(id) as { kind?: unknown } | undefined;
     if (current) {
-      if (current.kind !== 'serial' && current.kind !== 'telnet') {
+      if (current.kind !== 'ssh' && current.kind !== 'serial' && current.kind !== 'telnet') {
         throw new Error('profile ID belongs to a different connection type');
       }
       this.db
@@ -1165,7 +1205,7 @@ export class MuxusDatabase {
         SELECT profiles.*, groups.name AS group_name
         FROM connection_profiles AS profiles
         LEFT JOIN connection_groups AS groups ON groups.id = profiles.group_id
-        WHERE profiles.id = ? AND profiles.kind IN ('serial', 'telnet')
+        WHERE profiles.id = ? AND profiles.kind IN ('ssh', 'serial', 'telnet')
       `)
       .get(id);
     return row ? savedHostFromRow(row) : undefined;
@@ -1177,7 +1217,7 @@ export class MuxusDatabase {
         SELECT profiles.*, groups.name AS group_name
         FROM connection_profiles AS profiles
         LEFT JOIN connection_groups AS groups ON groups.id = profiles.group_id
-        WHERE profiles.id = ? AND profiles.kind IN ('serial', 'telnet')
+        WHERE profiles.id = ? AND profiles.kind IN ('ssh', 'serial', 'telnet')
       `)
       .get(id);
     if (!current) throw new Error('saved host not found');
@@ -1230,7 +1270,7 @@ export class MuxusDatabase {
         SET last_connected_at = CURRENT_TIMESTAMP,
             connect_count = connect_count + 1,
             updated_at = CURRENT_TIMESTAMP
-        WHERE id = ? AND kind IN ('serial', 'telnet')
+        WHERE id = ? AND kind IN ('ssh', 'serial', 'telnet')
       `)
       .run(id);
   }
@@ -1238,7 +1278,7 @@ export class MuxusDatabase {
   deleteSavedHostProfile(id: string): boolean {
     const deleted =
       this.db
-        .prepare(`DELETE FROM connection_profiles WHERE id = ? AND kind IN ('serial', 'telnet')`)
+        .prepare(`DELETE FROM connection_profiles WHERE id = ? AND kind IN ('ssh', 'serial', 'telnet')`)
         .run(id).changes > 0;
     if (deleted) {
       this.db

--- a/server/src/routes/profiles.ts
+++ b/server/src/routes/profiles.ts
@@ -8,6 +8,7 @@ import type {
 } from '@muxus/shared';
 import {
   serialProfileSchema,
+  sshProfileSchema,
   telnetProfileSchema,
 } from '@muxus/shared/ws-protocol';
 import type { AppContext } from '../app.js';
@@ -17,10 +18,14 @@ import { metadataPatchSchema } from './metadata-schema.js';
 const savedProfileSchema = z.object({
   id: z.string().min(1).max(200).optional(),
   name: z.string().trim().min(1).max(200),
-  profile: z.discriminatedUnion('kind', [telnetProfileSchema, serialProfileSchema]),
+  profile: z.discriminatedUnion('kind', [
+    sshProfileSchema,
+    telnetProfileSchema,
+    serialProfileSchema,
+  ]),
 });
 
-/** Muxus-owned Telnet and serial hosts. */
+/** Muxus-owned SSH, Telnet, and serial hosts. */
 export function registerProfileRoutes(app: FastifyInstance, ctx: AppContext): void {
   app.get('/api/profiles', (): SavedHostProfilesResponse => ({
     profiles: ctx.database.listSavedHostProfiles(),

--- a/server/src/routes/ssh.ts
+++ b/server/src/routes/ssh.ts
@@ -44,6 +44,9 @@ const upsertSchema = z.object({
     proxyCommand: z.string().optional(),
     forwards: z.array(forwardSchema).optional(),
     passwordOnly: z.boolean().optional(),
+    remoteCommand: z.string().optional(),
+    requestTty: z.enum(['no', 'yes', 'force', 'auto']).optional(),
+    strictHostKeyChecking: z.enum(['yes', 'no', 'accept-new', 'ask']).optional(),
     extras: z.array(z.object({ keyword: z.string(), value: z.string() })).optional(),
   }),
 });

--- a/server/src/session-logging/session-recorder.ts
+++ b/server/src/session-logging/session-recorder.ts
@@ -24,7 +24,12 @@ export function sessionProfileIdentity(profile: SessionProfile): {
 } {
   switch (profile.kind) {
     case 'ssh':
-      return { profileKey: `ssh:${profile.target}`, host: profile.target };
+      return {
+        profileKey: profile.profileId
+          ? `profile:${profile.profileId}`
+          : `ssh:${profile.target}`,
+        host: profile.target,
+      };
     case 'telnet': {
       const host = `${profile.host}:${profile.port}`;
       return {

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -269,9 +269,13 @@ export class SshConnectionManager {
   private readonly automaticPlainShellKeys = new Set<string>();
   private readonly loadConfig: () => ConfigDocument;
   private readonly vault: PasswordVault | undefined;
+  private readonly savedSshProfile: ((id: string) => SshProfile | undefined) | undefined;
   private readonly folderAuth: FolderAuthLookup | undefined;
+  private readonly profileFolderAuth: FolderAuthLookup | undefined;
   private readonly disableSftpForHost: ((alias: string) => boolean) | undefined;
   private readonly consoleCompatibilityForHost: ((alias: string) => boolean) | undefined;
+  private readonly disableSftpForProfile: ((id: string) => boolean) | undefined;
+  private readonly consoleCompatibilityForProfile: ((id: string) => boolean) | undefined;
   private readonly agentOperationTimeoutMs: number;
   private readonly agentWaitStatusMs: number;
   readonly knownHosts: KnownHostsStore;
@@ -282,12 +286,20 @@ export class SshConnectionManager {
       knownHosts?: KnownHostsStore;
       loadConfig?: () => ConfigDocument;
       vault?: PasswordVault;
+      /** Current database-owned SSH profile, keyed by stable profile ID. */
+      savedSshProfile?: (id: string) => SshProfile | undefined;
       /** Folder-inherited connection defaults per alias (Muxus sidebar folders). */
       folderAuth?: FolderAuthLookup;
+      /** Folder defaults for Muxus-owned profiles, keyed by stable profile ID. */
+      profileFolderAuth?: FolderAuthLookup;
       /** Muxus-owned per-host compatibility setting; never written to ssh_config. */
       disableSftpForHost?: (alias: string) => boolean;
       /** Muxus-owned console compatibility setting; never written to ssh_config. */
       consoleCompatibilityForHost?: (alias: string) => boolean;
+      /** Muxus-owned compatibility setting for a database-backed SSH host. */
+      disableSftpForProfile?: (id: string) => boolean;
+      /** Muxus-owned console setting for a database-backed SSH host. */
+      consoleCompatibilityForProfile?: (id: string) => boolean;
       /** Test seam; production uses the exported responsive-agent defaults. */
       agentOperationTimeoutMs?: number;
       /** Test seam; production uses the exported responsive-agent defaults. */
@@ -297,9 +309,13 @@ export class SshConnectionManager {
     this.knownHosts = options.knownHosts ?? new KnownHostsStore();
     this.loadConfig = options.loadConfig ?? (() => loadConfigDocument());
     this.vault = options.vault;
+    this.savedSshProfile = options.savedSshProfile;
     this.folderAuth = options.folderAuth;
+    this.profileFolderAuth = options.profileFolderAuth;
     this.disableSftpForHost = options.disableSftpForHost;
     this.consoleCompatibilityForHost = options.consoleCompatibilityForHost;
+    this.disableSftpForProfile = options.disableSftpForProfile;
+    this.consoleCompatibilityForProfile = options.consoleCompatibilityForProfile;
     this.agentOperationTimeoutMs =
       options.agentOperationTimeoutMs ?? DEFAULT_AGENT_OPERATION_TIMEOUT_MS;
     this.agentWaitStatusMs =
@@ -344,19 +360,31 @@ export class SshConnectionManager {
     owner: ConnectionLeaseOwner = 'terminal',
     opts: { freshTransport?: boolean; forcePlainShell?: boolean } = {},
   ): Promise<MuxedConnectionLease> {
+    profile = this.resolveProfile(profile);
     const doc = this.loadConfig();
-    const chain = buildChain(doc, profile, this.folderAuth);
+    const chain = buildChain(
+      doc,
+      profile,
+      this.folderAuth,
+      this.profileFolderAuth,
+    );
     const target = chain[chain.length - 1]!;
     const metadataAlias =
       profile.useConfig === false ? undefined : findMetadataAlias(doc, target.spec.host);
     const regularKey = muxKey(chain);
     const consoleCompatibility =
       (metadataAlias ? (this.consoleCompatibilityForHost?.(metadataAlias) ?? false) : false) ||
+      (profile.profileId
+        ? (this.consoleCompatibilityForProfile?.(profile.profileId) ?? false)
+        : false) ||
       this.automaticPlainShellKeys.has(regularKey) ||
       opts.forcePlainShell === true;
     const disableSftp =
       consoleCompatibility ||
-      (metadataAlias ? (this.disableSftpForHost?.(metadataAlias) ?? false) : false);
+      (metadataAlias ? (this.disableSftpForHost?.(metadataAlias) ?? false) : false) ||
+      (profile.profileId
+        ? (this.disableSftpForProfile?.(profile.profileId) ?? false)
+        : false);
     const key = muxKey(chain, disableSftp, consoleCompatibility);
     const configForwards = target.resolved.forwards;
     const label = `${target.user}@${target.resolved.hostname}:${target.port}`;
@@ -410,6 +438,20 @@ export class SshConnectionManager {
     } finally {
       if (this.pendingDials.get(key) === tracked) this.pendingDials.delete(key);
     }
+  }
+
+  /**
+   * A stable database ID is a reference, not permission for a client or a
+   * stale workspace to replace the saved connection fields. Resolve it at the
+   * server boundary so edits and deletions take effect on the next dial.
+   */
+  resolveProfile(profile: SshProfile): SshProfile {
+    if (!profile.profileId) return profile;
+    const saved = this.savedSshProfile?.(profile.profileId);
+    if (!saved || saved.profileId !== profile.profileId || saved.useConfig !== false) {
+      throw new Error(`saved SSH profile "${profile.profileId}" was not found`);
+    }
+    return saved;
   }
 
   /** Least-busy live, healthy transport with the same dial plan, if any. */
@@ -1013,6 +1055,7 @@ export function buildChain(
   doc: ConfigDocument,
   profile: Omit<SshProfile, 'kind'>,
   folderAuthFor?: FolderAuthLookup,
+  profileFolderAuthFor?: FolderAuthLookup,
 ): ChainHop[] {
   const chain: ChainHop[] = [];
   const visited = new Set<string>();
@@ -1022,8 +1065,16 @@ export function buildChain(
     if (visited.has(spec.host)) throw new Error(`ProxyJump cycle detected at "${spec.host}"`);
     visited.add(spec.host);
     const fromConfig = !final || profile.useConfig !== false;
-    const folder = fromConfig ? folderAuthFor?.(spec.host) : undefined;
-    const base = fromConfig ? resolveHost(doc, spec.host, folder?.optionLines) : directSettings(spec.host);
+    const folder = fromConfig
+      ? folderAuthFor?.(spec.host)
+      : final && profile.profileId
+        ? profileFolderAuthFor?.(profile.profileId)
+        : undefined;
+    const base = fromConfig
+      ? resolveHost(doc, spec.host, folder?.optionLines)
+      : folder
+        ? resolveHost(EMPTY_CONFIG_DOCUMENT, spec.host, folder.optionLines)
+        : directSettings(spec.host);
     const user = (final ? profile.user : undefined) ?? spec.user ?? base.user ?? os.userInfo().username;
     const resolved: ResolvedTarget = final
       ? {
@@ -1034,12 +1085,25 @@ export function buildChain(
               : profile.identityFiles.map((file) =>
                   expandIdentityPath(file, { h: base.hostname, r: user }),
                 ),
+          certificateFiles:
+            profile.certificateFiles === undefined
+              ? base.certificateFiles
+              : profile.certificateFiles.map((file) =>
+                  expandIdentityPath(file, { h: base.hostname, r: user }),
+                ),
           identitiesOnly: profile.identitiesOnly ?? base.identitiesOnly,
+          identityAgent: profile.identityAgent ?? base.identityAgent,
           forwardAgent: profile.forwardAgent ?? base.forwardAgent,
           proxyJump: profile.proxyJump ?? base.proxyJump,
           proxyCommand:
-            profile.proxyJump === undefined ? base.proxyCommand : undefined,
+            profile.proxyCommand ??
+            (profile.proxyJump === undefined ? base.proxyCommand : undefined),
+          forwards: profile.forwards ?? base.forwards,
           passwordOnly: profile.passwordOnly ?? base.passwordOnly,
+          remoteCommand: profile.remoteCommand ?? base.remoteCommand,
+          requestTty: profile.requestTty ?? base.requestTty,
+          strictHostKeyChecking:
+            profile.strictHostKeyChecking ?? base.strictHostKeyChecking,
         }
       : base;
     for (const hopSpec of resolved.proxyJump) walk(parseHostSpec(hopSpec), false, depth + 1);
@@ -1056,6 +1120,15 @@ export function buildChain(
   walk(parseHostSpec(profile.target), true, 0);
   return chain;
 }
+
+/** Empty base used to apply only Muxus folder defaults to a DB-backed host. */
+const EMPTY_CONFIG_DOCUMENT: ConfigDocument = {
+  rootPath: '',
+  files: new Map(),
+  fileOrder: [],
+  blocks: [],
+  sequence: [],
+};
 
 function directSettings(hostname: string): ResolvedTarget {
   return {

--- a/server/src/ssh/folder-auth.ts
+++ b/server/src/ssh/folder-auth.ts
@@ -27,26 +27,41 @@ export interface FolderAuthSource {
   ): { id: string; path: string; auth: FolderAuthSettings } | undefined;
 }
 
+export interface SavedProfileFolderAuthSource extends FolderAuthSource {
+  groupForSavedHost(id: string): string | undefined;
+}
+
 /**
  * Per-alias folder defaults for the dial path: the host's folder chain
  * (nearest first) collapses to one set of option lines, and every folder with
  * settings contributes a vault password candidate.
  */
 export function folderAuthResolver(source: FolderAuthSource): FolderAuthLookup {
-  return (alias) => {
-    const group = source.groupForAlias(alias);
-    if (!group) return undefined;
-    const rows = folderChain(group)
-      .map((path) => source.folderSettingsForPath(path))
-      .filter((row) => row !== undefined);
-    if (rows.length === 0) return undefined;
-    return {
-      optionLines: folderAuthOptionLines(mergeFolderAuth(rows.map((row) => row.auth))),
-      passwords: rows.map((row) => ({
-        account: folderPasswordAccount(row.id),
-        label: folderPasswordLabel(row.path),
-      })),
-    };
+  return (alias) => folderAuthForGroup(source, source.groupForAlias(alias));
+}
+
+/** Folder defaults for a Muxus-owned profile, keyed by its stable database ID. */
+export function savedProfileFolderAuthResolver(
+  source: SavedProfileFolderAuthSource,
+): FolderAuthLookup {
+  return (id) => folderAuthForGroup(source, source.groupForSavedHost(id));
+}
+
+function folderAuthForGroup(
+  source: FolderAuthSource,
+  group: string | undefined,
+): FolderAuthDefaults | undefined {
+  if (!group) return undefined;
+  const rows = folderChain(group)
+    .map((path) => source.folderSettingsForPath(path))
+    .filter((row) => row !== undefined);
+  if (rows.length === 0) return undefined;
+  return {
+    optionLines: folderAuthOptionLines(mergeFolderAuth(rows.map((row) => row.auth))),
+    passwords: rows.map((row) => ({
+      account: folderPasswordAccount(row.id),
+      label: folderPasswordLabel(row.path),
+    })),
   };
 }
 

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -417,7 +417,8 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
     // Shell-less transport (`ssh -N`): the socket holds a dial lease so the
     // client can start forwards on the connId; once those hold their own
     // leases the socket closes and the transport lives on with them.
-    const dialLease = await ctx.connections.connect(connectMsg.profile, io, 'dial');
+    const profile = ctx.connections.resolveProfile(connectMsg.profile);
+    const dialLease = await ctx.connections.connect(profile, io, 'dial');
     if (!socketOpen) {
       dialLease.release();
       return;
@@ -433,7 +434,7 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
       socket.close();
     });
     socket.once('close', () => unsubscribeDialClose());
-    app.log.info({ target: connectMsg.profile.target, host: conn.host, user: conn.user, connId: conn.id, reused: dialLease.reused }, 'ssh transport dialed');
+    app.log.info({ target: profile.target, host: conn.host, user: conn.user, connId: conn.id, reused: dialLease.reused }, 'ssh transport dialed');
     if (conn.metadataAlias) {
       try {
         ctx.database.recordOpenSshConnection(conn.metadataAlias);
@@ -459,7 +460,11 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
     return;
   }
 
-  const { profile, cols, rows } = connectMsg;
+  const { cols, rows } = connectMsg;
+  const profile =
+    connectMsg.profile.kind === 'ssh'
+      ? ctx.connections.resolveProfile(connectMsg.profile)
+      : connectMsg.profile;
   recorder = SessionRecorder.start(
     ctx.database,
     ctx.history,
@@ -687,6 +692,13 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
   });
 
   app.log.info({ target: profile.target, host: conn.host, user: conn.user, connId: conn.id, transport }, 'ssh session established');
+  if (profile.profileId) {
+    try {
+      ctx.database.recordSavedHostConnection(profile.profileId);
+    } catch (err) {
+      app.log.warn({ err, profileId: profile.profileId }, 'could not record recent connection');
+    }
+  }
   if (conn.metadataAlias) {
     try {
       ctx.database.recordOpenSshConnection(conn.metadataAlias);

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -264,10 +264,11 @@ export interface SerialPortsResponse {
 }
 
 export type SavedHostSessionProfile =
+  | import('./ws-protocol.js').SshProfile
   | import('./ws-protocol.js').TelnetProfile
   | import('./ws-protocol.js').SerialProfile;
 
-/** Telnet/serial host stored natively by Muxus rather than in ssh_config. */
+/** SSH/Telnet/serial host stored natively by Muxus rather than in ssh_config. */
 export interface SavedHostProfile {
   id: string;
   kind: SavedHostSessionProfile['kind'];

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -35,23 +35,43 @@ export const localProfileSchema = z.object({
 
 export const sshProfileSchema = z.object({
   kind: z.literal('ssh'),
+  /** Stable Muxus database profile when this is a saved host. */
+  profileId: z.string().min(1).max(200).optional(),
   /**
    * Host alias from ~/.ssh/config, or an ad-hoc "[user@]host[:port]".
    * Everything else — HostName, User, Port, keys, ProxyJump, forwards —
    * resolves server-side from the config, exactly like `ssh <target>`.
    */
   target: z.string().min(1),
-  /** False for a self-contained tunnel profile; jump aliases still resolve from config. */
+  /** False for a self-contained saved host or tunnel; jump aliases may still resolve from config. */
   useConfig: z.boolean().optional(),
   /** Quick-connect overrides on top of config resolution. */
   user: z.string().optional(),
   port: z.number().int().min(1).max(65535).optional(),
   /** Tunnel-owned overrides; passwords/passphrases still travel only in prompts. */
   identityFiles: z.array(z.string().min(1).max(4096)).max(32).optional(),
+  certificateFiles: z.array(z.string().min(1).max(4096)).max(32).optional(),
   identitiesOnly: z.boolean().optional(),
+  /** Agent socket path, environment indirection, SSH_AUTH_SOCK, or none. */
+  identityAgent: z.string().min(1).max(4096).optional(),
   forwardAgent: z.boolean().optional(),
   proxyJump: z.array(z.string().min(1).max(500)).max(8).optional(),
+  proxyCommand: z.string().min(1).max(32_768).optional(),
+  forwards: z
+    .array(
+      z.object({
+        type: z.enum(['local', 'remote', 'dynamic']),
+        bindPort: z.number().int().min(1).max(65535),
+        targetHost: z.string().min(1).max(4096).optional(),
+        targetPort: z.number().int().min(1).max(65535).optional(),
+      }),
+    )
+    .max(64)
+    .optional(),
   passwordOnly: z.boolean().optional(),
+  remoteCommand: z.string().min(1).max(32_768).optional(),
+  requestTty: z.enum(['no', 'yes', 'force', 'auto']).optional(),
+  strictHostKeyChecking: z.enum(['yes', 'no', 'accept-new', 'ask']).optional(),
 });
 
 export const telnetProfileSchema = z.object({

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiFetch } from '../../../client/src/api/http.js';
+import type { HostUpsertRequest } from '@muxus/shared';
 import {
   BACKUP_FORMAT,
   TRANSFER_VERSION,
   createBackupDocument,
+  createOpenSshExport,
   parseTransferDocument,
   restoreImportedConnections,
   sanitizePreferences,
@@ -353,6 +355,89 @@ describe('backing up folder credentials', () => {
   });
 });
 
+describe('exporting Muxus-only SSH hosts to OpenSSH', () => {
+  it('materializes non-secret folder defaults and marks an omitted folder password', async () => {
+    const previews: HostUpsertRequest[] = [];
+    apiFetchMock.mockImplementation(async (url, options) => {
+      if (url === '/api/ssh/config') return { hosts: [] } as never;
+      if (url === '/api/profiles') {
+        return {
+          profiles: [
+            {
+              id: 'saved-1',
+              kind: 'ssh',
+              name: 'Core router',
+              profile: {
+                kind: 'ssh',
+                profileId: 'saved-1',
+                target: 'router.example.test',
+                useConfig: false,
+                user: 'profile-user',
+              },
+              metadata: {
+                profileId: 'saved-1',
+                group: 'Prod/EU',
+                connectCount: 0,
+              },
+              createdAt: '2026-08-07T00:00:00.000Z',
+              updatedAt: '2026-08-07T00:00:00.000Z',
+            },
+          ],
+        } as never;
+      }
+      if (url === '/api/folders/settings') {
+        return {
+          folders: [
+            {
+              id: 'prod',
+              path: 'Prod',
+              auth: {
+                user: 'folder-user',
+                identityFiles: ['~/.ssh/prod'],
+                identityAgent: 'SSH_AUTH_SOCK',
+              },
+              hasPassword: true,
+              createdAt: '2026-08-07T00:00:00.000Z',
+              updatedAt: '2026-08-07T00:00:00.000Z',
+            },
+            {
+              id: 'prod-eu',
+              path: 'Prod/EU',
+              auth: { port: 2222 },
+              hasPassword: false,
+              createdAt: '2026-08-07T00:00:00.000Z',
+              updatedAt: '2026-08-07T00:00:00.000Z',
+            },
+          ],
+        } as never;
+      }
+      if (url === '/api/ssh/config/preview') {
+        if (typeof options?.body !== 'string') throw new Error('preview body was not JSON');
+        const request = JSON.parse(options.body) as HostUpsertRequest;
+        previews.push(request);
+        return { text: `Host ${request.aliases[0]}` } as never;
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    await expect(createOpenSshExport()).resolves.toContain('Host Core-router');
+    expect(previews).toEqual([
+      expect.objectContaining({
+        aliases: ['Core-router'],
+        description:
+          'Exported from Muxus app data. Shared folder password omitted.',
+        options: expect.objectContaining({
+          hostname: 'router.example.test',
+          user: 'profile-user',
+          port: 2222,
+          identityFiles: ['~/.ssh/prod'],
+          identityAgent: 'SSH_AUTH_SOCK',
+        }),
+      }),
+    ]);
+  });
+});
+
 describe('restoring SSH hosts', () => {
   const importedSecondaryAlias = {
     sshHosts: [
@@ -470,6 +555,54 @@ describe('restoring imported serial hosts', () => {
         }),
       }),
     );
+  });
+});
+
+describe('restoring Muxus-only SSH hosts', () => {
+  const importedSsh = {
+    sshHosts: [],
+    savedHosts: [
+      {
+        id: 'mobaxterm-ssh-router',
+        name: 'Core router',
+        profile: {
+          kind: 'ssh' as const,
+          target: 'router.example.test',
+          useConfig: false as const,
+          user: 'admin',
+          passwordOnly: true,
+        },
+        metadata: { group: 'Lab' },
+      },
+    ],
+    hostOrder: [],
+  };
+
+  it('restores through the native profile endpoint rather than ssh_config', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce({ hosts: [] })
+      .mockResolvedValueOnce({ profiles: [] })
+      .mockResolvedValueOnce({ id: 'mobaxterm-ssh-router' })
+      .mockResolvedValueOnce({ id: 'mobaxterm-ssh-router' });
+
+    await expect(
+      restoreImportedConnections(importedSsh, 'replace'),
+    ).resolves.toEqual({ added: 1, updated: 0, skipped: 0 });
+    expect(apiFetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/profiles',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          id: 'mobaxterm-ssh-router',
+          name: 'Core router',
+          profile: importedSsh.savedHosts[0]?.profile,
+        }),
+      }),
+    );
+    expect(
+      apiFetchMock.mock.calls.some(([url]) => url === '/api/ssh/config/hosts'),
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -88,6 +88,72 @@ describe('Muxus transfer file parsing', () => {
     expect(parseTransferDocument(JSON.stringify(document))).toEqual(document);
   });
 
+  it('keeps reading legacy version-1 backups', () => {
+    const document = {
+      format: BACKUP_FORMAT,
+      version: 1,
+      createdAt: '2026-07-24T12:00:00.000Z',
+      data: {
+        sshHosts: [],
+        savedHosts: [
+          {
+            id: 'legacy-telnet',
+            name: 'Console',
+            profile: { kind: 'telnet', host: 'console.example.test', port: 23 },
+            metadata: {},
+          },
+        ],
+        hostOrder: [{ kind: 'profile', id: 'legacy-telnet' }],
+        preferences: {},
+        tunnels: [],
+        loggingPolicies: [],
+        historySettings: {
+          maxTotalBytes: 5 * 1024 ** 3,
+          minFreeBytes: 2 * 1024 ** 3,
+          minFreePercent: 5,
+        },
+      },
+    };
+
+    expect(parseTransferDocument(JSON.stringify(document))).toEqual(document);
+  });
+
+  it('requires version 2 for saved SSH profiles', () => {
+    expect(() =>
+      parseTransferDocument(
+        JSON.stringify({
+          format: BACKUP_FORMAT,
+          version: 1,
+          createdAt: '2026-07-24T12:00:00.000Z',
+          data: {
+            sshHosts: [],
+            savedHosts: [
+              {
+                id: 'saved-ssh',
+                name: 'Router',
+                profile: {
+                  kind: 'ssh',
+                  target: 'router.example.test',
+                  useConfig: false,
+                },
+                metadata: {},
+              },
+            ],
+            hostOrder: [{ kind: 'profile', id: 'saved-ssh' }],
+            preferences: {},
+            tunnels: [],
+            loggingPolicies: [],
+            historySettings: {
+              maxTotalBytes: 5 * 1024 ** 3,
+              minFreeBytes: 2 * 1024 ** 3,
+              minFreePercent: 5,
+            },
+          },
+        }),
+      ),
+    ).toThrow('The connection data in this file is incomplete or too large.');
+  });
+
   it('rejects invalid JSON with a useful error', () => {
     expect(() => parseTransferDocument('{not json')).toThrow(
       'This file is not valid JSON.',
@@ -99,12 +165,14 @@ describe('Muxus transfer file parsing', () => {
       parseTransferDocument(
         JSON.stringify({
           format: BACKUP_FORMAT,
-          version: 2,
+          version: TRANSFER_VERSION + 1,
           createdAt: '2026-07-24T12:00:00.000Z',
           data: {},
         }),
       ),
-    ).toThrow('Muxus transfer version 2 is not supported.');
+    ).toThrow(
+      `Muxus transfer version ${TRANSFER_VERSION + 1} is not supported.`,
+    );
   });
 
   it('rejects malformed connection entries before restore can write', () => {

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import type { SshHostEntry } from '@muxus/shared';
+import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
 import {
   blankDraft,
   draftFromEntry,
+  draftFromSavedSshProfile,
+  draftProblem,
   draftToRequest,
+  draftToSavedSshInput,
   identityAgentForDetection,
 } from '../../../client/src/components/host-editor/draft.js';
 
@@ -37,6 +40,59 @@ const entry: SshHostEntry = {
 };
 
 describe('SSH host editor draft', () => {
+  it('loads and saves a self-contained Muxus SSH profile', () => {
+    const saved: SavedHostProfile = {
+      id: 'muxus-router',
+      kind: 'ssh',
+      name: 'Core router',
+      profile: {
+        kind: 'ssh',
+        profileId: 'muxus-router',
+        target: 'router.example.test',
+        useConfig: false,
+        user: 'admin',
+        port: 2222,
+        identityFiles: ['~/.ssh/router'],
+        identitiesOnly: true,
+        proxyJump: ['bastion'],
+      },
+      metadata: {
+        profileId: 'muxus-router',
+        group: 'Production',
+        connectCount: 0,
+      },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+
+    const draft = draftFromSavedSshProfile(saved, false);
+    expect(draft).toMatchObject({
+      storage: 'muxus',
+      aliasText: 'Core router',
+      hostname: 'router.example.test',
+      user: 'admin',
+      port: '2222',
+      group: 'Production',
+      authMode: 'key',
+      routeMode: 'jump',
+    });
+    expect(draftProblem(draft)).toBeNull();
+    expect(draftToSavedSshInput(draft, saved.id)).toMatchObject({
+      id: 'muxus-router',
+      name: 'Core router',
+      profile: {
+        kind: 'ssh',
+        target: 'router.example.test',
+        useConfig: false,
+        user: 'admin',
+        port: 2222,
+        identityFiles: ['~/.ssh/router'],
+        identitiesOnly: true,
+        proxyJump: ['bastion'],
+      },
+    });
+  });
+
   it('loads and saves modeled connection options as first-class fields', () => {
     const draft = draftFromEntry(entry, false);
     expect(draft.authMode).toBe('key');

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -176,6 +176,10 @@ describe('SSH host editor draft', () => {
       remoteCommand: 'none',
       requestTty: 'auto',
     });
+    const savedProfile = draftToSavedSshInput(draft).profile;
+    expect(savedProfile.kind).toBe('ssh');
+    if (savedProfile.kind !== 'ssh') throw new Error('Expected an SSH profile');
+    expect(savedProfile.remoteCommand).toBeUndefined();
   });
 
   it('selects the current per-host agent for live key detection', () => {

--- a/tests/unit/client/managed-hosts.test.ts
+++ b/tests/unit/client/managed-hosts.test.ts
@@ -170,6 +170,57 @@ describe('managed host identity and clipboard actions', () => {
       label: 'Copy ssh command',
       text: 'ssh -p 2222 admin@core.example.test',
     });
+
+    const routed = {
+      ...nativeSsh,
+      entry: {
+        ...nativeSsh.entry,
+        profile: {
+          ...nativeSsh.entry.profile,
+          identityFiles: ['~/.ssh/core key'],
+          certificateFiles: ['~/.ssh/core-cert.pub'],
+          identitiesOnly: true,
+          identityAgent: 'none',
+          forwardAgent: true,
+          proxyJump: ['bastion', 'ops@jump.example.test:2200'],
+          passwordOnly: true,
+          forwards: [
+            {
+              type: 'local' as const,
+              bindPort: 8080,
+              targetHost: '127.0.0.1',
+              targetPort: 80,
+            },
+          ],
+          requestTty: 'force' as const,
+          strictHostKeyChecking: 'accept-new' as const,
+          remoteCommand: 'tmux new -A -s main',
+        },
+      },
+    };
+    expect(managedHostCopyCommand(routed).text).toBe(
+      "ssh -p 2222 -i '~/.ssh/core key' -o CertificateFile=~/.ssh/core-cert.pub " +
+        '-o IdentitiesOnly=yes -o IdentityAgent=none -A ' +
+        '-J bastion,ops@jump.example.test:2200 -o PubkeyAuthentication=no ' +
+        '-o PreferredAuthentications=keyboard-interactive,password ' +
+        '-L 8080:127.0.0.1:80 -tt -o StrictHostKeyChecking=accept-new ' +
+        "admin@core.example.test 'tmux new -A -s main'",
+    );
+
+    const proxied = {
+      ...nativeSsh,
+      entry: {
+        ...nativeSsh.entry,
+        profile: {
+          ...nativeSsh.entry.profile,
+          proxyCommand: 'cloudflared access ssh --hostname %h',
+        },
+      },
+    };
+    expect(managedHostCopyCommand(proxied).text).toBe(
+      "ssh -p 2222 -o 'ProxyCommand=cloudflared access ssh --hostname %h' " +
+        'admin@core.example.test',
+    );
   });
 
   it('offers SFTP only for SSH hosts where it is not explicitly disabled', () => {

--- a/tests/unit/client/managed-hosts.test.ts
+++ b/tests/unit/client/managed-hosts.test.ts
@@ -82,6 +82,28 @@ function serialHost(name: string): SavedHostProfile {
   };
 }
 
+function nativeSshHost(name: string): SavedHostProfile {
+  return {
+    id: `native-ssh-${name}`,
+    kind: 'ssh',
+    name,
+    profile: {
+      kind: 'ssh',
+      profileId: `native-ssh-${name}`,
+      target: `${name}.example.test`,
+      useConfig: false,
+      user: 'admin',
+      port: 2222,
+    },
+    metadata: {
+      profileId: `native-ssh-${name}`,
+      connectCount: 0,
+    },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
 describe('managed host groups', () => {
   it('places ungrouped SSH, Telnet, and serial profiles in one Hosts group', () => {
     const groups = groupManagedHosts(
@@ -120,6 +142,7 @@ describe('managed host groups', () => {
 
 describe('managed host identity and clipboard actions', () => {
   const ssh = { kind: 'ssh' as const, entry: sshHost('router') };
+  const nativeSsh = { kind: 'profile' as const, entry: nativeSshHost('core') };
   const telnet = { kind: 'profile' as const, entry: telnetHost('console') };
   const serial = { kind: 'profile' as const, entry: serialHost('rack') };
 
@@ -143,6 +166,10 @@ describe('managed host identity and clipboard actions', () => {
       label: 'Copy device path',
       text: 'COM3',
     });
+    expect(managedHostCopyCommand(nativeSsh)).toEqual({
+      label: 'Copy ssh command',
+      text: 'ssh -p 2222 admin@core.example.test',
+    });
   });
 
   it('offers SFTP only for SSH hosts where it is not explicitly disabled', () => {
@@ -154,6 +181,7 @@ describe('managed host identity and clipboard actions', () => {
     };
 
     expect(managedHostSupportsSftp(ssh)).toBe(true);
+    expect(managedHostSupportsSftp(nativeSsh)).toBe(true);
     expect(managedHostSupportsSftp({ kind: 'ssh', entry: disabled })).toBe(false);
 
     const consoleCompatible = sshHost('console-compatible');
@@ -163,6 +191,15 @@ describe('managed host identity and clipboard actions', () => {
       consoleCompatibility: true,
     };
     expect(managedHostSupportsSftp({ kind: 'ssh', entry: consoleCompatible })).toBe(false);
+    expect(
+      managedHostSupportsSftp({
+        ...nativeSsh,
+        entry: {
+          ...nativeSsh.entry,
+          metadata: { ...nativeSsh.entry.metadata, disableSftp: true },
+        },
+      }),
+    ).toBe(false);
     expect(managedHostSupportsSftp(telnet)).toBe(false);
     expect(managedHostSupportsSftp(serial)).toBe(false);
   });

--- a/tests/unit/client/mobaxterm-import.test.ts
+++ b/tests/unit/client/mobaxterm-import.test.ts
@@ -147,4 +147,30 @@ Key host=#109#0%key.example.com%22%bob%3%rest
       },
     ]);
   });
+
+  it('can keep imported SSH sessions in Muxus app data', () => {
+    const parsed = parseMobaXtermSessions(`
+[Bookmarks]
+SubRep=Customers\\Acme
+Password host=#109#0%pw.example.com%2200%alice%%rest
+`);
+    const portable = mobaXtermConnections(parsed.sessions, 'muxus');
+
+    expect(portable.sshHosts).toEqual([]);
+    expect(portable.savedHosts).toEqual([
+      {
+        id: expect.stringMatching(/^mobaxterm-ssh-/),
+        name: 'Password host',
+        profile: {
+          kind: 'ssh',
+          target: 'pw.example.com',
+          useConfig: false,
+          user: 'alice',
+          port: 2200,
+          passwordOnly: true,
+        },
+        metadata: { group: 'Customers/Acme' },
+      },
+    ]);
+  });
 });

--- a/tests/unit/client/securecrt-import.test.ts
+++ b/tests/unit/client/securecrt-import.test.ts
@@ -242,4 +242,34 @@ describe('SecureCRT connection conversion', () => {
     expect(JSON.stringify(portable)).not.toContain('/private/key');
     expect(JSON.stringify(portable)).not.toContain('private-key-bytes');
   });
+
+  it('stores SSH sessions alongside native serial profiles when requested', () => {
+    const portable = secureCrtConnections(
+      parseSecureCrtSessions(EXPORT).sessions,
+      'muxus',
+    );
+
+    expect(portable.sshHosts).toEqual([]);
+    expect(portable.savedHosts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.stringMatching(/^securecrt-ssh-/),
+          name: 'Core router',
+          profile: expect.objectContaining({
+            kind: 'ssh',
+            target: 'router.example.test',
+            useConfig: false,
+            user: 'deploy',
+            port: 2222,
+            passwordOnly: true,
+          }),
+          metadata: { group: 'Customers & labs/Europe' },
+        }),
+        expect.objectContaining({
+          id: expect.stringMatching(/^securecrt-serial-/),
+          profile: expect.objectContaining({ kind: 'serial' }),
+        }),
+      ]),
+    );
+  });
 });

--- a/tests/unit/server/chain.test.ts
+++ b/tests/unit/server/chain.test.ts
@@ -9,6 +9,7 @@ import {
   findMetadataAlias,
   muxKey,
   observeSshTransportHealth,
+  SshConnectionManager,
   sshKeepaliveOptions,
   terminalPtyOptions,
 } from '../../../server/src/ssh/connection-manager.js';
@@ -93,8 +94,16 @@ describe('buildChain', () => {
       user: 'deploy',
       port: 2222,
       identityFiles: ['~/.ssh/tunnel_ed25519'],
+      certificateFiles: ['~/.ssh/tunnel_ed25519-cert.pub'],
       identitiesOnly: true,
+      identityAgent: 'none',
       proxyJump: ['bastion'],
+      forwards: [
+        { type: 'local', bindPort: 8080, targetHost: '127.0.0.1', targetPort: 80 },
+      ],
+      remoteCommand: 'tmux new -A -s main',
+      requestTty: 'yes',
+      strictHostKeyChecking: 'accept-new',
     });
 
     expect(chain.map((hop) => hop.resolved.hostname)).toEqual([
@@ -105,10 +114,20 @@ describe('buildChain', () => {
     expect(chain[1]).toMatchObject({ user: 'deploy', port: 2222 });
     expect(chain[1]!.resolved).toMatchObject({
       identitiesOnly: true,
+      identityAgent: 'none',
       proxyJump: ['bastion'],
+      forwards: [
+        { type: 'local', bindPort: 8080, targetHost: '127.0.0.1', targetPort: 80 },
+      ],
+      remoteCommand: 'tmux new -A -s main',
+      requestTty: 'yes',
+      strictHostKeyChecking: 'accept-new',
     });
     expect(chain[1]!.resolved.identityFiles[0]).toMatch(
       /[\\/]\.ssh[\\/]tunnel_ed25519$/,
+    );
+    expect(chain[1]!.resolved.certificateFiles[0]).toMatch(
+      /[\\/]\.ssh[\\/]tunnel_ed25519-cert\.pub$/,
     );
   });
 
@@ -141,6 +160,44 @@ describe('buildChain', () => {
     const jumped = buildChain(doc, { target: 'app', proxyJump: ['bastion'] });
     expect(jumped.map((hop) => hop.spec.host)).toEqual(['bastion', 'app']);
     expect(jumped[1]!.resolved.proxyCommand).toBeUndefined();
+  });
+});
+
+describe('saved SSH profile resolution', () => {
+  it('uses the current database profile instead of stale client fields', () => {
+    const manager = new SshConnectionManager({} as never, {
+      savedSshProfile: (id) =>
+        id === 'saved-1'
+          ? {
+              kind: 'ssh',
+              profileId: id,
+              target: 'current.example.test',
+              useConfig: false,
+              user: 'current-user',
+            }
+          : undefined,
+    });
+
+    expect(
+      manager.resolveProfile({
+        kind: 'ssh',
+        profileId: 'saved-1',
+        target: 'stale.example.test',
+        useConfig: false,
+        user: 'stale-user',
+      }),
+    ).toMatchObject({
+      target: 'current.example.test',
+      user: 'current-user',
+    });
+    expect(() =>
+      manager.resolveProfile({
+        kind: 'ssh',
+        profileId: 'deleted',
+        target: 'stale.example.test',
+        useConfig: false,
+      }),
+    ).toThrow(/not found/);
   });
 });
 

--- a/tests/unit/server/database.test.ts
+++ b/tests/unit/server/database.test.ts
@@ -461,7 +461,45 @@ describe('hybrid OpenSSH metadata', () => {
   });
 });
 
-describe('saved Telnet and serial hosts', () => {
+describe('Muxus-owned saved hosts', () => {
+  it('round-trips a self-contained SSH profile without an OpenSSH alias', () => {
+    database = new MuxusDatabase(':memory:');
+    const created = database.saveSavedHostProfile({
+      id: 'muxus-ssh-router',
+      name: 'Core router',
+      profile: {
+        kind: 'ssh',
+        target: 'router.example.test',
+        useConfig: false,
+        user: 'admin',
+        port: 2222,
+        passwordOnly: true,
+      },
+    });
+
+    expect(created).toMatchObject({
+      id: 'muxus-ssh-router',
+      kind: 'ssh',
+      name: 'Core router',
+      profile: {
+        kind: 'ssh',
+        profileId: 'muxus-ssh-router',
+        target: 'router.example.test',
+        useConfig: false,
+        user: 'admin',
+        port: 2222,
+        passwordOnly: true,
+      },
+    });
+    expect(database.listSavedHostProfiles()).toHaveLength(1);
+    expect(() =>
+      database!.saveSavedHostProfile({
+        name: 'Config-dependent profile',
+        profile: { kind: 'ssh', target: 'router-alias' },
+      }),
+    ).toThrow(/useConfig/);
+  });
+
   it('upserts supplied import IDs without crossing connection-kind ownership', () => {
     database = new MuxusDatabase(':memory:');
     const created = database.saveSavedHostProfile({
@@ -643,6 +681,7 @@ describe('credential and workspace safety', () => {
         },
       }),
     ).not.toThrow();
+    expect(() => assertSecretFree({ passwordOnly: true })).not.toThrow();
     expect(() =>
       database!.createNativeConnection({
         kind: 'ssh',

--- a/tests/unit/server/folder-auth.test.ts
+++ b/tests/unit/server/folder-auth.test.ts
@@ -8,6 +8,7 @@ import {
   folderAuthOptionLines,
   folderAuthResolver,
   mergeFolderAuth,
+  savedProfileFolderAuthResolver,
 } from '../../../server/src/ssh/folder-auth.js';
 import { folderPasswordAccount } from '../../../server/src/security/password-vault.js';
 import { loadConfigDocument, resolveHost } from '../../../server/src/ssh/ssh-config.js';
@@ -189,6 +190,33 @@ describe('buildChain with folder defaults', () => {
     expect(chain[0]!.port).toBe(22);
     expect(chain[0]!.folderPasswords).toBeUndefined();
   });
+
+  it('applies folder defaults to saved Muxus profiles without reading ssh_config', () => {
+    const doc = docOf('Host db.example.test\n  User config-user\n  Port 2200');
+    const chain = buildChain(
+      doc,
+      { target: 'db.example.test', useConfig: false, profileId: 'saved-1' },
+      undefined,
+      () => ({
+        optionLines: folderAuthOptionLines({
+          user: 'folder-user',
+          port: 2222,
+          identityFiles: ['~/.ssh/folder_key'],
+        }),
+        passwords: [{ account: 'acct', label: 'Folder' }],
+      }),
+    );
+
+    expect(chain[0]).toMatchObject({
+      user: 'folder-user',
+      port: 2222,
+      folderPasswords: [{ account: 'acct', label: 'Folder' }],
+    });
+    expect(chain[0]!.resolved.hostname).toBe('db.example.test');
+    expect(chain[0]!.resolved.identityFiles.map((file) => path.basename(file))).toEqual([
+      'folder_key',
+    ]);
+  });
 });
 
 describe('folderAuthResolver', () => {
@@ -219,5 +247,19 @@ describe('folderAuthResolver', () => {
       folderSettingsForPath: () => undefined,
     });
     expect(empty('web')).toBeUndefined();
+  });
+
+  it('resolves the same defaults for a saved profile through its database ID', () => {
+    const savedResolver = savedProfileFolderAuthResolver({
+      groupForAlias: () => undefined,
+      groupForSavedHost: (id) => (id === 'saved-1' ? 'Prod/EU' : undefined),
+      folderSettingsForPath: (path) => settings.get(folderPathKey(path)),
+    });
+
+    const defaults = savedResolver('saved-1');
+    expect(
+      Object.fromEntries(defaults!.optionLines.map((line) => [line.key, line.args[0]])),
+    ).toEqual({ user: 'root', port: '2222' });
+    expect(savedResolver('missing')).toBeUndefined();
   });
 });

--- a/tests/unit/server/profile-routes.test.ts
+++ b/tests/unit/server/profile-routes.test.ts
@@ -24,6 +24,56 @@ afterEach(async () => {
 const auth = () => ({ authorization: `Bearer ${TOKEN}` });
 
 describe('saved host profile routes', () => {
+  it('stores SSH connection settings without creating an ssh_config host', async () => {
+    const create = await app.inject({
+      method: 'PUT',
+      url: '/api/profiles',
+      headers: auth(),
+      payload: {
+        id: 'muxus-ssh-core-router',
+        name: 'Core router',
+        profile: {
+          kind: 'ssh',
+          target: 'router.example.test',
+          useConfig: false,
+          user: 'admin',
+          port: 2222,
+          identityFiles: ['~/.ssh/router'],
+          identitiesOnly: true,
+          proxyJump: ['bastion'],
+        },
+      },
+    });
+
+    expect(create.statusCode).toBe(200);
+    expect(create.json()).toMatchObject({
+      id: 'muxus-ssh-core-router',
+      kind: 'ssh',
+      profile: {
+        kind: 'ssh',
+        target: 'router.example.test',
+        useConfig: false,
+        user: 'admin',
+        port: 2222,
+      },
+    });
+
+    const config = await app.inject({
+      method: 'GET',
+      url: '/api/ssh/config',
+      headers: auth(),
+    });
+    expect(config.statusCode).toBe(200);
+    expect(
+      config
+        .json()
+        .hosts.some(
+          (host: { resolved: { hostname: string } }) =>
+            host.resolved.hostname === 'router.example.test',
+        ),
+    ).toBe(false);
+  });
+
   it('creates and updates an imported profile with a caller-supplied ID', async () => {
     const id = 'securecrt-serial-2p5f9abc';
     const create = await app.inject({

--- a/tests/unit/server/session-recorder.test.ts
+++ b/tests/unit/server/session-recorder.test.ts
@@ -119,6 +119,12 @@ describe('SessionRecorder', () => {
     expect(sessionProfileIdentity({ kind: 'ssh', target: 'edge' }).profileKey)
       .toBe('ssh:edge');
     expect(sessionProfileIdentity({
+      kind: 'ssh',
+      profileId: 'saved-ssh-1',
+      target: 'edge.example.test',
+      useConfig: false,
+    }).profileKey).toBe('profile:saved-ssh-1');
+    expect(sessionProfileIdentity({
       kind: 'telnet',
       profileId: 'saved-1',
       host: 'router',

--- a/tests/unit/server/terminal-socket-dial.test.ts
+++ b/tests/unit/server/terminal-socket-dial.test.ts
@@ -146,6 +146,7 @@ describe('terminal socket dial mode', () => {
     const postAuth = new Promise<void>((resolve) => {
       finishPostAuth = resolve;
     });
+    const resolveProfile = vi.fn((profile: unknown) => profile);
     const release = vi.fn();
     const connect = vi.fn().mockResolvedValue({
       connection: {
@@ -172,7 +173,7 @@ describe('terminal socket dial mode', () => {
       },
     };
     const ctx = {
-      connections: { connect },
+      connections: { connect, resolveProfile },
       database: { recordOpenSshConnection: vi.fn() },
     };
     registerTerminalSocket(app as never, ctx as never);


### PR DESCRIPTION
## Summary

- allow new SSH hosts to be stored in Muxus app data without modifying `ssh_config`
- add the same storage choice to MobaXterm and SecureCRT imports
- integrate database-backed SSH hosts with the sidebar, folders, saved workspaces, SFTP, connection history, logging, and compatibility settings
- include these hosts in Muxus backup/restore and OpenSSH export while continuing to exclude passwords
- resolve saved profile IDs from the database at connection time so edits and deletions take effect safely
- warn before restoring connections containing `ProxyCommand`
- document storage, import/export, and security behavior

## Why

Some SSH sessions should remain local to Muxus instead of becoming global OpenSSH configuration. This adds that option while preserving the existing OpenSSH-backed workflow.

## User impact

The new-host editor and supported import flows now offer either **Muxus app data only** or **OpenSSH config**. Existing OpenSSH hosts continue to behave as before. Muxus-only hosts can still inherit folder credentials, and named ProxyJump hops may resolve through OpenSSH configuration.

## Validation

- `pnpm test` — 884 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
