### PR TITLE
Prevent tab drags from creating desktop text files

### DIFF
--- a/client/src/tab-drag.ts
+++ b/client/src/tab-drag.ts
@@ -1,5 +1,4 @@
 export const TAB_TRANSFER_MIME = 'application/x-muxus-tab';
-const TEXT_PREFIX = 'muxus-tab:';
 
 let active: { tabId: string; transferId: string } | undefined;
 
@@ -29,8 +28,10 @@ export function endTabDrag(transferId: string): void {
 }
 
 export function writeTabTransfer(dataTransfer: DataTransfer, transferId: string): void {
+  // A text/plain payload is exported by the OS as a "Dragged Text" file when
+  // the pointer leaves the window. Keep tab drags private to Muxus instead.
+  dataTransfer.clearData();
   dataTransfer.setData(TAB_TRANSFER_MIME, transferId);
-  dataTransfer.setData('text/plain', `${TEXT_PREFIX}${transferId}`);
 }
 
 export function hasTabTransfer(dataTransfer: DataTransfer): boolean {
@@ -41,9 +42,7 @@ export function hasTabTransfer(dataTransfer: DataTransfer): boolean {
 
 export function readTabTransfer(dataTransfer: DataTransfer): string | undefined {
   const custom = dataTransfer.getData(TAB_TRANSFER_MIME);
-  if (custom) return custom;
-  const text = dataTransfer.getData('text/plain');
-  return text.startsWith(TEXT_PREFIX) ? text.slice(TEXT_PREFIX.length) : undefined;
+  return custom || undefined;
 }
 
 interface WindowScreenBounds {

--- a/tests/unit/client/tab-transfer.test.ts
+++ b/tests/unit/client/tab-transfer.test.ts
@@ -33,6 +33,11 @@ class TestDataTransfer {
     this.values.set(type, value);
   }
 
+  clearData(type?: string): void {
+    if (type === undefined) this.values.clear();
+    else this.values.delete(type);
+  }
+
   getData(type: string): string {
     return this.values.get(type) ?? '';
   }
@@ -140,13 +145,15 @@ describe('cross-window tab transfer', () => {
     vi.resetModules();
     const transfer = await import('../../../client/src/tab-drag.js');
     const data = new TestDataTransfer();
+    data.setData('text/plain', 'Router');
 
     transfer.writeTabTransfer(data as never, 'opaque-token');
 
     expect(transfer.hasTabTransfer(data as never)).toBe(true);
     expect(transfer.readTabTransfer(data as never)).toBe('opaque-token');
     expect(data.getData(transfer.TAB_TRANSFER_MIME)).toBe('opaque-token');
-    expect(data.getData('text/plain')).toBe('muxus-tab:opaque-token');
+    expect(data.getData('text/plain')).toBe('');
+    expect(data.types).toEqual([transfer.TAB_TRANSFER_MIME]);
   });
 
   it('detaches rejected drops only when they end outside the source window', async () => {


### PR DESCRIPTION
## Summary

- remove the `text/plain` fallback from terminal-tab drag payloads
- clear any browser-provided drag data before adding the private Muxus transfer type
- retain cross-window tab moves and detach behavior through `application/x-muxus-tab`
- add regression coverage ensuring tab drags expose no plain-text payload

## Why

Dragging a tab outside the application published its transfer token as `text/plain`. The operating system interpreted that as exported text and created a `Dragged Text-…` file on the desktop while Muxus detached the tab.

Tab transfers now use only the application-private MIME type, so the drag remains internal to Muxus and the desktop no longer receives text to materialize as a file.

## Validation

- focused tab-transfer unit tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @muxus/client build`
- `pnpm --filter @muxus/electron build`