### PR TITLE
Fix MobaXterm SSH protocol detection

### DIFF
--- a/client/src/mobaxterm-import.ts
+++ b/client/src/mobaxterm-import.ts
@@ -11,9 +11,9 @@ import {
   uniqueImportAlias,
 } from './session-import.js';
 
-const MOBAXTERM_SSH_SESSION_TYPE = 109;
+const MOBAXTERM_SSH_PROTOCOL = 0;
 const BOOKMARK_SECTION_RE = /^Bookmarks(?:_\d+)?$/i;
-const SESSION_TYPE_RE = /^#(\d+)#/;
+const SESSION_HEADER_RE = /^#\d+#(\d+)(?=%)/;
 const NON_SSH_REASON = 'Session type is not SSH (only SSH sessions can be imported)';
 const MISSING_NAME_REASON = 'SSH session has no name';
 const MISSING_HOST_REASON = 'SSH session has no hostname';
@@ -27,8 +27,8 @@ export interface MobaXtermParseResult
 /**
  * Parse SSH bookmarks from MobaXterm.ini or an .mxtsessions export.
  *
- * Session values use `#TYPE#flags%host%port%username%auth%...`; SSH is type
- * 109. This intentionally reads bookmark structure only—no P/C secret stores.
+ * Session values use `#metadata#protocol%host%port%username%auth%...`; SSH uses
+ * protocol 0. This intentionally reads bookmark structure only—no P/C secret stores.
  */
 export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
   if (new TextEncoder().encode(text).byteLength > MAX_MOBAXTERM_IMPORT_BYTES) {
@@ -72,15 +72,15 @@ export function parseMobaXtermSessions(text: string): MobaXtermParseResult {
       continue;
     }
 
-    const typeMatch = SESSION_TYPE_RE.exec(value);
-    if (!typeMatch) continue;
-    const type = Number.parseInt(typeMatch[1] ?? '', 10);
-    if (type !== MOBAXTERM_SSH_SESSION_TYPE) {
+    const headerMatch = SESSION_HEADER_RE.exec(value);
+    if (!headerMatch) continue;
+    const protocol = Number.parseInt(headerMatch[1] ?? '', 10);
+    if (protocol !== MOBAXTERM_SSH_PROTOCOL) {
       skip(lineIndex, name, undefined, NON_SSH_REASON);
       continue;
     }
 
-    const fields = value.slice(typeMatch[0].length).split('%');
+    const fields = value.slice(headerMatch[0].length).split('%');
     const host = fields[1]?.trim();
     if (!name) {
       skip(lineIndex, name, host, MISSING_NAME_REASON);

--- a/tests/unit/client/mobaxterm-import.test.ts
+++ b/tests/unit/client/mobaxterm-import.test.ts
@@ -63,11 +63,32 @@ My host!=#109#0%two.example.com%22%%%rest
     ]);
   });
 
+  it('uses the protocol field instead of the leading metadata identifier', () => {
+    const parsed = parseMobaXtermSessions(`
+[Bookmarks]
+SubRep=
+Custom icon SSH=#114#0%airframe.example.com%2222%root%%rest
+`);
+
+    expect(parsed.sessions).toEqual([
+      {
+        id: expect.any(String),
+        kind: 'ssh',
+        name: 'Custom icon SSH',
+        alias: 'Custom-icon-SSH',
+        host: 'airframe.example.com',
+        port: 2222,
+        username: 'root',
+        authMode: 'password',
+      },
+    ]);
+  });
+
   it('counts unsupported and malformed bookmark entries', () => {
     const parsed = parseMobaXtermSessions(`
 [Bookmarks]
-RDP=#91#0%desktop.example.com
-VNC=#5#0%desktop.example.com
+RDP=#91#4%desktop.example.com
+VNC=#5#5%desktop.example.com
 Broken SSH=#109#0%%22%root%%
 Valid=#109#0%valid.example.com%22%root%%
 `);
@@ -98,7 +119,7 @@ Valid=#109#0%valid.example.com%22%root%%
       parseMobaXtermSessions(`
 [Bookmarks]
 SubRep=
-RDP=#91#0%desktop.example.com
+RDP=#91#4%desktop.example.com
 `),
     ).toThrow('No SSH sessions were found');
   });


### PR DESCRIPTION
## Summary

- detect the MobaXterm session protocol from the second header field
- import SSH sessions whose leading metadata identifier differs from the default
- use realistic protocol values in unsupported-session fixtures
- add regression coverage for `#114#0` SSH sessions

## Root cause

The importer treated the first numeric field in a MobaXterm bookmark header as the session type. That field can vary between otherwise equivalent SSH sessions. The actual protocol is the second numeric field, where `0` represents SSH.

## Impact

MobaXterm SSH bookmarks such as `#114#0` are now imported instead of being incorrectly reported as non-SSH. Serial, WSL, RDP, VNC, and Telnet sessions remain excluded.

## Validation

- focused MobaXterm importer tests: 7 passed
- full test suite: 887 passed, 3 skipped
- client and test TypeScript checks
- lint and diff checks