### PR TITLE
Fix Windows ARM64 serial I/O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           $app = "electron/release/win-arm64-unpacked/resources/app.asar.unpacked/node_modules"
           $binaries = @(
             "$app/node-pty/prebuilds/win32-arm64/pty.node"
-            "$app/@serialport/bindings-cpp/prebuilds/win32-arm64/@serialport+bindings-cpp.armv8.node"
+            "$app/@serialport/bindings-cpp/build/Release/bindings.node"
           )
           foreach ($binary in $binaries) {
             if (-not (Test-Path -LiteralPath $binary)) {

--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -56,7 +56,7 @@ The desktop build rebuilds `node-pty` and `serialport` against Electron's ABI. B
 `pnpm electron` dev run:
 
 ```bash
-pnpm --filter @muxus/electron rebuild
+pnpm --filter @muxus/electron run rebuild
 ```
 
 ## Installers

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -18,6 +18,10 @@ extraResources:
 icon: build/icon.png
 artifactName: muxus-${version}-${os}-${arch}.${ext}
 npmRebuild: true
+# Muxus carries a source patch for @serialport/bindings-cpp's Windows APC
+# completion handling. Do not replace it with the package's stale ARM64
+# prebuild, which treats its internal baton pointer as an event handle.
+buildDependenciesFromSource: true
 win:
   target:
     - target: nsis

--- a/electron/package.json
+++ b/electron/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@muxus/shared": "workspace:*",
     "@napi-rs/keyring": "^1.3.0",
+    "@serialport/bindings-cpp": "13.0.0",
     "node-pty": "^1.1.0",
     "serialport": "^13.0.0"
   },

--- a/patches/@serialport__bindings-cpp@13.0.0.patch
+++ b/patches/@serialport__bindings-cpp@13.0.0.patch
@@ -1,0 +1,70 @@
+diff --git a/src/serialport_win.cpp b/src/serialport_win.cpp
+index 7e79216a37635a41d1c2db030f4009ea5d0d24b2..7f8bac6f701a7fcabfe96b2a61df3e381ca59366 100644
+--- a/src/serialport_win.cpp
++++ b/src/serialport_win.cpp
+@@ -326,18 +326,28 @@ bool IsClosingHandle(int fd) {
+ 
+ void __stdcall WriteIOCompletion(DWORD errorCode, DWORD bytesTransferred, OVERLAPPED* ov) {
+   WriteBaton* baton = static_cast<WriteBaton*>(ov->hEvent);
+-  DWORD bytesWritten;
+-  if (!GetOverlappedResult(int2handle(baton->fd), ov, &bytesWritten, TRUE)) {
+-    errorCode = GetLastError();
+-    ErrorCodeToString("Writing to COM port (GetOverlappedResult)", errorCode, baton->errorString);
++
++  if (errorCode) {
++    ErrorCodeToString("Writing to COM port (WriteIOCompletion)", errorCode, baton->errorString);
+     baton->complete = true;
+     return;
+   }
+-  if (bytesWritten) {
+-    baton->offset += bytesWritten;
++
++  // bytesTransferred is already provided by the APC completion callback.
++  // Do NOT call GetOverlappedResult here — MSDN explicitly states:
++  //   "Do not use GetOverlappedResult for I/O operations that use
++  //    ReadFileEx or WriteFileEx completion routines."
++  // The overlapped's hEvent holds a WriteBaton pointer (not a Windows event
++  // handle), so GetOverlappedResult fails with ERROR_INVALID_HANDLE on
++  // drivers that inspect hEvent (e.g. usbser.sys used by USB serial chips).
++  if (bytesTransferred) {
++    baton->offset += bytesTransferred;
+     if (baton->offset >= baton->bufferLength) {
+       baton->complete = true;
+     }
++  } else {
++    // Zero-byte completion with no error — avoid hanging in WriteThread.
++    baton->complete = true;
+   }
+ }
+ 
+@@ -441,13 +451,15 @@ void __stdcall ReadIOCompletion(DWORD errorCode, DWORD bytesTransferred, OVERLAP
+     return;
+   }
+ 
++  // bytesTransferred is already provided by the APC completion callback.
++  // Do NOT call GetOverlappedResult here — MSDN explicitly states:
++  //   "Do not use GetOverlappedResult for I/O operations that use
++  //    ReadFileEx or WriteFileEx completion routines."
++  // The overlapped's hEvent holds a ReadBaton pointer (not a Windows event
++  // handle), so GetOverlappedResult fails with ERROR_INVALID_HANDLE on
++  // drivers that inspect hEvent (e.g. usbser.sys used by ESP32 native USB).
++
+   DWORD lastError;
+-  if (!GetOverlappedResult(int2handle(baton->fd), ov, &bytesTransferred, TRUE)) {
+-    lastError = GetLastError();
+-    ErrorCodeToString("Reading from COM port (GetOverlappedResult)", lastError, baton->errorString);
+-    baton->complete = true;
+-    return;
+-  }
+   if (bytesTransferred) {
+     baton->bytesToRead -= bytesTransferred;
+     baton->bytesRead += bytesTransferred;
+@@ -455,7 +467,7 @@ void __stdcall ReadIOCompletion(DWORD errorCode, DWORD bytesTransferred, OVERLAP
+   }
+   if (!baton->bytesToRead) {
+     baton->complete = true;
+-    CloseHandle(ov->hEvent);
++    // Note: ov->hEvent is a baton pointer, not a Windows handle — do not CloseHandle
+     return;
+   }
+ 

--- a/patches/@serialport__bindings-cpp@13.0.0.patch
+++ b/patches/@serialport__bindings-cpp@13.0.0.patch
@@ -2,7 +2,7 @@ diff --git a/src/serialport_win.cpp b/src/serialport_win.cpp
 index 7e79216a37635a41d1c2db030f4009ea5d0d24b2..7f8bac6f701a7fcabfe96b2a61df3e381ca59366 100644
 --- a/src/serialport_win.cpp
 +++ b/src/serialport_win.cpp
-@@ -326,18 +326,28 @@ bool IsClosingHandle(int fd) {
+@@ -326,18 +326,30 @@ bool IsClosingHandle(int fd) {
  
  void __stdcall WriteIOCompletion(DWORD errorCode, DWORD bytesTransferred, OVERLAPPED* ov) {
    WriteBaton* baton = static_cast<WriteBaton*>(ov->hEvent);
@@ -32,7 +32,9 @@ index 7e79216a37635a41d1c2db030f4009ea5d0d24b2..7f8bac6f701a7fcabfe96b2a61df3e38
        baton->complete = true;
      }
 +  } else {
-+    // Zero-byte completion with no error — avoid hanging in WriteThread.
++    // Avoid hanging while still surfacing the incomplete write.
++    _snprintf_s(baton->errorString, ERROR_STRING_SIZE, _TRUNCATE,
++                "Writing to COM port (WriteIOCompletion): zero bytes transferred");
 +    baton->complete = true;
    }
  }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   brace-expansion@>=5.0.0 <5.0.8: 5.0.8
   dompurify@>=3.4.0 <3.4.12: 3.4.12
 
+patchedDependencies:
+  '@serialport/bindings-cpp@13.0.0': 1b9fdeec738893532bb06e0a4b6281e811c97d3ae6facc5d7e59c00cb6d40dba
+
 importers:
 
   .:
@@ -4300,7 +4303,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@serialport/bindings-cpp@13.0.0(supports-color@7.2.0)':
+  '@serialport/bindings-cpp@13.0.0(patch_hash=1b9fdeec738893532bb06e0a4b6281e811c97d3ae6facc5d7e59c00cb6d40dba)(supports-color@7.2.0)':
     dependencies:
       '@serialport/bindings-interface': 1.2.2
       '@serialport/parser-readline': 12.0.0
@@ -6050,7 +6053,7 @@ snapshots:
   serialport@13.0.0(supports-color@7.2.0):
     dependencies:
       '@serialport/binding-mock': 10.2.2(supports-color@7.2.0)
-      '@serialport/bindings-cpp': 13.0.0(supports-color@7.2.0)
+      '@serialport/bindings-cpp': 13.0.0(patch_hash=1b9fdeec738893532bb06e0a4b6281e811c97d3ae6facc5d7e59c00cb6d40dba)(supports-color@7.2.0)
       '@serialport/parser-byte-length': 13.0.0
       '@serialport/parser-cctalk': 13.0.0
       '@serialport/parser-delimiter': 13.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@napi-rs/keyring':
         specifier: ^1.3.0
         version: 1.3.0
+      '@serialport/bindings-cpp':
+        specifier: 13.0.0
+        version: 13.0.0(patch_hash=ccb198c80fb1ddcec527a44a9df5ada0b5b49112eaf75cb0fbd0397b15ff2cf4)(supports-color@7.2.0)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   dompurify@>=3.4.0 <3.4.12: 3.4.12
 
 patchedDependencies:
-  '@serialport/bindings-cpp@13.0.0': 1b9fdeec738893532bb06e0a4b6281e811c97d3ae6facc5d7e59c00cb6d40dba
+  '@serialport/bindings-cpp@13.0.0': ccb198c80fb1ddcec527a44a9df5ada0b5b49112eaf75cb0fbd0397b15ff2cf4
 
 importers:
 
@@ -4303,7 +4303,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@serialport/bindings-cpp@13.0.0(patch_hash=1b9fdeec738893532bb06e0a4b6281e811c97d3ae6facc5d7e59c00cb6d40dba)(supports-color@7.2.0)':
+  '@serialport/bindings-cpp@13.0.0(patch_hash=ccb198c80fb1ddcec527a44a9df5ada0b5b49112eaf75cb0fbd0397b15ff2cf4)(supports-color@7.2.0)':
     dependencies:
       '@serialport/bindings-interface': 1.2.2
       '@serialport/parser-readline': 12.0.0
@@ -6053,7 +6053,7 @@ snapshots:
   serialport@13.0.0(supports-color@7.2.0):
     dependencies:
       '@serialport/binding-mock': 10.2.2(supports-color@7.2.0)
-      '@serialport/bindings-cpp': 13.0.0(patch_hash=1b9fdeec738893532bb06e0a4b6281e811c97d3ae6facc5d7e59c00cb6d40dba)(supports-color@7.2.0)
+      '@serialport/bindings-cpp': 13.0.0(patch_hash=ccb198c80fb1ddcec527a44a9df5ada0b5b49112eaf75cb0fbd0397b15ff2cf4)(supports-color@7.2.0)
       '@serialport/parser-byte-length': 13.0.0
       '@serialport/parser-cctalk': 13.0.0
       '@serialport/parser-delimiter': 13.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,5 @@ allowBuilds:
   electron-winstaller: false
   cpu-features: false
   '@serialport/bindings-cpp': true
+patchedDependencies:
+  '@serialport/bindings-cpp@13.0.0': patches/@serialport__bindings-cpp@13.0.0.patch


### PR DESCRIPTION
## Summary

- patch `@serialport/bindings-cpp@13.0.0` with the upstream Windows completion-routine fix
- consume the byte count supplied by `ReadFileEx`/`WriteFileEx` callbacks instead of passing the baton pointer in `OVERLAPPED.hEvent` to `GetOverlappedResult` or `CloseHandle`
- build native dependencies from source so packaged applications contain the patched binding
- verify the rebuilt Windows ARM64 binding path in CI
- correct the documented Electron rebuild command

## Root cause

The Windows binding stores its internal baton pointer in `OVERLAPPED.hEvent`. Its APC completion callbacks then treat that pointer as a Windows event handle by calling `GetOverlappedResult` and `CloseHandle`. Drivers that inspect `hEvent`, including `usbser.sys` on Windows ARM64, consequently fail with `ERROR_INVALID_HANDLE`.

The patch follows serialport/bindings-cpp#238 and addresses the behavior reported in serialport/bindings-cpp#241.

Closes #135.

## Impact

Windows ARM64 serial connections can read and write without the invalid-handle failure. Packaged builds compile native dependencies from source rather than selecting the stale unpatched ARM64 prebuild.

## Validation

- frozen pnpm install
- Electron native dependency rebuild
- test suite: 931 passed, 3 skipped
- typecheck
- lint
- full build
- Linux x64 unpacked Electron packaging

A physical Windows ARM64 serial device was not available for a hardware test.