### PR TITLE
Fix terminal file link activation

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -65,6 +65,7 @@ import {
   interfaceZoomLabel,
 } from '../interface-zoom.js';
 import { useChordLabel } from '../keymap/hints.js';
+import { IS_MAC } from '../platform.js';
 import {
   MAX_INACTIVE_PANE_DIM_STRENGTH,
   MIN_INACTIVE_PANE_DIM_STRENGTH,
@@ -73,6 +74,7 @@ import {
   usePrefsStore,
   type RightClickAction,
   type TabNumberVisibility,
+  type TerminalFileLinkActivation,
   type ThemeMode,
 } from '../state/prefs.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
@@ -80,6 +82,10 @@ import { showErrorToast, showToast } from '../state/toast.js';
 import { confirmAction } from '../state/dialogs.js';
 import { useUiStore } from '../state/ui.js';
 import { TERMINAL_SCHEMES, terminalScheme, type TerminalScheme } from '../terminal/palette.js';
+import {
+  terminalFileLinkActivationForPlatform,
+  terminalFileLinkActivationOptions,
+} from '../terminal/file-link-activation.js';
 import {
   readInstalledTerminalFontFamilies,
   terminalFontFamilies,
@@ -127,6 +133,7 @@ const TERMINAL_SCHEME_GROUPS = [
 ] as const;
 
 const SCHEME_SWATCH_COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'] as const;
+const TERMINAL_FILE_LINK_ACTIVATION_OPTIONS = terminalFileLinkActivationOptions(IS_MAC);
 
 /**
  * All preferences, applied live — including already-open terminals. The one
@@ -647,6 +654,26 @@ function TerminalSection() {
             <MenuItem value="copy-paste">Copy selection, otherwise paste (terminal convention)</MenuItem>
             <MenuItem value="paste">Always paste</MenuItem>
             <MenuItem value="menu">Show context menu</MenuItem>
+          </TextField>
+          <TextField
+            select
+            label="Open terminal file links"
+            value={terminalFileLinkActivationForPlatform(
+              prefs.terminalFileLinkActivation,
+              IS_MAC,
+            )}
+            onChange={(e) =>
+              prefs.set({
+                terminalFileLinkActivation: e.target.value as TerminalFileLinkActivation,
+              })
+            }
+            sx={{ maxWidth: 420 }}
+          >
+            {TERMINAL_FILE_LINK_ACTIVATION_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
           </TextField>
           <FormControlLabel
             control={<Switch size="small" checked={prefs.copyOnSelect} onChange={(e) => prefs.set({ copyOnSelect: e.target.checked })} />}

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -69,6 +69,7 @@ import {
   attachTerminalFileLinks,
   resolveTerminalFilePath,
 } from '../terminal/file-links.js';
+import { terminalFileLinkActivationForPlatform } from '../terminal/file-link-activation.js';
 import { openTerminalWebLink } from '../terminal/web-links.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
@@ -661,7 +662,15 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         : undefined;
     const fileLinks =
       tab.profile.kind === 'ssh' || tab.profile.kind === 'local'
-        ? attachTerminalFileLinks(term, (candidate) => openLinkedTerminalFile(tab.id, candidate))
+        ? attachTerminalFileLinks(
+            term,
+            (candidate) => openLinkedTerminalFile(tab.id, candidate),
+            () =>
+              terminalFileLinkActivationForPlatform(
+                usePrefsStore.getState().terminalFileLinkActivation,
+                IS_MAC,
+              ),
+          )
         : undefined;
 
     // Application chords never reach xterm: the shortcut layer consumes them

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -69,7 +69,10 @@ import {
   attachTerminalFileLinks,
   resolveTerminalFilePath,
 } from '../terminal/file-links.js';
-import { terminalFileLinkActivationForPlatform } from '../terminal/file-link-activation.js';
+import {
+  altClickMovesCursorForFileLinkActivation,
+  terminalFileLinkActivationForPlatform,
+} from '../terminal/file-link-activation.js';
 import { openTerminalWebLink } from '../terminal/web-links.js';
 import { requiresPasteConfirmation } from '../terminal/paste-safety.js';
 import { shouldFitTerminal } from '../terminal/terminal-fit.js';
@@ -433,6 +436,10 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       cursorBlink: prefs.cursorBlink,
       cursorStyle: prefs.cursorStyle,
       scrollback: prefs.scrollback,
+      altClickMovesCursor: altClickMovesCursorForFileLinkActivation(
+        prefs.terminalFileLinkActivation,
+        IS_MAC,
+      ),
       // ED2 pushes the screen into scrollback instead of blanking it, so a
       // shell that clears on login cannot destroy freshly restored history.
       scrollOnEraseInDisplay: true,
@@ -771,7 +778,13 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
           unloadQueuedRevision !== snapshotRevision,
       },
     );
-    const unsubscribeReconnectPreference = usePrefsStore.subscribe((state, previous) => {
+    const unsubscribePreferences = usePrefsStore.subscribe((state, previous) => {
+      if (state.terminalFileLinkActivation !== previous.terminalFileLinkActivation) {
+        term.options.altClickMovesCursor = altClickMovesCursorForFileLinkActivation(
+          state.terminalFileLinkActivation,
+          IS_MAC,
+        );
+      }
       if (
         previous.autoReconnectRemote &&
         !state.autoReconnectRemote &&
@@ -1194,7 +1207,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       clearInterval(snapshotTimer);
       if (quietSnapshotTimer !== undefined) clearTimeout(quietSnapshotTimer);
       unregisterUnloadFlush();
-      unsubscribeReconnectPreference();
+      unsubscribePreferences();
       // The buffer outlives this socket generation: a reconnect replays it in
       // place, and the stored copy keeps the tail output a restart would lose.
       if (usePrefsStore.getState().restoreScrollback) {

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -30,6 +30,7 @@ import {
   MAX_INACTIVE_PANE_DIM_STRENGTH,
   MIN_INACTIVE_PANE_DIM_STRENGTH,
   isLocalShellProfileArray,
+  isTerminalFileLinkActivation,
   usePrefsStore,
   type FolderStyle,
   type PrefsState,
@@ -64,6 +65,7 @@ const PREFERENCE_KEYS = [
   'copyOnSelect',
   'allowOsc52ClipboardWrite',
   'rightClickAction',
+  'terminalFileLinkActivation',
   'pasteWarnMultiline',
   'confirmCloseConnected',
   'notifyOnNewVersion',
@@ -818,6 +820,9 @@ export function sanitizePreferences(
   }
   if (['copy-paste', 'paste', 'menu'].includes(input.rightClickAction)) {
     output.rightClickAction = input.rightClickAction;
+  }
+  if (isTerminalFileLinkActivation(input.terminalFileLinkActivation)) {
+    output.terminalFileLinkActivation = input.terminalFileLinkActivation;
   }
   if (typeof input.pasteWarnMultiline === 'boolean') {
     output.pasteWarnMultiline = input.pasteWarnMultiline;

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -9,6 +9,7 @@ import type { KeywordHighlightProfile, KeywordHighlightRule } from '@muxus/share
 export type ThemeMode = 'light' | 'dark' | 'os';
 export type EffectiveThemeMode = Exclude<ThemeMode, 'os'>;
 export type RightClickAction = 'copy-paste' | 'paste' | 'menu';
+export type TerminalFileLinkActivation = 'direct' | 'alt' | 'ctrl' | 'meta';
 export type TabNumberVisibility = 'shortcut' | 'always';
 
 export const DEFAULT_INACTIVE_PANE_DIM_STRENGTH = 0.15;
@@ -105,6 +106,8 @@ export interface PrefsState {
   allowOsc52ClipboardWrite: boolean;
   /** Right-click: copy selection / paste (terminal convention), always paste, or context menu. */
   rightClickAction: RightClickAction;
+  /** Mouse gesture that opens a detected terminal file path in the editor. */
+  terminalFileLinkActivation: TerminalFileLinkActivation;
   /** Preview multiline pastes before they can run several shell commands. */
   pasteWarnMultiline: boolean;
   /** Ask before closing a tab with a live session. */
@@ -172,6 +175,12 @@ function isTabNumberVisibility(value: unknown): value is TabNumberVisibility {
   return value === 'shortcut' || value === 'always';
 }
 
+export function isTerminalFileLinkActivation(
+  value: unknown,
+): value is TerminalFileLinkActivation {
+  return value === 'direct' || value === 'alt' || value === 'ctrl' || value === 'meta';
+}
+
 export function terminalSchemeIdForMode(
   prefs: Pick<PrefsState, 'lightTerminalScheme' | 'darkTerminalScheme'>,
   mode: EffectiveThemeMode,
@@ -189,6 +198,9 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
   // A missing or invalid value falls through to the store's System default.
   if (!isThemeMode(state.themeMode)) delete state.themeMode;
   if (!isTabNumberVisibility(state.tabNumberVisibility)) delete state.tabNumberVisibility;
+  if (!isTerminalFileLinkActivation(state.terminalFileLinkActivation)) {
+    delete state.terminalFileLinkActivation;
+  }
   if (typeof state.activePaneBorder !== 'boolean') delete state.activePaneBorder;
   if (typeof state.dimInactivePanes !== 'boolean') delete state.dimInactivePanes;
   if (
@@ -326,6 +338,7 @@ export const usePrefsStore = create<PrefsState>()(
       copyOnSelect: false,
       allowOsc52ClipboardWrite: true,
       rightClickAction: 'copy-paste',
+      terminalFileLinkActivation: 'alt',
       pasteWarnMultiline: true,
       confirmCloseConnected: true,
       autoReconnectRemote: true,
@@ -354,7 +367,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 12,
+      version: 13,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/client/src/terminal/file-link-activation.ts
+++ b/client/src/terminal/file-link-activation.ts
@@ -1,0 +1,34 @@
+import type { TerminalFileLinkActivation } from '../state/prefs.js';
+
+export interface TerminalFileLinkActivationOption {
+  value: TerminalFileLinkActivation;
+  label: string;
+}
+
+const NON_MAC_OPTIONS: readonly TerminalFileLinkActivationOption[] = [
+  { value: 'alt', label: 'Alt + left click' },
+  { value: 'ctrl', label: 'Ctrl + left click' },
+  { value: 'direct', label: 'Direct left click' },
+];
+
+const MAC_OPTIONS: readonly TerminalFileLinkActivationOption[] = [
+  { value: 'alt', label: 'Option + left click' },
+  { value: 'ctrl', label: 'Control + left click' },
+  { value: 'meta', label: 'Cmd + left click' },
+  { value: 'direct', label: 'Direct left click' },
+];
+
+/** Mouse gestures that can actually be produced on the current platform. */
+export function terminalFileLinkActivationOptions(
+  isMac: boolean,
+): readonly TerminalFileLinkActivationOption[] {
+  return isMac ? MAC_OPTIONS : NON_MAC_OPTIONS;
+}
+
+/** Gracefully handle a Cmd preference restored from a macOS backup elsewhere. */
+export function terminalFileLinkActivationForPlatform(
+  activation: TerminalFileLinkActivation,
+  isMac: boolean,
+): TerminalFileLinkActivation {
+  return activation === 'meta' && !isMac ? 'alt' : activation;
+}

--- a/client/src/terminal/file-link-activation.ts
+++ b/client/src/terminal/file-link-activation.ts
@@ -13,7 +13,6 @@ const NON_MAC_OPTIONS: readonly TerminalFileLinkActivationOption[] = [
 
 const MAC_OPTIONS: readonly TerminalFileLinkActivationOption[] = [
   { value: 'alt', label: 'Option + left click' },
-  { value: 'ctrl', label: 'Control + left click' },
   { value: 'meta', label: 'Cmd + left click' },
   { value: 'direct', label: 'Direct left click' },
 ];
@@ -25,10 +24,20 @@ export function terminalFileLinkActivationOptions(
   return isMac ? MAC_OPTIONS : NON_MAC_OPTIONS;
 }
 
-/** Gracefully handle a Cmd preference restored from a macOS backup elsewhere. */
+/** Map a cross-platform backup to a gesture that is safe on this platform. */
 export function terminalFileLinkActivationForPlatform(
   activation: TerminalFileLinkActivation,
   isMac: boolean,
 ): TerminalFileLinkActivation {
-  return activation === 'meta' && !isMac ? 'alt' : activation;
+  if (activation === 'meta' && !isMac) return 'alt';
+  if (activation === 'ctrl' && isMac) return 'meta';
+  return activation;
+}
+
+/** Keep xterm's Alt cursor movement from competing with an Alt file-open gesture. */
+export function altClickMovesCursorForFileLinkActivation(
+  activation: TerminalFileLinkActivation,
+  isMac: boolean,
+): boolean {
+  return terminalFileLinkActivationForPlatform(activation, isMac) !== 'alt';
 }

--- a/client/src/terminal/file-links.ts
+++ b/client/src/terminal/file-links.ts
@@ -1,4 +1,5 @@
 import type { IDisposable, ILink, Terminal } from '@xterm/xterm';
+import type { TerminalFileLinkActivation } from '../state/prefs.js';
 
 const MAX_LOGICAL_LINE_LENGTH = 4_096;
 const SHELL_TOKEN_BOUNDARY = /\s/;
@@ -389,10 +390,22 @@ function mappedFileLinks(term: Terminal, bufferLineNumber: number): MappedTermin
   return links;
 }
 
-/** Register ordinary hover-and-click file links while leaving other terminal text untouched. */
+function activationMatches(
+  event: MouseEvent,
+  activation: TerminalFileLinkActivation,
+): boolean {
+  if (event.shiftKey) return false;
+  if (activation === 'direct') return !event.altKey && !event.ctrlKey && !event.metaKey;
+  if (activation === 'alt') return event.altKey && !event.ctrlKey && !event.metaKey;
+  if (activation === 'ctrl') return event.ctrlKey && !event.altKey && !event.metaKey;
+  return event.metaKey && !event.altKey && !event.ctrlKey;
+}
+
+/** Register file links while leaving non-activating clicks available for terminal selection. */
 export function attachTerminalFileLinks(
   term: Terminal,
   onOpen: (candidate: string) => void | Promise<void>,
+  activation: TerminalFileLinkActivation | (() => TerminalFileLinkActivation) = 'direct',
 ): IDisposable {
   return term.registerLinkProvider({
     provideLinks: (bufferLineNumber, callback) => {
@@ -404,9 +417,15 @@ export function attachTerminalFileLinks(
           // them on leave, matching a normal browser-link affordance.
           decorations: { pointerCursor: true, underline: true },
           activate: (event) => {
-            if (event.button !== 0) return;
+            const currentActivation =
+              typeof activation === 'function' ? activation() : activation;
+            if (event.button !== 0 || !activationMatches(event, currentActivation)) return;
             event.preventDefault();
             event.stopPropagation();
+            // A tiny pointer movement can create a selection before xterm
+            // delivers the mouse-up activation. Do not leave it behind the
+            // editor after a deliberate file-open gesture.
+            term.clearSelection();
             void onOpen(candidate.path);
           },
         };

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -4,11 +4,12 @@ icon: lucide/file-pen
 
 # File editor
 
-Click an underlined file path in a local or SSH terminal to open it in
+Alt + left-click an underlined file path in a local or SSH terminal to open it in
 [Monaco](https://microsoft.github.io/monaco-editor/), the editor used by VS Code. Files in
 SSH sessions use that session's live SFTP transport; files in local terminals are read and
-saved directly on the machine running Muxus. Double-clicking a file in the
-[file browser](files.md) opens the same editor.
+saved directly on the machine running Muxus. The modifier can be changed to Ctrl, Cmd on
+macOS, or a direct click in **Settings → Terminal → Open terminal file links**.
+Double-clicking a file in the [file browser](files.md) opens the same editor.
 
 <figure markdown="span">
   ![Editing a remote file with Monaco](../assets/screenshots/remote-editor.png#only-light){ .shadow }

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -7,8 +7,9 @@ icon: lucide/file-pen
 Alt + left-click an underlined file path in a local or SSH terminal to open it in
 [Monaco](https://microsoft.github.io/monaco-editor/), the editor used by VS Code. Files in
 SSH sessions use that session's live SFTP transport; files in local terminals are read and
-saved directly on the machine running Muxus. The modifier can be changed to Ctrl, Cmd on
-macOS, or a direct click in **Settings → Terminal → Open terminal file links**.
+saved directly on the machine running Muxus. The modifier can be changed to Ctrl on Linux
+and Windows, Cmd on macOS, or a direct click in
+**Settings → Terminal → Open terminal file links**.
 Double-clicking a file in the [file browser](files.md) opens the same editor.
 
 <figure markdown="span">

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -41,6 +41,9 @@ because storage policy should not change under a running recorder.
 - **Cursor**: block, underline or bar, blinking or not.
 - **Right-click**: copy-selection-otherwise-paste (the terminal convention), always paste,
   or a context menu.
+- **Open terminal file links**: choose Alt or Ctrl + left click, Cmd + left click on macOS,
+  or restore direct left-click opening. Alt + left click is the default so ordinary clicks
+  and double-clicks remain available for terminal text selection.
 - **Copy on select**, **OSC 52 clipboard writes** from terminal programs such as tmux and
   Zellij, and the **multiline paste confirmation**. OSC 52 reads remain blocked so a
   terminal program cannot retrieve the local clipboard.

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -41,8 +41,8 @@ because storage policy should not change under a running recorder.
 - **Cursor**: block, underline or bar, blinking or not.
 - **Right-click**: copy-selection-otherwise-paste (the terminal convention), always paste,
   or a context menu.
-- **Open terminal file links**: choose Alt or Ctrl + left click, Cmd + left click on macOS,
-  or restore direct left-click opening. Alt + left click is the default so ordinary clicks
+- **Open terminal file links**: choose Alt or direct left click on every platform, plus Ctrl
+  on Linux and Windows or Cmd on macOS. Alt + left click is the default so ordinary clicks
   and double-clicks remain available for terminal text selection.
 - **Copy on select**, **OSC 52 clipboard writes** from terminal programs such as tmux and
   Zellij, and the **multiline paste confirmation**. OSC 52 reads remain blocked so a

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
     activePaneBorder: false,
     dimInactivePanes: false,
     inactivePaneDimStrength: 0.15,
+    terminalFileLinkActivation: 'alt',
     localShellProfiles: [],
     defaultLocalShellProfileId: '',
     keywordHighlightProfiles: [],
@@ -230,6 +231,7 @@ describe('backing up preferences', () => {
       activePaneBorder: false,
       dimInactivePanes: true,
       inactivePaneDimStrength: 0.35,
+      terminalFileLinkActivation: 'ctrl',
     });
     mockBackupSnapshot();
 
@@ -243,6 +245,7 @@ describe('backing up preferences', () => {
     expect(document.data.preferences.activePaneBorder).toBe(false);
     expect(document.data.preferences.dimInactivePanes).toBe(true);
     expect(document.data.preferences.inactivePaneDimStrength).toBe(0.35);
+    expect(document.data.preferences.terminalFileLinkActivation).toBe('ctrl');
   });
 
   it('includes saved local shell profiles and their default selection', async () => {
@@ -287,6 +290,23 @@ describe('backing up preferences', () => {
     const document = await createBackupDocument();
 
     expect(document.data.preferences.keywordHighlightProfiles).toEqual([profile]);
+  });
+});
+
+describe('restoring terminal file link activation preferences', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it.each(['direct', 'alt', 'ctrl', 'meta'] as const)('restores %s activation', (value) => {
+    expect(sanitizePreferences(prefs({ terminalFileLinkActivation: value }))).toMatchObject({
+      terminalFileLinkActivation: value,
+    });
+  });
+
+  it('drops malformed activation settings', () => {
+    expect(
+      sanitizePreferences(prefs({ terminalFileLinkActivation: 'double-click' }))
+        .terminalFileLinkActivation,
+    ).toBeUndefined();
   });
 });
 

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -47,6 +47,27 @@ describe('appearance preference', () => {
   });
 });
 
+describe('terminal file link activation preference', () => {
+  it('defaults to Alt + left click so normal terminal selection remains available', () => {
+    expect(usePrefsStore.getInitialState().terminalFileLinkActivation).toBe('alt');
+  });
+
+  it.each(['direct', 'alt', 'ctrl', 'meta'] as const)(
+    'keeps the valid %s activation setting during migration',
+    (terminalFileLinkActivation) => {
+      expect(migratePrefsState({ terminalFileLinkActivation }, 12)).toEqual({
+        terminalFileLinkActivation,
+      });
+    },
+  );
+
+  it('drops malformed persisted activation settings', () => {
+    expect(
+      migratePrefsState({ terminalFileLinkActivation: 'double-click', monoFontSize: 16 }, 12),
+    ).toEqual({ monoFontSize: 16 });
+  });
+});
+
 describe('split pane focus preferences', () => {
   it('leaves both indicators off by default with dimming set to 15%', () => {
     const initial = usePrefsStore.getInitialState();

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -4,6 +4,10 @@ import {
   resolveTerminalFilePath,
   terminalFileLinkCandidates,
 } from '../../../client/src/terminal/file-links.js';
+import {
+  terminalFileLinkActivationForPlatform,
+  terminalFileLinkActivationOptions,
+} from '../../../client/src/terminal/file-link-activation.js';
 import { openTerminalWebLink } from '../../../client/src/terminal/web-links.js';
 
 afterEach(() => vi.unstubAllGlobals());
@@ -24,6 +28,7 @@ interface StubLinkProvider {
 function terminalWithLine(text: string, spareCells = 1): {
   terminal: Parameters<typeof attachTerminalFileLinks>[0];
   provider: () => StubLinkProvider;
+  clearSelection: ReturnType<typeof vi.fn>;
 } {
   const cell = {
     chars: '',
@@ -44,6 +49,7 @@ function terminalWithLine(text: string, spareCells = 1): {
     },
   };
   let registered: StubLinkProvider | undefined;
+  const clearSelection = vi.fn();
   const terminal = {
     buffer: {
       active: {
@@ -55,9 +61,11 @@ function terminalWithLine(text: string, spareCells = 1): {
       registered = provider;
       return { dispose: () => undefined };
     },
+    clearSelection,
   } as unknown as Parameters<typeof attachTerminalFileLinks>[0];
   return {
     terminal,
+    clearSelection,
     provider: () => {
       if (!registered) throw new Error('link provider was not registered');
       return registered;
@@ -65,7 +73,52 @@ function terminalWithLine(text: string, spareCells = 1): {
   };
 }
 
+function mouseEvent(
+  modifiers: Partial<Pick<MouseEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>> = {},
+  button = 0,
+): {
+  event: MouseEvent;
+  preventDefault: ReturnType<typeof vi.fn>;
+  stopPropagation: ReturnType<typeof vi.fn>;
+} {
+  const preventDefault = vi.fn();
+  const stopPropagation = vi.fn();
+  return {
+    event: {
+      button,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      preventDefault,
+      stopPropagation,
+      ...modifiers,
+    } as unknown as MouseEvent,
+    preventDefault,
+    stopPropagation,
+  };
+}
+
 describe('terminal file links', () => {
+  it('only offers Cmd activation on macOS', () => {
+    expect(terminalFileLinkActivationOptions(false).map((option) => option.value)).toEqual([
+      'alt',
+      'ctrl',
+      'direct',
+    ]);
+    expect(terminalFileLinkActivationOptions(true).map((option) => option.value)).toEqual([
+      'alt',
+      'ctrl',
+      'meta',
+      'direct',
+    ]);
+  });
+
+  it('falls back to Alt when a Cmd preference is restored on a non-Mac platform', () => {
+    expect(terminalFileLinkActivationForPlatform('meta', false)).toBe('alt');
+    expect(terminalFileLinkActivationForPlatform('meta', true)).toBe('meta');
+  });
+
   it('finds absolute, relative, dotfile, and conventional file paths', () => {
     expect(
       terminalFileLinkCandidates(
@@ -161,10 +214,9 @@ describe('terminal file links', () => {
     ).toEqual(['lic.txt']);
   });
 
-  it('underlines a detected path on hover and opens it with a plain left-click', () => {
+  it('underlines a detected path on hover and maps its terminal range', () => {
     const { terminal, provider } = terminalWithLine('output: src/main.ts');
-    const onOpen = vi.fn();
-    attachTerminalFileLinks(terminal, onOpen);
+    attachTerminalFileLinks(terminal, vi.fn());
     let links: ProvidedLink[] | undefined;
     provider().provideLinks(1, (provided) => {
       links = provided;
@@ -175,24 +227,65 @@ describe('terminal file links', () => {
       end: { x: 19, y: 1 },
     });
 
-    const preventDefault = vi.fn();
-    const stopPropagation = vi.fn();
-    links![0]!.activate(
-      { button: 2, altKey: true, preventDefault, stopPropagation } as unknown as MouseEvent,
-      'src/main.ts',
-    );
+    expect(links![0]!.decorations).toEqual({ pointerCursor: true, underline: true });
+  });
+
+  it.each([
+    ['direct', {}, { altKey: true }],
+    ['alt', { altKey: true }, {}],
+    ['ctrl', { ctrlKey: true }, {}],
+    ['meta', { metaKey: true }, {}],
+  ] as const)(
+    'opens a link only for the configured %s activation gesture',
+    (activation, matchingModifiers, nonMatchingModifiers) => {
+      const { terminal, provider, clearSelection } = terminalWithLine('output: src/main.ts');
+      const onOpen = vi.fn();
+      attachTerminalFileLinks(terminal, onOpen, activation);
+      let links: ProvidedLink[] | undefined;
+      provider().provideLinks(1, (provided) => {
+        links = provided;
+      });
+
+      const wrongButton = mouseEvent(matchingModifiers, 2);
+      links![0]!.activate(wrongButton.event, 'src/main.ts');
+      expect(onOpen).not.toHaveBeenCalled();
+
+      const ignored = mouseEvent(nonMatchingModifiers);
+      links![0]!.activate(ignored.event, 'src/main.ts');
+      expect(onOpen).not.toHaveBeenCalled();
+      expect(ignored.preventDefault).not.toHaveBeenCalled();
+      expect(ignored.stopPropagation).not.toHaveBeenCalled();
+
+      const selectionGesture = mouseEvent({ ...matchingModifiers, shiftKey: true });
+      links![0]!.activate(selectionGesture.event, 'src/main.ts');
+      expect(onOpen).not.toHaveBeenCalled();
+
+      const matching = mouseEvent(matchingModifiers);
+      links![0]!.activate(matching.event, 'src/main.ts');
+      expect(onOpen).toHaveBeenCalledOnce();
+      expect(onOpen).toHaveBeenCalledWith('src/main.ts');
+      expect(matching.preventDefault).toHaveBeenCalledOnce();
+      expect(matching.stopPropagation).toHaveBeenCalledOnce();
+      expect(clearSelection).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('reads the activation setting when clicked so open terminals update immediately', () => {
+    const { terminal, provider } = terminalWithLine('output: src/main.ts');
+    const onOpen = vi.fn();
+    let activation: 'alt' | 'ctrl' = 'alt';
+    attachTerminalFileLinks(terminal, onOpen, () => activation);
+    let links: ProvidedLink[] | undefined;
+    provider().provideLinks(1, (provided) => {
+      links = provided;
+    });
+
+    links![0]!.activate(mouseEvent({ ctrlKey: true }).event, 'src/main.ts');
     expect(onOpen).not.toHaveBeenCalled();
 
-    expect(links![0]!.decorations).toEqual({ pointerCursor: true, underline: true });
-
-    links![0]!.activate(
-      { button: 0, altKey: false, preventDefault, stopPropagation } as unknown as MouseEvent,
-      'src/main.ts',
-    );
-    expect(onOpen).toHaveBeenCalledOnce();
+    activation = 'ctrl';
+    links![0]!.activate(mouseEvent({ ctrlKey: true }).event, 'src/main.ts');
     expect(onOpen).toHaveBeenCalledWith('src/main.ts');
-    expect(preventDefault).toHaveBeenCalledOnce();
-    expect(stopPropagation).toHaveBeenCalledOnce();
   });
 
   it('keeps a link ending in the terminal last column on the current row', () => {

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -5,6 +5,7 @@ import {
   terminalFileLinkCandidates,
 } from '../../../client/src/terminal/file-links.js';
 import {
+  altClickMovesCursorForFileLinkActivation,
   terminalFileLinkActivationForPlatform,
   terminalFileLinkActivationOptions,
 } from '../../../client/src/terminal/file-link-activation.js';
@@ -108,15 +109,23 @@ describe('terminal file links', () => {
     ]);
     expect(terminalFileLinkActivationOptions(true).map((option) => option.value)).toEqual([
       'alt',
-      'ctrl',
       'meta',
       'direct',
     ]);
   });
 
-  it('falls back to Alt when a Cmd preference is restored on a non-Mac platform', () => {
+  it('maps cross-platform modifier preferences to safe native gestures', () => {
     expect(terminalFileLinkActivationForPlatform('meta', false)).toBe('alt');
     expect(terminalFileLinkActivationForPlatform('meta', true)).toBe('meta');
+    expect(terminalFileLinkActivationForPlatform('ctrl', true)).toBe('meta');
+    expect(terminalFileLinkActivationForPlatform('ctrl', false)).toBe('ctrl');
+  });
+
+  it('disables xterm cursor movement only while Alt opens file links', () => {
+    expect(altClickMovesCursorForFileLinkActivation('alt', false)).toBe(false);
+    expect(altClickMovesCursorForFileLinkActivation('ctrl', false)).toBe(true);
+    expect(altClickMovesCursorForFileLinkActivation('meta', true)).toBe(true);
+    expect(altClickMovesCursorForFileLinkActivation('direct', false)).toBe(true);
   });
 
   it('finds absolute, relative, dotfile, and conventional file paths', () => {


### PR DESCRIPTION
## Summary

- add a Terminal setting for opening detected file links with Alt, Ctrl, Cmd on macOS, or a direct click
- default to Alt + click so normal clicks and double-clicks remain available for terminal text selection
- apply platform-aware choices and safely handle a Cmd preference restored on Linux or Windows
- clear transient terminal selection before opening the editor
- include the preference in persistence, backup/restore, and documentation

## Root cause

The terminal link provider activated every primary click. That made xterm's normal double-click path selection unusable and could leave a small drag selection behind after the editor opened, triggering Copy on Select.

## Impact

Terminal paths now open only with the configured gesture. The setting applies immediately to existing terminals, and non-activating clicks remain untouched for selection and copying.

Closes #116.

## Validation

- `pnpm test` — 905 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build-docs`