### PR TITLE
Avoid duplicate default workspace names

### DIFF
--- a/client/src/components/WorkspaceDialog.tsx
+++ b/client/src/components/WorkspaceDialog.tsx
@@ -41,6 +41,7 @@ import WorkspacesOutlinedIcon from '@mui/icons-material/WorkspacesOutlined';
 import {
   deleteWorkspace,
   focusOpenWorkspace,
+  nextWorkspaceName,
   openWorkspace,
   refreshWorkspaceCatalog,
   renameWorkspace,
@@ -77,13 +78,6 @@ interface WorkspaceMenu {
 function activityLabel(workspace: WorkspaceSummary): string {
   const opened = workspace.lastOpenedAt;
   return `${opened ? 'Opened' : 'Updated'} ${formatTimestamp(opened ?? workspace.updatedAt)}`;
-}
-
-function nextWorkspaceName(workspaces: readonly WorkspaceSummary[]): string {
-  const names = new Set(workspaces.map((workspace) => workspace.name.trim().toLocaleLowerCase()));
-  let number = 1;
-  while (names.has(`workspace ${number}`)) number++;
-  return `Workspace ${number}`;
 }
 
 export function WorkspaceDialog() {

--- a/client/src/workspace-persistence.ts
+++ b/client/src/workspace-persistence.ts
@@ -20,7 +20,6 @@ import {
 
 const SAVE_DELAY_MS = 350;
 const RETRY_DELAY_MS = 2_000;
-const DEFAULT_WORKSPACE_NAME = 'Workspace 1';
 const WORKSPACE_UNLOAD_PRIORITY = 100;
 
 interface WorkspaceSnapshot {
@@ -66,6 +65,13 @@ function mergeSummary(
 ): WorkspaceSummary[] {
   const summary = summaryOf(workspace);
   return [summary, ...summaries.filter((candidate) => candidate.id !== workspace.id)];
+}
+
+export function nextWorkspaceName(workspaces: readonly WorkspaceSummary[]): string {
+  const names = new Set(workspaces.map((workspace) => workspace.name.trim().toLocaleLowerCase()));
+  let number = 1;
+  while (names.has(`workspace ${number}`)) number++;
+  return `Workspace ${number}`;
 }
 
 export class WorkspaceRuntime {
@@ -519,13 +525,13 @@ export class WorkspaceRuntime {
     if (!this.pending || this.stopped) return Promise.resolve();
     const snapshot = this.pending;
     this.pending = undefined;
-    const { activeId, activeName } = useWorkspacesStore.getState();
+    const { activeId, activeName, workspaces } = useWorkspacesStore.getState();
     const save = apiFetch<WorkspaceRecord>('/api/workspaces', {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         id: activeId,
-        name: activeId ? activeName : DEFAULT_WORKSPACE_NAME,
+        name: activeId ? activeName : nextWorkspaceName(workspaces),
         layout: snapshot.layout,
         multiExecGroups: snapshot.multiExecGroups,
       }),
@@ -619,10 +625,10 @@ export class WorkspaceRuntime {
 
   flushOnUnload(maxBodyBytes = PAGE_KEEPALIVE_BODY_LIMIT_BYTES): number {
     if (!this.pending || this.activeWorkspaceIsLocked()) return 0;
-    const { activeId, activeName } = useWorkspacesStore.getState();
+    const { activeId, activeName, workspaces } = useWorkspacesStore.getState();
     const body = JSON.stringify({
       id: activeId,
-      name: activeId ? activeName : DEFAULT_WORKSPACE_NAME,
+      name: activeId ? activeName : nextWorkspaceName(workspaces),
       layout: this.pending.layout,
       multiExecGroups: this.pending.multiExecGroups,
     });

--- a/client/src/workspace-persistence.ts
+++ b/client/src/workspace-persistence.ts
@@ -532,6 +532,7 @@ export class WorkspaceRuntime {
       body: JSON.stringify({
         id: activeId,
         name: activeId ? activeName : nextWorkspaceName(workspaces),
+        allocateDefaultName: !activeId,
         layout: snapshot.layout,
         multiExecGroups: snapshot.multiExecGroups,
       }),
@@ -629,6 +630,7 @@ export class WorkspaceRuntime {
     const body = JSON.stringify({
       id: activeId,
       name: activeId ? activeName : nextWorkspaceName(workspaces),
+      allocateDefaultName: !activeId,
       layout: this.pending.layout,
       multiExecGroups: this.pending.multiExecGroups,
     });

--- a/server/src/persistence/database.ts
+++ b/server/src/persistence/database.ts
@@ -1368,6 +1368,29 @@ export class MuxusDatabase {
     return this.workspace(id)!;
   }
 
+  saveWorkspaceWithDefaultName(input: {
+    layout: unknown;
+    multiExecGroups?: WorkspaceMultiExecGroup[];
+  }): WorkspaceRecord {
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const names = new Set(
+        this.db
+          .prepare('SELECT name FROM workspaces')
+          .all()
+          .map((row) => String(row.name).trim().toLocaleLowerCase()),
+      );
+      let number = 1;
+      while (names.has(`workspace ${number}`)) number++;
+      const workspace = this.saveWorkspace({ ...input, name: `Workspace ${number}` });
+      this.db.exec('COMMIT');
+      return workspace;
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+  }
+
   workspace(id: string): WorkspaceRecord | undefined {
     const row = this.db
       .prepare(`

--- a/server/src/routes/workspaces.ts
+++ b/server/src/routes/workspaces.ts
@@ -124,6 +124,7 @@ const workspaceSaveSchema = z.object({
   layout: workspaceLayoutSchema,
   overwriteLocked: z.boolean().optional().default(false),
   createIfMissing: z.boolean().optional().default(false),
+  allocateDefaultName: z.boolean().optional().default(false),
   multiExecGroups: z.array(
     z.object({
       id: z.string().min(1),
@@ -138,6 +139,9 @@ const workspaceSaveSchema = z.object({
 }).superRefine((workspace, ctx) => {
   if (workspace.createIfMissing && !workspace.id) {
     ctx.addIssue({ code: 'custom', message: 'createIfMissing requires a workspace id' });
+  }
+  if (workspace.allocateDefaultName && workspace.id) {
+    ctx.addIssue({ code: 'custom', message: 'allocateDefaultName cannot update a workspace' });
   }
   const ids = new Set<string>();
   const names = new Set<string>();
@@ -214,17 +218,22 @@ export function registerWorkspaceRoutes(app: FastifyInstance, ctx: AppContext): 
       if (!parsed.success) {
         throw new HttpProblem(400, parsed.error.issues[0]?.message ?? 'invalid workspace');
       }
-      const { overwriteLocked, createIfMissing, ...workspace } = parsed.data;
+      const { overwriteLocked, createIfMissing, allocateDefaultName, ...workspace } = parsed.data;
       const existing = workspace.id ? ctx.database.workspace(workspace.id) : undefined;
       if (workspace.id && !existing && !createIfMissing) {
         throw new HttpProblem(404, 'workspace not found', 'workspace-not-found');
       }
-      const saved = existing && createIfMissing
-        ? (existing as WorkspaceRecord)
-        : ctx.database.saveWorkspace(
-            existing ? { ...workspace, name: existing.name } : workspace,
-            overwriteLocked,
-          ) as WorkspaceRecord;
+      const saved = allocateDefaultName
+        ? ctx.database.saveWorkspaceWithDefaultName({
+            layout: workspace.layout,
+            multiExecGroups: workspace.multiExecGroups,
+          }) as WorkspaceRecord
+        : existing && createIfMissing
+          ? (existing as WorkspaceRecord)
+          : ctx.database.saveWorkspace(
+              existing ? { ...workspace, name: existing.name } : workspace,
+              overwriteLocked,
+            ) as WorkspaceRecord;
       ctx.database.pruneTerminalSnapshots();
       return saved;
     } catch (err) {

--- a/tests/unit/client/workspace-persistence.test.ts
+++ b/tests/unit/client/workspace-persistence.test.ts
@@ -120,9 +120,55 @@ describe('workspace persistence', () => {
     await vi.advanceTimersByTimeAsync(400);
 
     expect(created).toMatchObject({ name: 'Workspace 2' });
+    const createRequest = fetchMock.mock.calls.find(
+      ([path, init]) => path === '/api/workspaces' && init?.method === 'PUT',
+    );
+    expect(JSON.parse(createRequest?.[1]?.body as string)).toMatchObject({
+      name: 'Workspace 2',
+      allocateDefaultName: true,
+    });
     expect(useWorkspacesStore.getState()).toMatchObject({
       activeId: 'new-default',
       activeName: 'Workspace 2',
+    });
+
+    runtime.stop();
+  });
+
+  it('requests server-side name allocation when unloading an unsaved window', async () => {
+    const existing: WorkspaceRecord = {
+      id: 'existing-default',
+      name: 'Workspace 1',
+      layout: { version: 1, root: null },
+      multiExecGroups: [],
+      isLocked: false,
+      isStartup: false,
+      createdAt: '2026-08-11T08:00:00Z',
+      updatedAt: '2026-08-11T08:00:00Z',
+    };
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      if (path === '/api/workspaces' && method === 'GET') {
+        return json({ workspaces: [summaryOf(existing)] });
+      }
+      if (path === '/api/workspaces' && method === 'PUT') return json(existing);
+      throw new Error(`Unexpected request: ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const runtime = new WorkspaceRuntime({ kind: 'blank' });
+    await runtime.start();
+    useTabsStore.getState().open({ kind: 'local' }, 'Transferred session');
+
+    expect(runtime.flushOnUnload()).toBeGreaterThan(0);
+    const unloadRequest = fetchMock.mock.calls.find(
+      ([path, init]) => path === '/api/workspaces' && init?.method === 'PUT',
+    );
+    expect(JSON.parse(unloadRequest?.[1]?.body as string)).toMatchObject({
+      name: 'Workspace 2',
+      allocateDefaultName: true,
     });
 
     runtime.stop();

--- a/tests/unit/client/workspace-persistence.test.ts
+++ b/tests/unit/client/workspace-persistence.test.ts
@@ -74,6 +74,60 @@ describe('workspace persistence', () => {
     runtime.stop();
   });
 
+  it('uses the next free workspace name when an unsaved window is automatically saved', async () => {
+    const existing: WorkspaceRecord = {
+      id: 'existing-default',
+      name: 'Workspace 1',
+      layout: { version: 1, root: null },
+      multiExecGroups: [],
+      isLocked: false,
+      isStartup: false,
+      createdAt: '2026-08-11T08:00:00Z',
+      updatedAt: '2026-08-11T08:00:00Z',
+    };
+    let created: WorkspaceRecord | undefined;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      if (path === '/api/workspaces' && method === 'GET') {
+        return json({ workspaces: [summaryOf(existing)] });
+      }
+      if (path === '/api/workspaces' && method === 'PUT') {
+        if (typeof init?.body !== 'string') throw new Error('Expected a JSON request body');
+        const saved = JSON.parse(init.body) as Pick<
+          WorkspaceRecord,
+          'name' | 'layout' | 'multiExecGroups'
+        >;
+        created = {
+          ...saved,
+          id: 'new-default',
+          isLocked: false,
+          isStartup: false,
+          createdAt: '2026-08-11T08:05:00Z',
+          updatedAt: '2026-08-11T08:05:00Z',
+        };
+        return json(created);
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const runtime = new WorkspaceRuntime({ kind: 'blank' });
+    await runtime.start();
+
+    useTabsStore.getState().open({ kind: 'local' }, 'Transferred session');
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(created).toMatchObject({ name: 'Workspace 2' });
+    expect(useWorkspacesStore.getState()).toMatchObject({
+      activeId: 'new-default',
+      activeName: 'Workspace 2',
+    });
+
+    runtime.stop();
+  });
+
   it('creates a named empty workspace for a new workspace window', async () => {
     let created: WorkspaceRecord | undefined;
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {

--- a/tests/unit/server/workspace-routes.test.ts
+++ b/tests/unit/server/workspace-routes.test.ts
@@ -115,6 +115,36 @@ describe('workspace routes', () => {
     });
   });
 
+  it('allocates implicit default workspace names on the server', async () => {
+    const first = await app.inject({
+      method: 'PUT',
+      url: '/api/workspaces',
+      headers: auth(),
+      payload: { name: 'Workspace 1', layout },
+    });
+    expect(first.statusCode).toBe(200);
+
+    const [second, third] = await Promise.all([
+      app.inject({
+        method: 'PUT',
+        url: '/api/workspaces',
+        headers: auth(),
+        payload: { name: 'Workspace 2', allocateDefaultName: true, layout },
+      }),
+      app.inject({
+        method: 'PUT',
+        url: '/api/workspaces',
+        headers: auth(),
+        payload: { name: 'Workspace 2', allocateDefaultName: true, layout },
+      }),
+    ]);
+
+    expect([second.statusCode, third.statusCode]).toEqual([200, 200]);
+    expect(new Set([second.json().name, third.json().name])).toEqual(
+      new Set(['Workspace 2', 'Workspace 3']),
+    );
+  });
+
   it('renames, opens, and configures a startup workspace', async () => {
     const save = await app.inject({
       method: 'PUT',


### PR DESCRIPTION
## Summary

- allocate implicit `Workspace N` names atomically on the server
- mark debounced and unload persistence requests for server-side name allocation
- keep the workspace dialog’s next-name suggestion for immediate UI feedback
- cover normal autosave, unload keepalive, and simultaneous stale-name requests

## Root cause

Automatic and unload persistence originally always used `Workspace 1`. Choosing the next name only from the client catalog still left a race: an unload keepalive does not update other windows, so multiple stale clients could submit the same generated name.

## Impact

The server now selects and saves the first available numbered name inside a SQLite `BEGIN IMMEDIATE` transaction. Simultaneous or stale implicit saves therefore receive distinct names such as `Workspace 2` and `Workspace 3`, while explicit user-chosen names keep their existing behavior.

Fixes #125

## Validation

- 922 tests completed: 919 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`