### PR TITLE
Bump version to v0.6.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "packageManager": "pnpm@11.17.0",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -27,9 +27,9 @@ describe('app routes', () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          version: 'v0.6.0',
-          releaseName: 'Muxus 0.6',
-          releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.6.0',
+          version: 'v0.7.0',
+          releaseName: 'Muxus 0.7',
+          releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.7.0',
           publishedAt: '2026-07-26T08:00:00Z',
         }),
         { status: 200, headers: { 'content-type': 'application/json' } },
@@ -46,17 +46,17 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.5.1',
-      latestVersion: '0.6.0',
-      releaseName: 'Muxus 0.6',
-      releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.6.0',
+      currentVersion: '0.6.0',
+      latestVersion: '0.7.0',
+      releaseName: 'Muxus 0.7',
+      releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.7.0',
       publishedAt: '2026-07-26T08:00:00Z',
     });
     expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.5.1' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.6.0' },
     });
   });
 
@@ -66,8 +66,8 @@ describe('app routes', () => {
       vi.fn().mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            version: '0.6.0',
-            releaseUrl: 'https://attacker.example/FloSch62/muxus/releases/tag/v0.6.0',
+            version: '0.7.0',
+            releaseUrl: 'https://attacker.example/FloSch62/muxus/releases/tag/v0.7.0',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         ),
@@ -83,8 +83,8 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.5.1',
-      latestVersion: '0.6.0',
+      currentVersion: '0.6.0',
+      latestVersion: '0.7.0',
       reason: 'missing-release-url',
     });
   });


### PR DESCRIPTION
## Summary

- bump the root and workspace package versions from 0.5.1 to 0.6.0
- advance update-check fixtures to 0.7.0 so they continue exercising a newer release

## Impact

Prepares the application and workspace packages for the v0.6.0 release while preserving update-check coverage.

## Validation

- `pnpm --filter @muxus/tests test -- unit/server/app-routes.test.ts` (104 test files passed, 1 skipped; 887 tests passed, 3 skipped)
- `git diff --check`