### PR TITLE
Fix Windows local terminal file links

### DIFF
--- a/client/src/terminal/shell-integration.ts
+++ b/client/src/terminal/shell-integration.ts
@@ -45,8 +45,16 @@ function decodePropertyValue(value: string): string | undefined {
   return decoded;
 }
 
+function windowsTerminalCwd(value: string | undefined): value is string {
+  return !!value && /^(?:[a-z]:[\\/]|\\\\[^\\/]+[\\/][^\\/]+)/i.test(value);
+}
+
 function validTerminalCwd(value: string | undefined): value is string {
-  return !!value && value.startsWith('/') && value.length <= MAX_TERMINAL_CWD_LENGTH;
+  return (
+    !!value &&
+    (value.startsWith('/') || windowsTerminalCwd(value)) &&
+    value.length <= MAX_TERMINAL_CWD_LENGTH
+  );
 }
 
 /** Reads current-directory reports from shell integration and standard OSC 7. */
@@ -57,7 +65,11 @@ export class CwdTracker {
 
   handleProperty(data: string): boolean {
     if (!data.startsWith(CWD_PROPERTY_PREFIX)) return false;
-    this.report(decodePropertyValue(data.slice(CWD_PROPERTY_PREFIX.length)));
+    const value = data.slice(CWD_PROPERTY_PREFIX.length);
+    // cmd.exe's $P prompt token supplies a native path but cannot escape its
+    // backslashes according to the OSC 133 property convention. It is still
+    // unambiguous at the drive-letter/UNC root, so preserve it as reported.
+    this.report(windowsTerminalCwd(value) ? value : decodePropertyValue(value));
     return true;
   }
 
@@ -65,7 +77,9 @@ export class CwdTracker {
     try {
       const uri = new URL(data);
       if (uri.protocol !== 'file:') return false;
-      this.report(decodeURIComponent(uri.pathname));
+      const pathname = decodeURIComponent(uri.pathname);
+      const windowsDrivePath = pathname.match(/^\/([a-z]:\/.*)$/i)?.[1];
+      this.report(windowsDrivePath ? windowsDrivePath.replaceAll('/', '\\') : pathname);
       return true;
     } catch {
       return false;

--- a/client/src/terminal/shell-integration.ts
+++ b/client/src/terminal/shell-integration.ts
@@ -21,6 +21,7 @@ export interface MarkerHost {
 
 const MAX_TERMINAL_CWD_LENGTH = 4096;
 const CWD_PROPERTY_PREFIX = 'P;Cwd=';
+const RAW_WINDOWS_CWD_PROPERTY_PREFIX = 'P;CwdRaw=';
 
 /** Decode the escaping used by OSC 133/633 property values. */
 function decodePropertyValue(value: string): string | undefined {
@@ -64,13 +65,19 @@ export class CwdTracker {
   constructor(private readonly onChange: (cwd: string) => void) {}
 
   handleProperty(data: string): boolean {
-    if (!data.startsWith(CWD_PROPERTY_PREFIX)) return false;
-    const value = data.slice(CWD_PROPERTY_PREFIX.length);
-    // cmd.exe's $P prompt token supplies a native path but cannot escape its
-    // backslashes according to the OSC 133 property convention. It is still
-    // unambiguous at the drive-letter/UNC root, so preserve it as reported.
-    this.report(windowsTerminalCwd(value) ? value : decodePropertyValue(value));
-    return true;
+    if (data.startsWith(CWD_PROPERTY_PREFIX)) {
+      this.report(decodePropertyValue(data.slice(CWD_PROPERTY_PREFIX.length)));
+      return true;
+    }
+    if (data.startsWith(RAW_WINDOWS_CWD_PROPERTY_PREFIX)) {
+      const value = data.slice(RAW_WINDOWS_CWD_PROPERTY_PREFIX.length);
+      // cmd.exe's $P prompt token cannot apply OSC property escaping. Keep its
+      // internal property distinct so standards-compliant Cwd values above
+      // always decode doubled backslashes and \xNN escapes.
+      this.report(windowsTerminalCwd(value) ? value : undefined);
+      return true;
+    }
+    return false;
   }
 
   handleFileUri(data: string): boolean {

--- a/server/src/local/shell-integration.ts
+++ b/server/src/local/shell-integration.ts
@@ -113,7 +113,7 @@ export interface ShellIntegration {
 // time it draws a prompt. Prefixing the user's prompt with this invisible OSC
 // property gives Windows local terminals the same live cwd reports as the
 // bash/zsh shims without replacing the visible prompt.
-const CMD_CWD_PROMPT_PREFIX = '$E]133;P;Cwd=$P$E' + '\\';
+const CMD_CWD_PROMPT_PREFIX = '$E]133;P;CwdRaw=$P$E' + '\\';
 
 /** Spawn arguments and env that switch integration on for a given shell.
  *  Unrecognized shells spawn untouched (fish emits OSC 133 on its own). */

--- a/server/src/local/shell-integration.ts
+++ b/server/src/local/shell-integration.ts
@@ -109,16 +109,30 @@ export interface ShellIntegration {
   env: Record<string, string>;
 }
 
+// cmd.exe expands $E to ESC and $P to its current drive and directory every
+// time it draws a prompt. Prefixing the user's prompt with this invisible OSC
+// property gives Windows local terminals the same live cwd reports as the
+// bash/zsh shims without replacing the visible prompt.
+const CMD_CWD_PROMPT_PREFIX = '$E]133;P;Cwd=$P$E' + '\\';
+
 /** Spawn arguments and env that switch integration on for a given shell.
  *  Unrecognized shells spawn untouched (fish emits OSC 133 on its own). */
 export function shellIntegration(
   shell: string,
   baseEnv: NodeJS.ProcessEnv,
   root: string | null = integrationRoot(),
+  platform: NodeJS.Platform = process.platform,
 ): ShellIntegration {
   const none: ShellIntegration = { args: [], env: {} };
-  if (process.platform === 'win32' || !root) return none;
-  const name = path.basename(shell);
+  const name = platform === 'win32' ? path.win32.basename(shell).toLowerCase() : path.basename(shell);
+  if (platform === 'win32') {
+    if (name !== 'cmd' && name !== 'cmd.exe') return none;
+    return {
+      args: [],
+      env: { PROMPT: `${CMD_CWD_PROMPT_PREFIX}${baseEnv.PROMPT || '$P$G'}` },
+    };
+  }
+  if (!root) return none;
   if (name === 'zsh') {
     const env: Record<string, string> = { ZDOTDIR: path.join(root, 'zsh') };
     const userZdotdir = baseEnv.ZDOTDIR?.trim();

--- a/tests/unit/client/shell-integration.test.ts
+++ b/tests/unit/client/shell-integration.test.ts
@@ -105,10 +105,22 @@ describe('CwdTracker', () => {
     const paths: string[] = [];
     const tracker = new CwdTracker((path) => paths.push(path));
 
-    expect(tracker.handleProperty(String.raw`P;Cwd=C:\Users\alice\project`)).toBe(true);
-    expect(tracker.handleProperty(String.raw`P;Cwd=C:\Users\alice\project`)).toBe(true);
-    expect(tracker.handleProperty(String.raw`P;Cwd=D:\source`)).toBe(true);
+    expect(tracker.handleProperty(String.raw`P;CwdRaw=C:\Users\alice\project`)).toBe(true);
+    expect(tracker.handleProperty(String.raw`P;CwdRaw=C:\Users\alice\project`)).toBe(true);
+    expect(tracker.handleProperty(String.raw`P;CwdRaw=D:\source`)).toBe(true);
     expect(paths).toEqual([String.raw`C:\Users\alice\project`, String.raw`D:\source`]);
+  });
+
+  it('decodes standards-escaped Windows cwd properties', () => {
+    const paths: string[] = [];
+    const tracker = new CwdTracker((path) => paths.push(path));
+
+    expect(tracker.handleProperty(String.raw`P;Cwd=C:\\work\\semi\x3bcolon`)).toBe(true);
+    expect(tracker.handleProperty(String.raw`P;Cwd=\\\\server\\share\\dir`)).toBe(true);
+    expect(paths).toEqual([
+      String.raw`C:\work\semi;colon`,
+      String.raw`\\server\share\dir`,
+    ]);
   });
 
   it('accepts standard file URIs and ignores invalid or relative paths', () => {

--- a/tests/unit/client/shell-integration.test.ts
+++ b/tests/unit/client/shell-integration.test.ts
@@ -101,6 +101,16 @@ describe('CwdTracker', () => {
     expect(paths).toEqual(['/srv/with;semi\\backslash']);
   });
 
+  it('reports native Windows cwd properties emitted by cmd prompts', () => {
+    const paths: string[] = [];
+    const tracker = new CwdTracker((path) => paths.push(path));
+
+    expect(tracker.handleProperty(String.raw`P;Cwd=C:\Users\alice\project`)).toBe(true);
+    expect(tracker.handleProperty(String.raw`P;Cwd=C:\Users\alice\project`)).toBe(true);
+    expect(tracker.handleProperty(String.raw`P;Cwd=D:\source`)).toBe(true);
+    expect(paths).toEqual([String.raw`C:\Users\alice\project`, String.raw`D:\source`]);
+  });
+
   it('accepts standard file URIs and ignores invalid or relative paths', () => {
     const paths: string[] = [];
     const tracker = new CwdTracker((path) => paths.push(path));
@@ -109,6 +119,14 @@ describe('CwdTracker', () => {
     expect(tracker.handleProperty('P;Cwd=relative/path')).toBe(true);
     expect(tracker.handleFileUri('https://example.test/srv/app')).toBe(false);
     expect(paths).toEqual(['/srv/my app']);
+  });
+
+  it('converts Windows OSC 7 file URIs to native drive paths', () => {
+    const paths: string[] = [];
+    const tracker = new CwdTracker((path) => paths.push(path));
+
+    expect(tracker.handleFileUri('file:///C:/Users/alice/my%20project')).toBe(true);
+    expect(paths).toEqual([String.raw`C:\Users\alice\my project`]);
   });
 
   it('leaves unrelated shell-integration properties for other handlers', () => {

--- a/tests/unit/server/shell-integration.test.ts
+++ b/tests/unit/server/shell-integration.test.ts
@@ -68,12 +68,12 @@ describe('shellIntegration', () => {
     );
 
     expect(result.args).toEqual([]);
-    expect(result.env).toEqual({ PROMPT: String.raw`$E]133;P;Cwd=$P$E\$S$P$G` });
+    expect(result.env).toEqual({ PROMPT: String.raw`$E]133;P;CwdRaw=$P$E\$S$P$G` });
   });
 
   it('uses the standard visible cmd prompt when none was configured', () => {
     expect(shellIntegration('cmd.exe', {}, null, 'win32').env).toEqual({
-      PROMPT: String.raw`$E]133;P;Cwd=$P$E\$P$G`,
+      PROMPT: String.raw`$E]133;P;CwdRaw=$P$E\$P$G`,
     });
   });
 

--- a/tests/unit/server/shell-integration.test.ts
+++ b/tests/unit/server/shell-integration.test.ts
@@ -59,6 +59,28 @@ describe('shellIntegration', () => {
     expect(result.env).toEqual({});
   });
 
+  it('prefixes the native cmd prompt with a live Windows cwd report', () => {
+    const result = shellIntegration(
+      String.raw`C:\Windows\System32\cmd.exe`,
+      { PROMPT: '$S$P$G' },
+      null,
+      'win32',
+    );
+
+    expect(result.args).toEqual([]);
+    expect(result.env).toEqual({ PROMPT: String.raw`$E]133;P;Cwd=$P$E\$S$P$G` });
+  });
+
+  it('uses the standard visible cmd prompt when none was configured', () => {
+    expect(shellIntegration('cmd.exe', {}, null, 'win32').env).toEqual({
+      PROMPT: String.raw`$E]133;P;Cwd=$P$E\$P$G`,
+    });
+  });
+
+  it('leaves other Windows shells untouched', () => {
+    expect(shellIntegration('powershell.exe', {}, null, 'win32')).toEqual({ args: [], env: {} });
+  });
+
   it('leaves other shells untouched', () => {
     expect(shellIntegration('/usr/bin/fish', {}, root)).toEqual({ args: [], env: {} });
   });


### PR DESCRIPTION
## Summary

- report the live working directory from native `cmd.exe` prompts without changing the visible prompt
- accept Windows drive and UNC working directories in the terminal CWD tracker
- normalize Windows OSC 7 file URIs to native paths
- add client and server regression coverage

## Root cause

Windows local `cmd.exe` sessions did not publish their current working directory. Relative terminal file links were detected, but Muxus could not resolve them and showed the “local working directory is unavailable” warning.

## Validation

- full test suite: 104 passed, 1 skipped
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Closes #115