### PR TITLE
Hide file links when SFTP is disabled

### DIFF
--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -697,7 +697,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
                 .tabs.find((candidate) => candidate.id === tab.id);
               return (
                 current?.profile?.kind === 'local' ||
-                (current?.profile?.kind === 'ssh' && current.sftpAvailable !== false)
+                (current?.profile?.kind === 'ssh' && current.sftpAvailable === true)
               );
             },
           )

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -691,6 +691,15 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
                 usePrefsStore.getState().terminalFileLinkActivation,
                 IS_MAC,
               ),
+            () => {
+              const current = useTabsStore
+                .getState()
+                .tabs.find((candidate) => candidate.id === tab.id);
+              return (
+                current?.profile?.kind === 'local' ||
+                (current?.profile?.kind === 'ssh' && current.sftpAvailable !== false)
+              );
+            },
           )
         : undefined;
 

--- a/client/src/terminal/file-links.ts
+++ b/client/src/terminal/file-links.ts
@@ -406,9 +406,15 @@ export function attachTerminalFileLinks(
   term: Terminal,
   onOpen: (candidate: string) => void | Promise<void>,
   activation: TerminalFileLinkActivation | (() => TerminalFileLinkActivation) = 'direct',
+  enabled: boolean | (() => boolean) = true,
 ): IDisposable {
   return term.registerLinkProvider({
     provideLinks: (bufferLineNumber, callback) => {
+      const currentEnabled = typeof enabled === 'function' ? enabled() : enabled;
+      if (!currentEnabled) {
+        callback(undefined);
+        return;
+      }
       const links = mappedFileLinks(term, bufferLineNumber).map(({ candidate, range, text }) => {
         const link: ILink = {
           range,

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -239,10 +239,10 @@ describe('terminal file links', () => {
     expect(links![0]!.decorations).toEqual({ pointerCursor: true, underline: true });
   });
 
-  it('does not create file links while the session disables them', () => {
+  it('does not create file links until the session positively enables them', () => {
     const { terminal, provider } = terminalWithLine('output: src/main.ts');
-    let enabled = false;
-    attachTerminalFileLinks(terminal, vi.fn(), 'direct', () => enabled);
+    let available: boolean | undefined;
+    attachTerminalFileLinks(terminal, vi.fn(), 'direct', () => available === true);
 
     let links: ProvidedLink[] | undefined;
     provider().provideLinks(1, (provided) => {
@@ -250,7 +250,13 @@ describe('terminal file links', () => {
     });
     expect(links).toBeUndefined();
 
-    enabled = true;
+    available = false;
+    provider().provideLinks(1, (provided) => {
+      links = provided;
+    });
+    expect(links).toBeUndefined();
+
+    available = true;
     provider().provideLinks(1, (provided) => {
       links = provided;
     });

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -239,6 +239,24 @@ describe('terminal file links', () => {
     expect(links![0]!.decorations).toEqual({ pointerCursor: true, underline: true });
   });
 
+  it('does not create file links while the session disables them', () => {
+    const { terminal, provider } = terminalWithLine('output: src/main.ts');
+    let enabled = false;
+    attachTerminalFileLinks(terminal, vi.fn(), 'direct', () => enabled);
+
+    let links: ProvidedLink[] | undefined;
+    provider().provideLinks(1, (provided) => {
+      links = provided;
+    });
+    expect(links).toBeUndefined();
+
+    enabled = true;
+    provider().provideLinks(1, (provided) => {
+      links = provided;
+    });
+    expect(links).toHaveLength(1);
+  });
+
   it.each([
     ['direct', {}, { altKey: true }],
     ['alt', { altKey: true }, {}],


### PR DESCRIPTION
## Summary

- Stop advertising terminal file hyperlinks when the live SSH connection reports that SFTP is unavailable.
- Keep link availability responsive to reconnects without remounting the terminal.
- Add regression coverage for disabled and re-enabled link creation.

## Root cause

The file-open handler rejected disabled SFTP sessions, but the terminal link provider still created and decorated path links unconditionally.

## Impact

Hosts with SFTP disabled no longer show remote file hyperlinks. Local sessions and SFTP-capable SSH hosts are unaffected.

## Testing

- `pnpm test` — 927 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`

Fixes #127