### PR TITLE
Add session tab quality-of-life actions

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -106,7 +106,8 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const workspacesOpen = useUiStore((s) => s.workspacesOpen);
   const dialogOpen = useDialogStore((s) => s.queue.length > 0);
   const toastOpen = useToastStore((s) => !!s.toast);
-  const [startupReady, setStartupReady] = useState(launch?.kind === 'session');
+  const standaloneLaunch = launch?.kind === 'session' || launch?.kind === 'tab-transfer';
+  const [startupReady, setStartupReady] = useState(standaloneLaunch);
   const [newWorkspaceId] = useState(() =>
     launch?.kind === 'workspace' && !launch.workspaceId
       ? (globalThis.crypto?.randomUUID?.() ??
@@ -120,7 +121,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const effectiveMode = themeMode === 'os' ? osTheme : themeMode;
   const theme = useMemo(() => buildTheme(effectiveMode), [effectiveMode]);
   const initialWorkspace: WorkspaceInitialSelection | undefined =
-    launch?.kind === 'session'
+    standaloneLaunch
       ? { kind: 'blank' }
       : launch?.kind === 'workspace'
         ? launch.workspaceId

--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -30,7 +30,9 @@ import CheckIcon from '@mui/icons-material/Check';
 import CloseFullscreenOutlinedIcon from '@mui/icons-material/CloseFullscreenOutlined';
 import CloseIcon from '@mui/icons-material/Close';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DriveFileMoveOutlinedIcon from '@mui/icons-material/DriveFileMoveOutlined';
 import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import GridViewOutlinedIcon from '@mui/icons-material/GridViewOutlined';
 import HorizontalSplitOutlinedIcon from '@mui/icons-material/HorizontalSplitOutlined';
@@ -50,6 +52,8 @@ import { useChordLabel } from '../keymap/hints.js';
 import { ChordHint, withChord } from './ChordHint.js';
 import {
   duplicateTab,
+  detachTabToNewWindow,
+  moveTabToNewWindow,
   openEmptyTab,
   openTabInNewWindow,
   requestClosePane,
@@ -57,6 +61,7 @@ import {
   splitActivePane,
 } from '../session-actions.js';
 import {
+  closableTabIdsToRight,
   useTabsStore,
   type PaneDirection,
   type TabStatus,
@@ -66,6 +71,10 @@ import { findPane } from '../state/workspace-layout.js';
 import { layout, statusTextColor } from '../theme.js';
 import { useMultiExecStore } from '../state/multi-exec.js';
 import { terminalHandle } from '../terminal/terminal-registry.js';
+import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
+import { editableManagedHostForProfile } from '../managed-hosts.js';
+import { useUiStore } from '../state/ui.js';
+import { loadHostEditorDialog } from '../lazy-features.js';
 import { hostKindIcon } from './host-kind-icon.js';
 import {
   activeTabTransfer,
@@ -158,6 +167,13 @@ export function TabStrip({
   const setPinned = useTabsStore((s) => s.setPinned);
   const moveTabToNewPane = useTabsStore((s) => s.moveTabToNewPane);
   const reconnect = useTabsStore((s) => s.reconnect);
+  const setHostEditor = useUiStore((s) => s.setHostEditor);
+  const { data: sshConfig } = useSshConfig(
+    allTabs.some((tab) => tab.profile?.kind === 'ssh' && tab.profile.useConfig !== false),
+  );
+  const { data: savedHostProfiles } = useSavedHostProfiles(
+    allTabs.some((tab) => tab.profile !== null && tab.profile.kind !== 'local' && !!tab.profile.profileId),
+  );
   const multiExecTargets = useMultiExecStore((s) => s.selectedIds);
   const multiExecSelected = new Set(multiExecTargets);
   const toggleMultiExecTarget = useMultiExecStore((s) => s.toggleTarget);
@@ -312,6 +328,14 @@ export function TabStrip({
 
   const openMenu = (tab: TerminalTab, position: { top: number; left: number }) => setMenu({ position, tab });
   const menuTab = menu ? allTabs.find((t) => t.id === menu.tab.id) : undefined;
+  const editableMenuHost = menuTab?.profile
+    ? editableManagedHostForProfile(
+        menuTab.profile,
+        sshConfig?.hosts ?? [],
+        savedHostProfiles?.profiles ?? [],
+      )
+    : undefined;
+  const menuTabIdsToRight = menuTab ? closableTabIdsToRight(tabs, menuTab.id) : [];
   const menuTabSupportsSftp =
     menuTab?.profile?.kind === 'ssh' &&
     (menuTab.status === 'connecting' || menuTab.status === 'connected') &&
@@ -521,11 +545,13 @@ export function TabStrip({
               setDropIndicator(null);
               dropTab(transferId, tab.id, dropEdge(event));
             }}
-            onDragEnd={() => {
+            onDragEnd={(event) => {
               setDraggingId(null);
               setDropIndicator(null);
               const current = activeTabTransfer();
-              if (current?.tabId === tab.id) endTabDrag(current.transferId);
+              if (current?.tabId !== tab.id) return;
+              detachTabToNewWindow(current.transferId, tab.title, event);
+              endTabDrag(current.transferId);
             }}
             onClick={() => activate(tab.id)}
             onKeyDown={(e) => {
@@ -1067,6 +1093,26 @@ export function TabStrip({
           <ListItemText>Rename tab</ListItemText>
         </MenuItem>
         <MenuItem
+          disabled={!editableMenuHost}
+          onMouseEnter={() => void loadHostEditorDialog()}
+          onFocus={() => void loadHostEditorDialog()}
+          onClick={() => {
+            if (editableMenuHost) {
+              setHostEditor(
+                editableMenuHost.kind === 'ssh'
+                  ? { mode: 'edit', entry: editableMenuHost.entry }
+                  : { mode: 'edit-profile', entry: editableMenuHost.entry },
+              );
+            }
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <EditOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Edit host</ListItemText>
+        </MenuItem>
+        <MenuItem
           onClick={() => {
             if (menuTab) setPinned(menuTab.id, !menuTab.pinned);
             setMenu(null);
@@ -1103,6 +1149,19 @@ export function TabStrip({
             <OpenInNewOutlinedIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Open in new window</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onMouseEnter={() => void loadTabTransfer()}
+          onFocus={() => void loadTabTransfer()}
+          onClick={() => {
+            if (menuTab) moveTabToNewWindow(menuTab.id);
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <DriveFileMoveOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Move to new window</ListItemText>
         </MenuItem>
         {menuTabSupportsSftp ? (
           <MenuItem
@@ -1300,6 +1359,18 @@ export function TabStrip({
             <CloseIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Close other tabs</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={menuTabIdsToRight.length === 0}
+          onClick={() => {
+            void requestCloseTabs(menuTabIdsToRight);
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <CloseIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Close tabs to the right</ListItemText>
         </MenuItem>
       </Menu>
 

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -33,6 +33,10 @@ declare global {
       listLocalFontFamilies(): Promise<string[] | undefined>;
       /** Open a secondary native application window. */
       openWindow(launch: AppWindowLaunch): void;
+      /** Open a tab-transfer window when the native cursor is outside every app window. */
+      detachTab(
+        launch: Extract<AppWindowLaunch, { kind: 'tab-transfer' }>,
+      ): Promise<boolean>;
       /** Register the saved workspace currently owned by this native window. */
       setActiveWorkspace(
         workspaceId?: string,

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -18,6 +18,12 @@ if (windowLaunch?.kind === 'session') {
   const id = useTabsStore.getState().open(windowLaunch.profile, windowLaunch.title);
   if (windowLaunch.color) useTabsStore.getState().update(id, { color: windowLaunch.color });
 }
+if (windowLaunch?.kind === 'tab-transfer') {
+  const paneId = useTabsStore.getState().activePaneId;
+  void import('./tab-transfer.js').then((module) =>
+    module.receiveTabTransfer(windowLaunch.transferId, paneId),
+  );
+}
 if (windowLaunch?.kind !== 'sftp') installShortcuts();
 
 const queryClient = new QueryClient({

--- a/client/src/managed-hosts.ts
+++ b/client/src/managed-hosts.ts
@@ -1,6 +1,7 @@
 import type {
   ManagedHostRef,
   SavedHostProfile,
+  SessionProfile,
   SshHostEntry,
   SshProfile,
 } from '@muxus/shared';
@@ -22,6 +23,22 @@ import {
 export type ManagedHost =
   | { kind: 'ssh'; entry: SshHostEntry }
   | { kind: 'profile'; entry: SavedHostProfile };
+
+/** Resolve the persisted host which produced a live tab, when one still exists. */
+export function editableManagedHostForProfile(
+  profile: SessionProfile,
+  sshHosts: readonly SshHostEntry[],
+  savedProfiles: readonly SavedHostProfile[],
+): ManagedHost | undefined {
+  if (profile.kind === 'local') return undefined;
+  if (profile.profileId) {
+    const entry = savedProfiles.find((candidate) => candidate.id === profile.profileId);
+    return entry ? { kind: 'profile', entry } : undefined;
+  }
+  if (profile.kind !== 'ssh' || profile.useConfig === false) return undefined;
+  const entry = sshHosts.find((candidate) => candidate.aliases.includes(profile.target));
+  return entry ? { kind: 'ssh', entry } : undefined;
+}
 
 export interface ManagedHostGroup
   extends Omit<HostGroup, 'hosts'> {

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -19,6 +19,7 @@ import { showToast } from './state/toast.js';
 import { confirmDiscardRemoteEditors } from './editor/remote-editor-registry.js';
 import { findPane, visibleTabIds } from './state/workspace-layout.js';
 import { openAppWindow } from './window-management.js';
+import { createTabTransferId, shouldDetachTabDrag } from './tab-drag.js';
 
 /**
  * How long a launch swallows an identical repeat. A tab appears instantly but
@@ -260,6 +261,38 @@ export function openTabInNewWindow(tabId: string): void {
     title: tab.title,
     ...(tab.color ? { color: tab.color } : {}),
   });
+}
+
+/** Open a new window which claims the existing tab instead of redialing it. */
+export function moveTabToNewWindow(tabId: string): void {
+  const tab = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
+  if (!tab) return;
+  const transferId = createTabTransferId();
+  void import('./tab-transfer.js').then((module) =>
+    module.registerTabTransferSource(transferId, tabId),
+  );
+  // Keep the native/web window open inside the original user gesture. The
+  // destination retries its claim while the lazily loaded source registers.
+  openTabTransferInNewWindow(transferId, tab.title);
+}
+
+/** Finish a drag outside this renderer by opening a destination for its token. */
+export function openTabTransferInNewWindow(transferId: string, title: string): void {
+  openAppWindow({ kind: 'tab-transfer', transferId, title });
+}
+
+/** Detach a drag using native cursor bounds on desktop and DOM bounds on the web. */
+export function detachTabToNewWindow(
+  transferId: string,
+  title: string,
+  event: Pick<DragEvent, 'dataTransfer' | 'screenX' | 'screenY'>,
+): void {
+  const launch = { kind: 'tab-transfer' as const, transferId, title };
+  if (window.muxusDesktop) {
+    void window.muxusDesktop.detachTab(launch);
+    return;
+  }
+  if (shouldDetachTabDrag(event)) openAppWindow(launch);
 }
 
 /** Open a listed host as a fresh SSH session in a separate app window. */

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -284,6 +284,16 @@ export function tabsInOrder(
   return ordered;
 }
 
+/** Browser-style bulk close target: unpinned tabs after one tab in its strip. */
+export function closableTabIdsToRight(
+  paneTabs: readonly TerminalTab[],
+  tabId: string,
+): string[] {
+  const index = paneTabs.findIndex((tab) => tab.id === tabId);
+  if (index < 0) return [];
+  return paneTabs.slice(index + 1).filter((tab) => !tab.pinned).map((tab) => tab.id);
+}
+
 /** Insert a tab at an exact target, while keeping each pane's pinned group first. */
 export function insertIntoPane(
   tabs: readonly TerminalTab[],

--- a/client/src/tab-drag.ts
+++ b/client/src/tab-drag.ts
@@ -8,9 +8,14 @@ function randomId(): string {
     `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
+/** Create the opaque identity shared by a source and destination renderer. */
+export function createTabTransferId(): string {
+  return randomId();
+}
+
 /** Start the synchronous portion of an HTML drag; cross-window setup stays lazy. */
 export function beginTabDrag(tabId: string): string {
-  const transferId = randomId();
+  const transferId = createTabTransferId();
   active = { tabId, transferId };
   return transferId;
 }
@@ -39,4 +44,27 @@ export function readTabTransfer(dataTransfer: DataTransfer): string | undefined 
   if (custom) return custom;
   const text = dataTransfer.getData('text/plain');
   return text.startsWith(TEXT_PREFIX) ? text.slice(TEXT_PREFIX.length) : undefined;
+}
+
+interface WindowScreenBounds {
+  screenX: number;
+  screenY: number;
+  outerWidth: number;
+  outerHeight: number;
+}
+
+/** A rejected drop is a detach only when the pointer actually left this window. */
+export function shouldDetachTabDrag(
+  event: Pick<DragEvent, 'dataTransfer' | 'screenX' | 'screenY'>,
+  bounds: WindowScreenBounds = window,
+): boolean {
+  if (event.dataTransfer?.dropEffect !== 'none') return false;
+  const right = bounds.screenX + bounds.outerWidth;
+  const bottom = bounds.screenY + bounds.outerHeight;
+  return (
+    event.screenX < bounds.screenX ||
+    event.screenX >= right ||
+    event.screenY < bounds.screenY ||
+    event.screenY >= bottom
+  );
 }

--- a/client/src/window-management.ts
+++ b/client/src/window-management.ts
@@ -38,6 +38,16 @@ export function isAppWindowLaunch(value: unknown): value is AppWindowLaunch {
     const profile = launch.profile as Record<string, unknown>;
     return isSessionProfile(profile);
   }
+  if (launch.kind === 'tab-transfer') {
+    return (
+      typeof launch.transferId === 'string' &&
+      launch.transferId.length > 0 &&
+      launch.transferId.length <= 200 &&
+      typeof launch.title === 'string' &&
+      launch.title.length > 0 &&
+      launch.title.length <= 500
+    );
+  }
   return (
     launch.kind === 'sftp' &&
     typeof launch.connId === 'string' &&

--- a/client/src/window-management.ts
+++ b/client/src/window-management.ts
@@ -44,7 +44,6 @@ export function isAppWindowLaunch(value: unknown): value is AppWindowLaunch {
       launch.transferId.length > 0 &&
       launch.transferId.length <= 200 &&
       typeof launch.title === 'string' &&
-      launch.title.length > 0 &&
       launch.title.length <= 500
     );
   }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -679,7 +679,6 @@ function parseWindowLaunch(value: unknown): AppWindowLaunch | undefined {
       launch.transferId.length === 0 ||
       launch.transferId.length > 200 ||
       typeof launch.title !== 'string' ||
-      launch.title.length === 0 ||
       launch.title.length > 500
     ) {
       return undefined;

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -10,6 +10,7 @@ import {
   ipcMain,
   Menu,
   nativeTheme,
+  screen,
   shell,
   type MenuItemConstructorOptions,
 } from 'electron';
@@ -32,6 +33,7 @@ import { importLoginShellEnvironment } from './login-shell-environment.js';
 import { initMainLog, installCrashCapture, mainLog, mainLogPath } from './main-log.js';
 import { readLocalMobaXtermSessions } from './mobaxterm.js';
 import { workspaceOwnershipUpdate } from './workspace-window-state.js';
+import { pointInsideAnyWindow } from './tab-detach.js';
 
 // Name first: userData (and with it the log location) derives from it.
 app.setName('Muxus');
@@ -477,6 +479,22 @@ ipcMain.on('muxus:open-window', (event, value: unknown) => {
   createWindow(appUrl, launch);
 });
 
+ipcMain.handle('muxus:detach-tab', (event, value: unknown): boolean => {
+  if (!isManagedWindowSender(event) || !appUrl) return false;
+  const launch = parseWindowLaunch(value);
+  if (launch?.kind !== 'tab-transfer') return false;
+  const cursor = screen.getCursorScreenPoint();
+  const bounds = [...managedWindows]
+    .filter(
+      (candidate) =>
+        !candidate.isDestroyed() && candidate.isVisible() && !candidate.isMinimized(),
+    )
+    .map((candidate) => candidate.getBounds());
+  if (pointInsideAnyWindow(cursor, bounds)) return false;
+  createWindow(appUrl, launch);
+  return true;
+});
+
 ipcMain.on(
   'muxus:active-workspace',
   (event, value: unknown, title: unknown, clearLaunch: unknown) => {
@@ -653,6 +671,19 @@ function parseWindowLaunch(value: unknown): AppWindowLaunch | undefined {
         (profile.flowControl === undefined ||
           ['none', 'hardware', 'software'].includes(profile.flowControl as string)));
     if (!valid) return undefined;
+    return value as AppWindowLaunch;
+  }
+  if (launch.kind === 'tab-transfer') {
+    if (
+      typeof launch.transferId !== 'string' ||
+      launch.transferId.length === 0 ||
+      launch.transferId.length > 200 ||
+      typeof launch.title !== 'string' ||
+      launch.title.length === 0 ||
+      launch.title.length > 500
+    ) {
+      return undefined;
+    }
     return value as AppWindowLaunch;
   }
   if (

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -124,6 +124,10 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   openWindow(launch: AppWindowLaunch): void {
     ipcRenderer.send('muxus:open-window', launch);
   },
+  /** Detach a tab only when the native cursor is outside every Muxus window. */
+  detachTab(launch: Extract<AppWindowLaunch, { kind: 'tab-transfer' }>): Promise<boolean> {
+    return ipcRenderer.invoke('muxus:detach-tab', launch);
+  },
   setActiveWorkspace(
     workspaceId?: string,
     workspaceTitle?: string,

--- a/electron/src/tab-detach.ts
+++ b/electron/src/tab-detach.ts
@@ -1,0 +1,25 @@
+export interface ScreenPoint {
+  x: number;
+  y: number;
+}
+
+export interface WindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Whether the native cursor is currently over any Muxus window. */
+export function pointInsideAnyWindow(
+  point: ScreenPoint,
+  windows: readonly WindowBounds[],
+): boolean {
+  return windows.some(
+    (bounds) =>
+      point.x >= bounds.x &&
+      point.x < bounds.x + bounds.width &&
+      point.y >= bounds.y &&
+      point.y < bounds.y + bounds.height,
+  );
+}

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -320,6 +320,12 @@ export type AppWindowLaunch =
       color?: string;
     }
   | {
+      /** One live tab claimed from another renderer through an opaque token. */
+      kind: 'tab-transfer';
+      transferId: string;
+      title: string;
+    }
+  | {
       kind: 'sftp';
       connId: string;
       title: string;

--- a/tests/unit/client/managed-hosts.test.ts
+++ b/tests/unit/client/managed-hosts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
 import {
+  editableManagedHostForProfile,
   groupManagedHosts,
   managedHostCopyCommand,
   managedHostKey,
@@ -145,6 +146,40 @@ describe('managed host identity and clipboard actions', () => {
   const nativeSsh = { kind: 'profile' as const, entry: nativeSshHost('core') };
   const telnet = { kind: 'profile' as const, entry: telnetHost('console') };
   const serial = { kind: 'profile' as const, entry: serialHost('rack') };
+
+  it('resolves the persisted host behind a session profile for editing', () => {
+    expect(
+      editableManagedHostForProfile(
+        { kind: 'ssh', target: 'router' },
+        [ssh.entry],
+        [nativeSsh.entry, telnet.entry],
+      ),
+    ).toEqual(ssh);
+    expect(
+      editableManagedHostForProfile(
+        { ...telnet.entry.profile, profileId: telnet.entry.id },
+        [ssh.entry],
+        [nativeSsh.entry, telnet.entry],
+      ),
+    ).toEqual(telnet);
+    expect(
+      editableManagedHostForProfile(
+        { kind: 'ssh', target: 'unlisted.example.test' },
+        [ssh.entry],
+        [nativeSsh.entry],
+      ),
+    ).toBeUndefined();
+    expect(
+      editableManagedHostForProfile(
+        { kind: 'ssh', target: 'router', useConfig: false },
+        [ssh.entry],
+        [],
+      ),
+    ).toBeUndefined();
+    expect(
+      editableManagedHostForProfile({ kind: 'local' }, [ssh.entry], [nativeSsh.entry]),
+    ).toBeUndefined();
+  });
 
   it('derives stable keys matching the reorder refs', () => {
     expect(managedHostKey(ssh)).toBe('ssh:router');

--- a/tests/unit/client/tab-transfer.test.ts
+++ b/tests/unit/client/tab-transfer.test.ts
@@ -148,4 +148,21 @@ describe('cross-window tab transfer', () => {
     expect(data.getData(transfer.TAB_TRANSFER_MIME)).toBe('opaque-token');
     expect(data.getData('text/plain')).toBe('muxus-tab:opaque-token');
   });
+
+  it('detaches rejected drops only when they end outside the source window', async () => {
+    vi.resetModules();
+    const { shouldDetachTabDrag } = await import('../../../client/src/tab-drag.js');
+    const bounds = { screenX: 100, screenY: 50, outerWidth: 800, outerHeight: 600 };
+    const event = (screenX: number, screenY: number, dropEffect = 'none') => ({
+      dataTransfer: { dropEffect },
+      screenX,
+      screenY,
+    });
+
+    expect(shouldDetachTabDrag(event(99, 300) as never, bounds)).toBe(true);
+    expect(shouldDetachTabDrag(event(900, 300) as never, bounds)).toBe(true);
+    expect(shouldDetachTabDrag(event(400, 650) as never, bounds)).toBe(true);
+    expect(shouldDetachTabDrag(event(400, 300) as never, bounds)).toBe(false);
+    expect(shouldDetachTabDrag(event(950, 300, 'move') as never, bounds)).toBe(false);
+  });
 });

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -9,7 +9,10 @@ import {
 } from '../../../client/src/components/sidebar/host-sftp-action.js';
 import { useDialogStore } from '../../../client/src/state/dialogs.js';
 import { usePrefsStore } from '../../../client/src/state/prefs.js';
-import { useTabsStore } from '../../../client/src/state/tabs.js';
+import {
+  closableTabIdsToRight,
+  useTabsStore,
+} from '../../../client/src/state/tabs.js';
 import { findPane } from '../../../client/src/state/workspace-layout.js';
 
 /** Let the close flow run up to the point where it raises its dialog. */
@@ -875,6 +878,22 @@ describe('moving tabs between panes', () => {
       [thirdId, false],
       [firstId, false],
     ]);
+  });
+
+  it('selects only unpinned tabs to the right for browser-style bulk close', () => {
+    const store = useTabsStore.getState();
+    const pinnedSourceId = store.open({ kind: 'local' }, 'Pinned source');
+    const pinnedNeighborId = store.open({ kind: 'local' }, 'Pinned neighbor');
+    const firstId = store.open({ kind: 'local' }, 'One');
+    const secondId = store.open({ kind: 'local' }, 'Two');
+    useTabsStore.getState().setPinned(pinnedSourceId, true);
+    useTabsStore.getState().setPinned(pinnedNeighborId, true);
+    const tabs = useTabsStore.getState().tabs;
+
+    expect(closableTabIdsToRight(tabs, pinnedSourceId)).toEqual([firstId, secondId]);
+    expect(closableTabIdsToRight(tabs, firstId)).toEqual([secondId]);
+    expect(closableTabIdsToRight(tabs, secondId)).toEqual([]);
+    expect(closableTabIdsToRight(tabs, 'missing')).toEqual([]);
   });
 
   it('keeps a pinned tab ahead of unpinned tabs when moving it to another pane', () => {

--- a/tests/unit/client/window-management.test.ts
+++ b/tests/unit/client/window-management.test.ts
@@ -54,6 +54,16 @@ describe('secondary window launch payloads', () => {
     expect(decodeAppWindowLaunch(encodeAppWindowLaunch(launch))).toEqual(launch);
   });
 
+  it('round-trips a live-tab transfer with an empty title', () => {
+    const launch: AppWindowLaunch = {
+      kind: 'tab-transfer',
+      transferId: 'opaque-transfer-token',
+      title: '',
+    };
+
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(launch))).toEqual(launch);
+  });
+
   it('accepts cross-platform Telnet and serial session launches', () => {
     const telnet: AppWindowLaunch = {
       kind: 'session',

--- a/tests/unit/client/window-management.test.ts
+++ b/tests/unit/client/window-management.test.ts
@@ -44,6 +44,16 @@ describe('secondary window launch payloads', () => {
     expect(decodeAppWindowLaunch(encodeAppWindowLaunch(launch))).toEqual(launch);
   });
 
+  it('round-trips an opaque live-tab transfer', () => {
+    const launch: AppWindowLaunch = {
+      kind: 'tab-transfer',
+      transferId: 'opaque-transfer-token',
+      title: 'Serial console',
+    };
+
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(launch))).toEqual(launch);
+  });
+
   it('accepts cross-platform Telnet and serial session launches', () => {
     const telnet: AppWindowLaunch = {
       kind: 'session',
@@ -94,6 +104,9 @@ describe('secondary window launch payloads', () => {
       isAppWindowLaunch({ kind: 'workspace', title: 'Operations', workspaceId: '' }),
     ).toBe(false);
     expect(isAppWindowLaunch({ kind: 'session', title: 'Missing profile' })).toBe(false);
+    expect(
+      isAppWindowLaunch({ kind: 'tab-transfer', title: 'Router', transferId: '' }),
+    ).toBe(false);
     expect(
       isAppWindowLaunch({
         kind: 'session',

--- a/tests/unit/electron/tab-detach.test.ts
+++ b/tests/unit/electron/tab-detach.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { pointInsideAnyWindow } from '../../../electron/src/tab-detach.js';
+
+describe('native tab detach bounds', () => {
+  const windows = [
+    { x: 100, y: 50, width: 800, height: 600 },
+    { x: 1_000, y: 100, width: 500, height: 400 },
+  ];
+
+  it('recognizes points inside either Muxus window', () => {
+    expect(pointInsideAnyWindow({ x: 100, y: 50 }, windows)).toBe(true);
+    expect(pointInsideAnyWindow({ x: 899, y: 649 }, windows)).toBe(true);
+    expect(pointInsideAnyWindow({ x: 1_250, y: 300 }, windows)).toBe(true);
+  });
+
+  it('leaves outer edges and desktop points available for detaching', () => {
+    expect(pointInsideAnyWindow({ x: 900, y: 300 }, windows)).toBe(false);
+    expect(pointInsideAnyWindow({ x: 1_500, y: 300 }, windows)).toBe(false);
+    expect(pointInsideAnyWindow({ x: 50, y: 20 }, windows)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add **Edit host** and **Close tabs to the right** to the session-tab menu
- add **Move to new window**, transferring the existing live session instead of redialing it
- detach a tab into a new window when it is dropped outside every visible Muxus window
- preserve serial sessions and terminal state through opaque cross-window transfer tokens
- cover host resolution, close targeting, transfer payloads, and native detach bounds with tests

## Why

**Open in new window** creates a fresh connection, which is unsuitable for exclusive serial devices. The new move and detach paths hand off the existing terminal session and remove the source tab only after the destination takes ownership.

The initial renderer-coordinate approach for detecting desktop drops was unreliable in Electron. Detach detection now uses the main process's native cursor position and BrowserWindow bounds, while suppressing a new window when the tab was dropped onto another Muxus window.

Closes #126

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm check:bundle`
- `pnpm --filter @muxus/electron build`
- focused client and Electron unit tests (72 client tests plus native detach coverage)
