### PR TITLE
Fix terminal URL activation gesture

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -575,7 +575,7 @@ function TerminalSection() {
           </TextField>
           <TextField
             select
-            label="Open terminal file links"
+            label="Open terminal links"
             value={terminalFileLinkActivationForPlatform(
               prefs.terminalFileLinkActivation,
               IS_MAC,

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -486,7 +486,20 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     term.loadAddon(fit);
     term.loadAddon(new Unicode11Addon());
     term.unicode.activeVersion = '11';
-    term.loadAddon(new WebLinksAddon(openTerminalWebLink));
+    term.loadAddon(
+      new WebLinksAddon((event, uri) =>
+        openTerminalWebLink(
+          event,
+          uri,
+          () =>
+            terminalFileLinkActivationForPlatform(
+              usePrefsStore.getState().terminalFileLinkActivation,
+              IS_MAC,
+            ),
+          () => term.clearSelection(),
+        ),
+      ),
+    );
     // xterm 6.1 streams Kitty APC payloads straight into ImageAddon's WASM
     // base64 decoder. This also handles Sixel and iTerm2 inline images.
     const image = new ImageAddon({

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -106,7 +106,7 @@ export interface PrefsState {
   allowOsc52ClipboardWrite: boolean;
   /** Right-click: copy selection / paste (terminal convention), always paste, or context menu. */
   rightClickAction: RightClickAction;
-  /** Mouse gesture that opens a detected terminal file path in the editor. */
+  /** Mouse gesture that opens a detected terminal file path or web URL. */
   terminalFileLinkActivation: TerminalFileLinkActivation;
   /** Preview multiline pastes before they can run several shell commands. */
   pasteWarnMultiline: boolean;

--- a/client/src/terminal/file-link-activation.ts
+++ b/client/src/terminal/file-link-activation.ts
@@ -34,6 +34,18 @@ export function terminalFileLinkActivationForPlatform(
   return activation;
 }
 
+/** Match only the configured left-click gesture, leaving every other click to the terminal. */
+export function terminalLinkActivationMatches(
+  event: Pick<MouseEvent, 'altKey' | 'button' | 'ctrlKey' | 'metaKey' | 'shiftKey'>,
+  activation: TerminalFileLinkActivation,
+): boolean {
+  if (event.button !== 0 || event.shiftKey) return false;
+  if (activation === 'direct') return !event.altKey && !event.ctrlKey && !event.metaKey;
+  if (activation === 'alt') return event.altKey && !event.ctrlKey && !event.metaKey;
+  if (activation === 'ctrl') return event.ctrlKey && !event.altKey && !event.metaKey;
+  return event.metaKey && !event.altKey && !event.ctrlKey;
+}
+
 /** Keep xterm's Alt cursor movement from competing with an Alt file-open gesture. */
 export function altClickMovesCursorForFileLinkActivation(
   activation: TerminalFileLinkActivation,

--- a/client/src/terminal/file-links.ts
+++ b/client/src/terminal/file-links.ts
@@ -1,5 +1,6 @@
 import type { IDisposable, ILink, Terminal } from '@xterm/xterm';
 import type { TerminalFileLinkActivation } from '../state/prefs.js';
+import { terminalLinkActivationMatches } from './file-link-activation.js';
 
 const MAX_LOGICAL_LINE_LENGTH = 4_096;
 const SHELL_TOKEN_BOUNDARY = /\s/;
@@ -390,17 +391,6 @@ function mappedFileLinks(term: Terminal, bufferLineNumber: number): MappedTermin
   return links;
 }
 
-function activationMatches(
-  event: MouseEvent,
-  activation: TerminalFileLinkActivation,
-): boolean {
-  if (event.shiftKey) return false;
-  if (activation === 'direct') return !event.altKey && !event.ctrlKey && !event.metaKey;
-  if (activation === 'alt') return event.altKey && !event.ctrlKey && !event.metaKey;
-  if (activation === 'ctrl') return event.ctrlKey && !event.altKey && !event.metaKey;
-  return event.metaKey && !event.altKey && !event.ctrlKey;
-}
-
 /** Register file links while leaving non-activating clicks available for terminal selection. */
 export function attachTerminalFileLinks(
   term: Terminal,
@@ -425,7 +415,7 @@ export function attachTerminalFileLinks(
           activate: (event) => {
             const currentActivation =
               typeof activation === 'function' ? activation() : activation;
-            if (event.button !== 0 || !activationMatches(event, currentActivation)) return;
+            if (!terminalLinkActivationMatches(event, currentActivation)) return;
             event.preventDefault();
             event.stopPropagation();
             // A tiny pointer movement can create a selection before xterm

--- a/client/src/terminal/web-links.ts
+++ b/client/src/terminal/web-links.ts
@@ -1,3 +1,6 @@
+import type { TerminalFileLinkActivation } from '../state/prefs.js';
+import { terminalLinkActivationMatches } from './file-link-activation.js';
+
 const WEB_PROTOCOLS = new Set(['http:', 'https:']);
 
 /**
@@ -6,7 +9,15 @@ const WEB_PROTOCOLS = new Set(['http:', 'https:']);
  * browser; WebLinksAddon's default two-step about:blank flow is denied before
  * it can assign the real URL.
  */
-export function openTerminalWebLink(event: MouseEvent, uri: string): void {
+export function openTerminalWebLink(
+  event: MouseEvent,
+  uri: string,
+  activation: TerminalFileLinkActivation | (() => TerminalFileLinkActivation) = 'direct',
+  clearSelection?: () => void,
+): void {
+  const currentActivation = typeof activation === 'function' ? activation() : activation;
+  if (!terminalLinkActivationMatches(event, currentActivation)) return;
+
   let url: string;
   try {
     const parsed = new URL(uri);
@@ -18,5 +29,6 @@ export function openTerminalWebLink(event: MouseEvent, uri: string): void {
 
   event.preventDefault();
   event.stopPropagation();
+  clearSelection?.();
   window.open(url, '_blank', 'noopener');
 }

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -41,9 +41,10 @@ because storage policy should not change under a running recorder.
 - **Cursor**: block, underline or bar, blinking or not.
 - **Right-click**: copy-selection-otherwise-paste (the terminal convention), always paste,
   or a context menu.
-- **Open terminal file links**: choose Alt or direct left click on every platform, plus Ctrl
-  on Linux and Windows or Cmd on macOS. Alt + left click is the default so ordinary clicks
-  and double-clicks remain available for terminal text selection.
+- **Open terminal links**: choose Alt or direct left click on every platform, plus Ctrl on
+  Linux and Windows or Cmd on macOS. The gesture applies to both file paths and web URLs.
+  Alt + left click is the default so ordinary clicks and double-clicks remain available for
+  terminal text selection.
 - **Copy on select**, **OSC 52 clipboard writes** from terminal programs such as tmux and
   Zellij, and the **multiline paste confirmation**. OSC 52 reads remain blocked so a
   terminal program cannot retrieve the local clipboard.

--- a/tests/unit/client/terminal-file-links.test.ts
+++ b/tests/unit/client/terminal-file-links.test.ts
@@ -339,31 +339,80 @@ describe('terminal file links', () => {
 });
 
 describe('terminal web links', () => {
-  it('opens a valid web URL directly so Electron can hand it to the system browser', () => {
+  it.each([
+    ['direct', {}, { altKey: true }],
+    ['alt', { altKey: true }, {}],
+    ['ctrl', { ctrlKey: true }, {}],
+    ['meta', { metaKey: true }, {}],
+  ] as const)(
+    'opens a valid web URL only for the configured %s activation gesture',
+    (activation, matchingModifiers, nonMatchingModifiers) => {
+      const open = vi.fn();
+      const clearSelection = vi.fn();
+      vi.stubGlobal('window', { open });
+
+      const wrongButton = mouseEvent(matchingModifiers, 2);
+      openTerminalWebLink(wrongButton.event, 'https://google.com', activation, clearSelection);
+
+      const ignored = mouseEvent(nonMatchingModifiers);
+      openTerminalWebLink(ignored.event, 'https://google.com', activation, clearSelection);
+
+      const selectionGesture = mouseEvent({ ...matchingModifiers, shiftKey: true });
+      openTerminalWebLink(
+        selectionGesture.event,
+        'https://google.com',
+        activation,
+        clearSelection,
+      );
+
+      expect(open).not.toHaveBeenCalled();
+      expect(ignored.preventDefault).not.toHaveBeenCalled();
+      expect(ignored.stopPropagation).not.toHaveBeenCalled();
+
+      const matching = mouseEvent(matchingModifiers);
+      openTerminalWebLink(matching.event, 'https://google.com', activation, clearSelection);
+
+      expect(open).toHaveBeenCalledWith('https://google.com/', '_blank', 'noopener');
+      expect(matching.preventDefault).toHaveBeenCalledOnce();
+      expect(matching.stopPropagation).toHaveBeenCalledOnce();
+      expect(clearSelection).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('reads the activation setting when clicked so open terminals update immediately', () => {
     const open = vi.fn();
     vi.stubGlobal('window', { open });
-    const preventDefault = vi.fn();
-    const stopPropagation = vi.fn();
+    let activation: 'alt' | 'ctrl' = 'alt';
 
     openTerminalWebLink(
-      { preventDefault, stopPropagation } as unknown as MouseEvent,
+      mouseEvent({ ctrlKey: true }).event,
       'https://google.com',
+      () => activation,
+    );
+    expect(open).not.toHaveBeenCalled();
+
+    activation = 'ctrl';
+
+    openTerminalWebLink(
+      mouseEvent({ ctrlKey: true }).event,
+      'https://google.com',
+      () => activation,
     );
 
     expect(open).toHaveBeenCalledWith('https://google.com/', '_blank', 'noopener');
-    expect(preventDefault).toHaveBeenCalledOnce();
-    expect(stopPropagation).toHaveBeenCalledOnce();
   });
 
   it('ignores malformed and non-web URLs', () => {
     const open = vi.fn();
     vi.stubGlobal('window', { open });
-    const event = { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as MouseEvent;
+    const event = mouseEvent();
 
-    openTerminalWebLink(event, 'file:///etc/passwd');
-    openTerminalWebLink(event, 'not a URL');
+    openTerminalWebLink(event.event, 'file:///etc/passwd');
+    openTerminalWebLink(event.event, 'not a URL');
 
     expect(open).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- apply the configured terminal link activation gesture to web URLs as well as file paths
- keep non-matching clicks available for terminal text selection
- clear incidental selections after a URL is deliberately opened
- rename the setting label to **Open terminal links** and document that it covers both link types

## Why

Terminal web URLs were handled directly by the xterm web-links callback, bypassing the modifier checks used by terminal file links. As a result, an ordinary click could open a URL while the default file-link behavior required Alt + left click.

This makes URL and file-link interactions consistent and preserves normal click and double-click text selection.

Closes #134.

## Validation

- `pnpm exec vitest run unit/client/terminal-file-links.test.ts` — 28 tests passed
- full unit suite — 931 tests passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`