### PR TITLE
docs: add release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ pnpm start
 For development setup, architecture, the security model and how the screenshots are
 generated, use the docs.
 
+## Support
+
+<a href="https://www.buymeacoffee.com/FloSch62">
+  <img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" height="60">
+</a>
+
 ## License
 
 [MIT](./LICENSE)

--- a/docs/release-notes/0.1.md
+++ b/docs/release-notes/0.1.md
@@ -21,9 +21,8 @@ live beside them in the same workspace.
 
 ## Files, editors and tunnels
 
-Each SSH session can open an SFTP browser over its existing connection. Remote files open in
-the built-in Monaco editor, while saved local, remote and dynamic forwards keep running
-independently of terminal tabs.
+Each SSH session can open an SFTP browser. Remote files open in the built-in Monaco editor,
+while saved local, remote and dynamic forwards keep running independently of terminal tabs.
 
 The quick launcher searches hosts, tabs, workspaces, commands, tunnels and retained session
 history from one place.
@@ -37,4 +36,13 @@ repetitive work around a shell without taking control away from it.
 Muxus runs locally and binds its server to the loopback interface. Host organization,
 workspaces, preferences and history stay in a local database.
 
-[View the v0.1.0 release on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.1.0)
+## Patches
+
+### 0.1.1
+
+:material-calendar: 26 July 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.1.0...4510a80)
+
+- Windows desktop builds use a compatible Electron release to restore GPU rendering.
+- Saved workspace layouts appear before the first paint instead of flashing an empty window.
+
+[View the v0.1.1 source on GitHub](https://github.com/FloSch62/muxus/tree/4510a80)

--- a/docs/release-notes/0.1.md
+++ b/docs/release-notes/0.1.md
@@ -1,0 +1,40 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.1
+
+:material-calendar: 25 July 2026 · [View release](https://github.com/FloSch62/muxus/releases/tag/v0.1.0)
+
+Release 0.1 is the first public version of Muxus: a local SSH, Telnet and serial client
+built around OpenSSH hosts, reusable workspaces and a modern terminal.
+
+## The first Muxus workspace
+
+The initial release reads the hosts already present in `~/.ssh/config` and writes edits back
+to the same files. Open a host in a tab, divide the window into resizable panes and save the
+whole arrangement as a workspace that can be restored later.
+
+SSH sessions support jump hosts, proxy commands, certificates, agents and the usual key and
+password authentication methods. Local shells, Telnet connections and serial consoles can
+live beside them in the same workspace.
+
+## Files, editors and tunnels
+
+Each SSH session can open an SFTP browser over its existing connection. Remote files open in
+the built-in Monaco editor, while saved local, remote and dynamic forwards keep running
+independently of terminal tabs.
+
+The quick launcher searches hosts, tabs, workspaces, commands, tunnels and retained session
+history from one place.
+
+## A terminal that draws
+
+The terminal supports kitty, Sixel and iTerm2 images, the kitty keyboard protocol and Nerd
+Font symbols. Reusable command buttons, keyword highlighting and multi-execution cover the
+repetitive work around a shell without taking control away from it.
+
+Muxus runs locally and binds its server to the loopback interface. Host organization,
+workspaces, preferences and history stay in a local database.
+
+[View the v0.1.0 release on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.1.0)

--- a/docs/release-notes/0.2.md
+++ b/docs/release-notes/0.2.md
@@ -1,0 +1,39 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.2
+
+:material-calendar: 26 July 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/v0.1.0...v0.2.0)
+
+Release 0.2 makes interrupted sessions recoverable. Remote terminals reconnect in place,
+saved scrollback returns with a restored workspace and installed desktop builds can tell you
+when a newer Muxus release is available.
+
+## Reconnect without rebuilding the tab
+
+When an SSH, Telnet or serial connection closes unexpectedly, the existing tab offers to
+reconnect with the same profile. Reconnecting preserves the tab's place in its pane instead
+of making you rebuild the surrounding workspace.
+
+Saved workspaces restore retained terminal history before the first window is shown. A clear
+divider separates that snapshot from new output, and local sessions recover automatically
+when possible.
+
+## Desktop releases and update notifications
+
+Release builds are packaged for Windows, macOS and Linux. Muxus checks the release manifest
+published with its documentation and shows a notification when a newer version is available.
+The notification links to the matching GitHub release rather than updating the application
+behind your back.
+
+## Patches
+
+### 0.2.1
+
+:material-calendar: 28 July 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.2.0...v0.2.1)
+
+- Split panes and SFTP sessions reuse a shared SSH transport instead of opening another login.
+- Connection lifetime is tracked independently so closing one consumer does not interrupt the others.
+
+[View the 0.2 releases on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.2.1)

--- a/docs/release-notes/0.2.md
+++ b/docs/release-notes/0.2.md
@@ -36,4 +36,13 @@ behind your back.
 - Split panes and SFTP sessions reuse a shared SSH transport instead of opening another login.
 - Connection lifetime is tracked independently so closing one consumer does not interrupt the others.
 
-[View the 0.2 releases on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.2.1)
+### 0.2.2
+
+:material-calendar: 29 July 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.2.1...261e107)
+
+- SSH connections honour configured algorithms, agent and host-key policies and startup options.
+- The host editor exposes the same connection settings resolved from OpenSSH configuration.
+- MobaXterm sessions can be imported with their folders and connection settings.
+- Restored-output dividers stay out of later scrollback snapshots.
+
+[View the v0.2.2 source on GitHub](https://github.com/FloSch62/muxus/tree/261e107)

--- a/docs/release-notes/0.3.md
+++ b/docs/release-notes/0.3.md
@@ -4,20 +4,10 @@ icon: lucide/scroll-text
 
 # Release 0.3
 
-:material-calendar: 29 July 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/v0.2.1...v0.3.0)
+:material-calendar: 29 July 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/261e107...12b99bf)
 
-Release 0.3 deepens OpenSSH compatibility and gives saved passwords a proper encrypted vault.
-It also introduces MobaXterm import, making it possible to bring an existing session library
-into Muxus without recreating every host by hand.
-
-## More of `ssh_config`, end to end
-
-Muxus now honours configured ciphers, key-exchange methods, host-key algorithms and MACs when
-dialling. Agent forwarding, host-key policy, TTY requests, remote commands and other startup
-options are exposed in the host editor as well as resolved from OpenSSH configuration.
-
-Edits preserve symbolic links to SSH configuration files, and authentication follows custom
-agent sockets reliably even when a specific identity file is configured.
+Release 0.3 gives saved passwords a proper encrypted vault and tightens the handling around
+SSH authentication, configuration edits and keyboard-driven multi-execution.
 
 ## An encrypted password vault
 
@@ -28,21 +18,25 @@ a master password instead.
 Recovery and reset flows are explicit, and vault backups contain encrypted records rather
 than plaintext credentials.
 
-## Import MobaXterm sessions
+## More reliable SSH authentication and edits
 
-The importer reads MobaXterm session files, reconstructs folders and connection settings and
-reports entries it cannot safely convert. Secondary SSH aliases are resolved without creating
-duplicate hosts.
+Authentication follows custom agent sockets reliably, including desktop flows that start a
+connection outside the main host list. Edits preserve symbolic links to SSH configuration
+files instead of replacing the link itself.
+
+## Multi-execution from the keyboard
+
+A dedicated shortcut toggles multi-execution for the active terminal. Mirrored input remains
+limited to the visible target panes, including when one pane is zoomed.
 
 ## Patches
 
 ### 0.3.1
 
-:material-calendar: 30 July 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.3.0...v0.3.1)
+:material-calendar: 30 July 2026 · [Changes](https://github.com/FloSch62/muxus/compare/12b99bf...v0.3.1)
 
 - Diagnostic mode captures server and desktop logs for inspection and export inside Muxus.
 - Terminal text can use a custom foreground colour.
 - SSH agent connections no longer stall when a session also names a specific key.
-- Restored-output dividers stay out of later scrollback snapshots.
 
 [View the 0.3 releases on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.3.1)

--- a/docs/release-notes/0.3.md
+++ b/docs/release-notes/0.3.md
@@ -1,0 +1,48 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.3
+
+:material-calendar: 29 July 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/v0.2.1...v0.3.0)
+
+Release 0.3 deepens OpenSSH compatibility and gives saved passwords a proper encrypted vault.
+It also introduces MobaXterm import, making it possible to bring an existing session library
+into Muxus without recreating every host by hand.
+
+## More of `ssh_config`, end to end
+
+Muxus now honours configured ciphers, key-exchange methods, host-key algorithms and MACs when
+dialling. Agent forwarding, host-key policy, TTY requests, remote commands and other startup
+options are exposed in the host editor as well as resolved from OpenSSH configuration.
+
+Edits preserve symbolic links to SSH configuration files, and authentication follows custom
+agent sockets reliably even when a specific identity file is configured.
+
+## An encrypted password vault
+
+Saved SSH passwords are encrypted automatically. Desktop builds keep the wrapping key in the
+operating-system credential store; environments without a usable keyring can protect it with
+a master password instead.
+
+Recovery and reset flows are explicit, and vault backups contain encrypted records rather
+than plaintext credentials.
+
+## Import MobaXterm sessions
+
+The importer reads MobaXterm session files, reconstructs folders and connection settings and
+reports entries it cannot safely convert. Secondary SSH aliases are resolved without creating
+duplicate hosts.
+
+## Patches
+
+### 0.3.1
+
+:material-calendar: 30 July 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.3.0...v0.3.1)
+
+- Diagnostic mode captures server and desktop logs for inspection and export inside Muxus.
+- Terminal text can use a custom foreground colour.
+- SSH agent connections no longer stall when a session also names a specific key.
+- Restored-output dividers stay out of later scrollback snapshots.
+
+[View the 0.3 releases on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.3.1)

--- a/docs/release-notes/0.4.md
+++ b/docs/release-notes/0.4.md
@@ -1,0 +1,37 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.4
+
+:material-calendar: 3 August 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/v0.3.1...v0.4.0)
+
+Release 0.4 makes busy terminal workspaces easier to manage. Tabs can be pinned, reordered and
+moved into new panes, background output is visible at a glance and folders can share SSH
+credentials across the hosts they contain.
+
+## Tabs that behave like a workspace
+
+Tabs can be dragged into a new order, pinned to the start of a pane or moved into a new split
+from their context menu. A quiet status marker shows which background terminals have produced
+new output without pulling focus away from the active session.
+
+Terminal history search moves to the matching line and highlights the result. Remote programs
+can also write to the local clipboard through OSC 52, subject to the configured clipboard
+policy.
+
+## Shared credentials and broader imports
+
+A sidebar folder can provide authentication settings to the hosts beneath it, reducing
+repetition without changing the underlying SSH host definitions. Keyboard-interactive
+passwords can be saved in the encrypted vault and reused on the next connection.
+
+SecureCRT joins MobaXterm as an import source. Import previews explain skipped sessions, while
+single-quoted OpenSSH arguments are parsed consistently with other configuration values.
+
+## Update controls
+
+Update notifications can be disabled from the notification itself or from Settings. That
+preference is included in backup and restore along with the rest of the application settings.
+
+[View the v0.4.0 release on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.4.0)

--- a/docs/release-notes/0.5.md
+++ b/docs/release-notes/0.5.md
@@ -1,0 +1,52 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.5
+
+:material-calendar: 4 August 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/v0.4.0...v0.5.0)
+
+Release 0.5 adds more control over the way a workspace looks and behaves. Local shell profiles,
+light and dark terminal themes and reusable highlighting profiles make sessions distinct,
+while workspace locking protects layouts that should not be rewritten automatically.
+
+## Terminal appearance for each environment
+
+Light and dark application modes can use separate terminal colour schemes, with optional
+custom foreground and background colours. Desktop builds discover installed fonts, and split
+panes can show a configurable focus border so the target of typing and multi-execution remains
+clear.
+
+Keyword rules can be collected into named highlighting profiles, exported and reused across
+hosts. Appearance mode selection also follows the operating-system theme more predictably.
+
+## Saved commands and safer pastes
+
+Saved commands move into a searchable menu, and the command bar itself can be hidden when it
+is not needed. Multiline paste confirmation becomes an editable preview with line numbers,
+making it possible to remove a dangerous line before anything reaches the terminal.
+
+Numbered tab shortcuts work across every pane in the window and restore focus after a command
+button runs.
+
+## Workspaces and local shells
+
+Workspaces can be locked so live tab and pane changes no longer overwrite the saved layout.
+An explicit save action records changes when you choose, while reusable local shell profiles
+store a program, arguments, starting directory and environment for future tabs.
+
+SFTP actions are available directly from host and tab menus. For SSH servers that cannot
+support the usual terminal setup, Muxus detects console compatibility and adjusts the session
+without requiring a separate host profile.
+
+## Patches
+
+### 0.5.1
+
+:material-calendar: 5 August 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.5.0...v0.5.1)
+
+- Console compatibility no longer removes the TTY when only environment requests are unsupported.
+- SFTP can follow directory changes reported by the active terminal.
+- Console fallback and the SFTP capability setting remain independent.
+
+[View the 0.5 releases on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.5.1)

--- a/docs/release-notes/0.5.md
+++ b/docs/release-notes/0.5.md
@@ -26,8 +26,7 @@ Saved commands move into a searchable menu, and the command bar itself can be hi
 is not needed. Multiline paste confirmation becomes an editable preview with line numbers,
 making it possible to remove a dangerous line before anything reaches the terminal.
 
-Numbered tab shortcuts work across every pane in the window and restore focus after a command
-button runs.
+Numbered tab shortcuts work across every pane in the window.
 
 ## Workspaces and local shells
 

--- a/docs/release-notes/0.6.md
+++ b/docs/release-notes/0.6.md
@@ -1,0 +1,70 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.6
+
+:material-calendar: 7 August 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/v0.5.1...v0.6.0)
+
+Release 0.6 lets Muxus spread across several desktop windows. Saved workspaces can open in
+their own windows, terminal file paths open directly in the editor and SSH hosts can be kept
+in Muxus without adding them to `~/.ssh/config`.
+
+## One workspace per window
+
+Create a workspace in a new window or open an existing one there. Muxus tracks which window
+owns each saved workspace, synchronizes catalog changes between windows and focuses an
+already-open workspace instead of silently opening a competing copy.
+
+Focus mode hides the surrounding application chrome when a terminal needs the whole window.
+The tab strip scrolls more naturally when it overflows and keeps the active tab visible.
+
+## Open terminal paths in the editor
+
+Recognized file paths in SSH terminals open through SFTP in the remote editor. Local terminal
+paths use the same editor for files on the current machine, with permission and path handling
+kept on the corresponding side of the connection.
+
+## OpenSSH hosts or Muxus-only hosts
+
+New and imported SSH hosts can now live entirely in the Muxus database. OpenSSH-backed hosts
+continue to read from and write to the configured SSH files, while database-backed entries
+make sense for settings that should remain private to the application.
+
+## A steadier terminal
+
+Sessions survive system sleep more reliably, right-click actions preserve useful selections
+and copied wrapped lines retain their spaces. macOS numpad Enter behaves like Return, and
+running a saved command gives focus back to the terminal.
+
+Windows ARM64 installers are built alongside the existing platforms, and Linux release
+artifacts carry detached signatures that can be verified with the published project key.
+
+## Patches
+
+### 0.6.1
+
+:material-calendar: 10 August 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.6.0...v0.6.1)
+
+- Terminal file links use an explicit click modifier and avoid conflicts with selection gestures.
+- Local Windows paths follow terminal directory reports and open in the editor correctly.
+- Multiline paste previews use the configured terminal typography.
+- Individual hosts can override the terminal font, colours and light or dark scheme.
+
+### 0.6.2
+
+:material-calendar: 11 August 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.6.1...v0.6.2)
+
+- Default workspace names are allocated atomically, including across several open windows.
+- Tabs can edit their host, close everything to the right and move into a new window without reconnecting.
+- Dragging a tab outside the Muxus window detaches it instead of creating a text file on the desktop.
+- Terminal file links stay disabled until SFTP is ready and remain hidden for hosts without SFTP.
+
+### 0.6.3
+
+:material-calendar: 17 August 2026 · [Changes](https://github.com/FloSch62/muxus/compare/v0.6.2...v0.6.3)
+
+- Terminal web links use the same deliberate activation gesture as terminal file links.
+- Serial connections work in Windows ARM64 builds and report incomplete writes instead of losing data silently.
+
+[View the 0.6 releases on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.6.3)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,12 @@
+---
+icon: lucide/scroll-text
+hide:
+  - navigation
+  - toc
+---
+
+<meta http-equiv="refresh" content="0; url=0.6/">
+
+# Latest release
+
+[Continue to release 0.6](0.6.md)

--- a/zensical.toml
+++ b/zensical.toml
@@ -56,6 +56,14 @@ nav = [
     { "Architecture" = "reference/architecture.md" },
     { "Security model" = "reference/security.md" },
   ] },
+  { "Release notes" = [
+    { "0.6" = "release-notes/0.6.md" },
+    { "0.5" = "release-notes/0.5.md" },
+    { "0.4" = "release-notes/0.4.md" },
+    { "0.3" = "release-notes/0.3.md" },
+    { "0.2" = "release-notes/0.2.md" },
+    { "0.1" = "release-notes/0.1.md" },
+  ] },
   { "Community" = [
     "community/index.md",
     { "Contributing" = "community/contributing.md" },


### PR DESCRIPTION
## Summary

- add release notes for the 0.1 through 0.6 release lines, including patch history through 0.6.3
- add a latest-release redirect and release-note navigation to the documentation site
- link each release and patch to its matching GitHub release or comparison
- add the same Buy Me a Coffee support section used by Kubus to the README

## Why

Muxus release history currently lives across individual GitHub releases and comparison pages. Consolidating it in the documentation makes the progression of features and fixes easier to browse and keeps it alongside the rest of the user guide. The README support section also gives users a direct way to support the project.

## Impact

Readers get a versioned, chronological overview of shipped features and patch fixes directly in the documentation navigation, plus a visible project support link in the README.

## Validation

- `uvx --from zensical zensical build --clean --strict`
- `git diff --check`
