### PR TITLE
Bump version to v0.6.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/electron",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Muxus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muxus",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "packageManager": "pnpm@11.17.0",
   "description": "Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane sessions, SFTP, port forwarding",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxus/tests",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/server/app-routes.test.ts
+++ b/tests/unit/server/app-routes.test.ts
@@ -46,7 +46,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: true,
-      currentVersion: '0.6.0',
+      currentVersion: '0.6.1',
       latestVersion: '0.7.0',
       releaseName: 'Muxus 0.7',
       releaseUrl: 'https://github.com/FloSch62/muxus/releases/tag/v0.7.0',
@@ -56,7 +56,7 @@ describe('app routes', () => {
       /^https:\/\/flosch62\.github\.io\/muxus\/latest\.json\?t=\d+$/,
     );
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.6.0' },
+      headers: { Accept: 'application/json', 'User-Agent': 'Muxus/0.6.1' },
     });
   });
 
@@ -83,7 +83,7 @@ describe('app routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       available: false,
-      currentVersion: '0.6.0',
+      currentVersion: '0.6.1',
       latestVersion: '0.7.0',
       reason: 'missing-release-url',
     });


### PR DESCRIPTION
## Summary

- bump all workspace package versions from `0.6.0` to `0.6.1`
- update server update-check expectations for the new current version

## Impact

Prepares the application and release packages for the `v0.6.1` release.

## Validation

- `pnpm --filter @muxus/tests test -- unit/server/app-routes.test.ts`
- 104 test files passed, 1 skipped
- 916 tests passed, 3 skipped
- `git diff --check`