### PR TITLE
feat: add live GPU renderer (WebGL) toggle for terminals

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "@xterm/addon-serialize": "^0.15.0-beta.292",
     "@xterm/addon-unicode11": "^0.10.0-beta.292",
     "@xterm/addon-web-links": "^0.13.0-beta.292",
+    "@xterm/addon-webgl": "0.20.0-beta.291",
     "@xterm/xterm": "^6.1.0-beta.292",
     "monaco-editor": "^0.56.0",
     "react": "^19.2.7",

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -640,6 +640,28 @@ function TerminalSection() {
           sx={{ width: 200 }}
         />
       </Box>
+      <Box>
+        <SectionTitle>Renderer</SectionTitle>
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={prefs.webglRenderer}
+              onChange={(e) => prefs.set({ webglRenderer: e.target.checked })}
+            />
+          }
+          label={
+            <Box>
+              <Typography variant="body2">GPU renderer (WebGL)</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Paints terminals on the GPU instead of the DOM — smoother under
+                heavy output, slightly more CPU while idle. Applies to open
+                terminals immediately.
+              </Typography>
+            </Box>
+          }
+        />
+      </Box>
     </Stack>
   );
 }

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -656,7 +656,8 @@ function TerminalSection() {
               <Typography variant="caption" color="text.secondary">
                 Paints terminals on the GPU instead of the DOM — smoother under
                 heavy output, slightly more CPU while idle. Applies to open
-                terminals immediately.
+                terminals immediately; where WebGL is unavailable, terminals
+                keep the standard renderer.
               </Typography>
             </Box>
           }

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -223,6 +223,9 @@ async function openLinkedTerminalFile(tabId: string, candidate: string): Promise
   useTabsStore.getState().openEditor(tabId, path);
 }
 
+/** One warning per page load: the failure is machine-wide, not per-terminal. */
+let webglUnavailableWarned = false;
+
 export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; active: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -361,6 +364,15 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     if (!shouldFitTerminal(containerRef.current)) return false;
     fitRef.current?.fit();
     return true;
+  };
+
+  /** Return to the DOM renderer — the pref-off path and context loss share it. */
+  const dropWebglAddon = () => {
+    const webgl = webglAddonRef.current;
+    if (!webgl) return;
+    webglAddonRef.current = null;
+    webgl.dispose();
+    fitTerminal();
   };
 
   const applyZoom = (action: 'in' | 'out' | 'reset') => {
@@ -541,6 +553,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     ])
       .then(() => {
         if (termRef.current !== term) return;
+        // The WebGL atlas caches glyphs rasterized with the fallback face;
+        // refresh alone would repaint those same bitmaps.
+        webglAddonRef.current?.clearTextureAtlas();
         term.refresh(0, term.rows - 1);
         fitTerminal();
       })
@@ -1326,6 +1341,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         ) {
           return;
         }
+        webglAddonRef.current?.clearTextureAtlas();
         term.refresh(0, term.rows - 1);
         fitTerminal();
       })
@@ -1347,11 +1363,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     const term = termRef.current;
     if (!term) return;
     if (!webglRenderer) {
-      if (webglAddonRef.current) {
-        webglAddonRef.current.dispose();
-        webglAddonRef.current = null;
-        fitTerminal();
-      }
+      dropWebglAddon();
       return;
     }
     if (webglAddonRef.current) return;
@@ -1360,17 +1372,23 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       .then(({ WebglAddon }) => {
         if (cancelled || termRef.current !== term || webglAddonRef.current) return;
         const webgl = new WebglAddon();
-        webgl.onContextLoss(() => {
-          webglAddonRef.current = null;
+        webgl.onContextLoss(() => dropWebglAddon());
+        try {
+          term.loadAddon(webgl);
+        } catch (err) {
           webgl.dispose();
-          fitTerminal();
-        });
+          throw err;
+        }
+        // Only a live addon may reach the ref: a failed activation must not
+        // suppress retries or make toggle-off dispose a renderer that never ran.
         webglAddonRef.current = webgl;
-        term.loadAddon(webgl);
         fitTerminal();
       })
       .catch(() => {
-        // No usable WebGL on this machine — stay on the DOM renderer.
+        // Chunk fetch failed or WebGL2 is unusable — the DOM renderer stays.
+        if (webglUnavailableWarned) return;
+        webglUnavailableWarned = true;
+        showToast('warning', 'GPU rendering is unavailable here — terminals keep the standard renderer.');
       });
     return () => {
       cancelled = true;

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -30,6 +30,9 @@ import { SearchAddon, type ISearchOptions } from '@xterm/addon-search';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebLinksAddon } from '@xterm/addon-web-links';
+// Type-only: the addon stays lazily imported at runtime so it lands in its
+// own async chunk instead of the eager xterm bundle.
+import type { WebglAddon } from '@xterm/addon-webgl';
 import '@xterm/xterm/css/xterm.css';
 import type { AppInfo, TerminalServerMessage } from '@muxus/shared';
 import {
@@ -228,6 +231,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const searchRef = useRef<SearchAddon | null>(null);
   const serializeRef = useRef<SerializeAddon | null>(null);
   const imageRef = useRef<ImageAddon | null>(null);
+  const webglAddonRef = useRef<WebglAddon | null>(null);
   const keywordHighlighterRef = useRef<KeywordHighlighter | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   /** xterm's native default is enabled on macOS and disabled elsewhere. */
@@ -272,6 +276,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const cursorBlink = usePrefsStore((s) => s.cursorBlink);
   const cursorStyle = usePrefsStore((s) => s.cursorStyle);
   const scrollback = usePrefsStore((s) => s.scrollback);
+  const webglRenderer = usePrefsStore((s) => s.webglRenderer);
   const applicationSchemeId = usePrefsStore((prefs) =>
     terminalSchemeIdForMode(prefs, theme.palette.mode),
   );
@@ -1286,6 +1291,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       searchRef.current = null;
       serializeRef.current = null;
       imageRef.current = null;
+      webglAddonRef.current = null;
       keywordHighlighterRef.current = null;
       termRef.current = null;
       wsRef.current = null;
@@ -1325,6 +1331,51 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       })
       .catch(() => undefined);
   }, [monoFontSize, fontFamily, lineHeight, cursorBlink, cursorStyle, scrollback, terminalTheme, generation]);
+
+  // The GPU renderer is a live preference: loading the addon hands painting
+  // over to WebGL, disposing it drops back to the DOM renderer — no session
+  // reopen either way. The import stays lazy so the chunk lands outside the
+  // eager bundle, and a context loss (backgrounded tab, GPU driver reset)
+  // disposes the addon, which also returns to the DOM renderer.
+  //
+  // The renderers disagree on cell width: DOM keeps the fractional measured
+  // width (14px JetBrains Mono = 8.4px) while WebGL floors it to whole device
+  // pixels (8.0). Swapping without a refit leaves the grid sized for the other
+  // renderer — dead space beside the pane and a visibly different pitch — so
+  // every swap refits.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    if (!webglRenderer) {
+      if (webglAddonRef.current) {
+        webglAddonRef.current.dispose();
+        webglAddonRef.current = null;
+        fitTerminal();
+      }
+      return;
+    }
+    if (webglAddonRef.current) return;
+    let cancelled = false;
+    void import('@xterm/addon-webgl')
+      .then(({ WebglAddon }) => {
+        if (cancelled || termRef.current !== term || webglAddonRef.current) return;
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => {
+          webglAddonRef.current = null;
+          webgl.dispose();
+          fitTerminal();
+        });
+        webglAddonRef.current = webgl;
+        term.loadAddon(webgl);
+        fitTerminal();
+      })
+      .catch(() => {
+        // No usable WebGL on this machine — stay on the DOM renderer.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [webglRenderer, generation]);
 
   useEffect(() => {
     keywordHighlighterRef.current?.setRules(keywordHighlights);

--- a/client/src/data-transfer.ts
+++ b/client/src/data-transfer.ts
@@ -59,6 +59,7 @@ const PREFERENCE_KEYS = [
   'scrollback',
   'cursorBlink',
   'cursorStyle',
+  'webglRenderer',
   'localShell',
   'localShellProfiles',
   'defaultLocalShellProfileId',
@@ -804,6 +805,7 @@ export function sanitizePreferences(
   if (['block', 'underline', 'bar'].includes(input.cursorStyle)) {
     output.cursorStyle = input.cursorStyle;
   }
+  if (typeof input.webglRenderer === 'boolean') output.webglRenderer = input.webglRenderer;
   if (typeof input.localShell === 'string' && input.localShell.length <= 4096) {
     output.localShell = input.localShell;
   }

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -94,6 +94,8 @@ export interface PrefsState {
   scrollback: number;
   cursorBlink: boolean;
   cursorStyle: 'block' | 'underline' | 'bar';
+  /** Render terminals on the GPU via WebGL; off keeps the DOM renderer. */
+  webglRenderer: boolean;
   /** Local terminal shell; 'auto' lets the server pick the login shell. */
   localShell: string;
   /** Named alternatives offered wherever a local terminal can be launched. */
@@ -332,6 +334,7 @@ export const usePrefsStore = create<PrefsState>()(
       scrollback: 10_000,
       cursorBlink: true,
       cursorStyle: 'block',
+      webglRenderer: true,
       localShell: 'auto',
       localShellProfiles: [],
       defaultLocalShellProfileId: '',

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -205,6 +205,7 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
   }
   if (typeof state.activePaneBorder !== 'boolean') delete state.activePaneBorder;
   if (typeof state.dimInactivePanes !== 'boolean') delete state.dimInactivePanes;
+  if (typeof state.webglRenderer !== 'boolean') delete state.webglRenderer;
   if (
     typeof state.inactivePaneDimStrength !== 'number' ||
     !Number.isFinite(state.inactivePaneDimStrength) ||
@@ -334,7 +335,7 @@ export const usePrefsStore = create<PrefsState>()(
       scrollback: 10_000,
       cursorBlink: true,
       cursorStyle: 'block',
-      webglRenderer: true,
+      webglRenderer: false,
       localShell: 'auto',
       localShellProfiles: [],
       defaultLocalShellProfileId: '',

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -24,7 +24,9 @@ export default defineConfig({
           groups: [
             { name: 'preload-helper', test: /vite[\\/]preload-helper/ },
             { name: 'react', test: /node_modules[\\/](react|react-dom|scheduler)[\\/]/ },
-            { name: 'xterm', test: /node_modules[\\/]@xterm[\\/]/ },
+            // addon-webgl stays out: it is lazy-loaded by the terminal so it
+            // must land in its own async chunk, not the eager xterm chunk.
+            { name: 'xterm', test: /node_modules[\\/]@xterm[\\/](?!addon-webgl)/ },
           ],
         },
       },

--- a/hack/renderer-size-probe.mjs
+++ b/hack/renderer-size-probe.mjs
@@ -2,11 +2,14 @@
 // Drives the LIVE muxus web server, opens a local terminal, toggles the
 // renderer, and measures the character cell grid + glyph ink width per mode.
 //   node hack/renderer-size-probe.mjs
+// Set CHROME to override the browser.
 import os from 'node:os';
 import path from 'node:path';
 import { chromium } from 'playwright-core';
 
-const CHROME = path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
+const CHROME =
+  process.env.CHROME ||
+  path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
 // Servers mint a fresh token per start, so it must come from the environment.
 const TOKEN = process.env.MUXUS_TOKEN;
 const BASE = process.env.MUXUS_URL ?? 'http://127.0.0.1:3002';
@@ -25,6 +28,7 @@ const browser = await chromium.launch({
     '--window-size=1920,1080',
     '--disable-backgrounding-occluded-windows',
     '--disable-renderer-backgrounding',
+    '--disable-background-timer-throttling',
   ],
 });
 const page = await (await browser.newContext({ viewport: null })).newPage();
@@ -52,7 +56,7 @@ await page.goto(`${BASE}/#token=${TOKEN}`, { waitUntil: 'domcontentloaded' });
 await page.waitForSelector('text=Local terminal');
 await page.click('text=Local terminal');
 await page.waitForSelector('.xterm-screen');
-await page.waitForTimeout(2500); // webfonts + lazy addon + first prompt
+await page.waitForTimeout(2500); // webfonts + first prompt
 
 const measure = () =>
   page.evaluate(() => {
@@ -87,11 +91,22 @@ const measure = () =>
 
 const toggle = async () => {
   await page.click('[aria-label="Settings"]');
-  await page.waitForSelector('.MuiDialog-paper');
-  await page.waitForTimeout(500);
-  await page.click('.MuiDialog-paper [role="button"]:has-text("Terminal")');
+  // The dialog container intercepts pointer events during the paper
+  // transition, so click through the DOM instead of coordinates.
+  await page.waitForSelector('.MuiDialog-paper [role="button"]:has-text("Terminal")');
+  await page.waitForTimeout(600);
+  await page.evaluate(() =>
+    [...document.querySelectorAll('.MuiDialog-paper [role="button"]')]
+      .find((b) => b.textContent.trim() === 'Terminal')
+      .click(),
+  );
   await page.waitForSelector('.MuiDialog-paper >> text=GPU renderer (WebGL)');
-  await page.click('.MuiDialog-paper >> text=GPU renderer (WebGL)');
+  await page.evaluate(() =>
+    [...document.querySelectorAll('.MuiDialog-paper .MuiFormControlLabel-root')]
+      .find((l) => l.textContent.includes('GPU renderer'))
+      .querySelector('input[type="checkbox"]')
+      .click(),
+  );
   await page.keyboard.press('Escape');
   await page.waitForTimeout(1500); // swap + lazy import
 };
@@ -109,16 +124,16 @@ const report = (label, m) => {
 };
 
 console.log('mode after load:', JSON.stringify((await measure()).domRows ? 'dom' : 'webgl?'));
-report('after load (default = webgl on)', await measure());
-
-await toggle(); // → DOM
-const dom = await measure();
-report('after toggle OFF (dom)', dom);
-await page.locator('.xterm-screen').screenshot({ path: '/tmp/muxus-webgl-perf/size-dom.png' });
+report('after load (default = dom)', await measure());
 
 await toggle(); // → WebGL
 const webgl = await measure();
 report('after toggle ON (webgl)', webgl);
 await page.locator('.xterm-screen').screenshot({ path: '/tmp/muxus-webgl-perf/size-webgl.png' });
+
+await toggle(); // → DOM
+const dom = await measure();
+report('after toggle OFF (dom)', dom);
+await page.locator('.xterm-screen').screenshot({ path: '/tmp/muxus-webgl-perf/size-dom.png' });
 
 await browser.close();

--- a/hack/renderer-size-probe.mjs
+++ b/hack/renderer-size-probe.mjs
@@ -7,8 +7,13 @@ import path from 'node:path';
 import { chromium } from 'playwright-core';
 
 const CHROME = path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
-const TOKEN = '7f3t2Q8kw-5kuEiwoe-4vmUW8BrV092-';
-const BASE = 'http://127.0.0.1:3002';
+// Servers mint a fresh token per start, so it must come from the environment.
+const TOKEN = process.env.MUXUS_TOKEN;
+const BASE = process.env.MUXUS_URL ?? 'http://127.0.0.1:3002';
+if (!TOKEN) {
+  console.error('MUXUS_TOKEN is required — the running server prints it in its browser URL.');
+  process.exit(1);
+}
 
 const browser = await chromium.launch({
   executablePath: CHROME,

--- a/hack/renderer-size-probe.mjs
+++ b/hack/renderer-size-probe.mjs
@@ -1,0 +1,119 @@
+// One-off measurement: does the WebGL/DOM renderer swap change glyph size?
+// Drives the LIVE muxus web server, opens a local terminal, toggles the
+// renderer, and measures the character cell grid + glyph ink width per mode.
+//   node hack/renderer-size-probe.mjs
+import os from 'node:os';
+import path from 'node:path';
+import { chromium } from 'playwright-core';
+
+const CHROME = path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
+const TOKEN = '7f3t2Q8kw-5kuEiwoe-4vmUW8BrV092-';
+const BASE = 'http://127.0.0.1:3002';
+
+const browser = await chromium.launch({
+  executablePath: CHROME,
+  headless: false,
+  env: { ...process.env, DISPLAY: ':0' },
+  args: [
+    '--no-sandbox',
+    '--window-position=0,0',
+    '--window-size=1920,1080',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+  ],
+});
+const page = await (await browser.newContext({ viewport: null })).newPage();
+
+// Read-only: never let the live server restore (and dial) saved workspaces.
+await page.route('**/api/workspaces/latest', (r) => r.fulfill({ json: { workspace: null } }));
+await page.route('**/api/workspaces/startup', (r) =>
+  r.request().method() === 'GET' ? r.fulfill({ json: { workspace: null } }) : r.continue(),
+);
+
+// cols/rows arrive in the terminal session's JSON control frames.
+let grid = { cols: 0, rows: 0 };
+page.on('websocket', (ws) => {
+  if (!ws.url().includes('/ws/terminal')) return;
+  ws.on('framesent', (f) => {
+    if (typeof f.payload !== 'string') return;
+    try {
+      const msg = JSON.parse(f.payload);
+      if (msg.cols && msg.rows) grid = { cols: msg.cols, rows: msg.rows };
+    } catch { /* binary input frames */ }
+  });
+});
+
+await page.goto(`${BASE}/#token=${TOKEN}`, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('text=Local terminal');
+await page.click('text=Local terminal');
+await page.waitForSelector('.xterm-screen');
+await page.waitForTimeout(2500); // webfonts + lazy addon + first prompt
+
+const measure = () =>
+  page.evaluate(() => {
+    const screen = document.querySelector('.xterm-screen');
+    const rect = screen.getBoundingClientRect();
+    const ctx = document.createElement('canvas').getContext('2d');
+    ctx.font = '14px "JetBrains Mono", "Pure Nerd Font", "Noto Sans Mono", "DejaVu Sans Mono", monospace';
+    const rows = screen.querySelectorAll('.xterm-rows > div');
+    const firstRow = rows[0]?.getBoundingClientRect();
+    return {
+      dpr: devicePixelRatio,
+      screenW: rect.width,
+      screenH: rect.height,
+      domRows: rows.length,
+      rowH: firstRow?.height ?? null,
+      rowW: firstRow?.width ?? null,
+      canvases: [...screen.querySelectorAll('canvas')].map((c) => ({
+        cls: c.className,
+        w: c.width,
+        h: c.height,
+        cssW: c.getBoundingClientRect().width,
+      })),
+      jetbrainsLoaded: document.fonts.check('14px "JetBrains Mono"'),
+      symbolLoaded: document.fonts.check('14px "Pure Nerd Font"'),
+      measureTextW: ctx.measureText('W').width,
+      measureText10: ctx.measureText('WWWWWWWWWW').width / 10,
+      computedFont: rows.length
+        ? getComputedStyle(rows[0]).fontSize + ' / ' + getComputedStyle(rows[0]).fontFamily.slice(0, 60)
+        : null,
+    };
+  });
+
+const toggle = async () => {
+  await page.click('[aria-label="Settings"]');
+  await page.waitForSelector('.MuiDialog-paper');
+  await page.waitForTimeout(500);
+  await page.click('.MuiDialog-paper [role="button"]:has-text("Terminal")');
+  await page.waitForSelector('.MuiDialog-paper >> text=GPU renderer (WebGL)');
+  await page.click('.MuiDialog-paper >> text=GPU renderer (WebGL)');
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(1500); // swap + lazy import
+};
+
+const report = (label, m) => {
+  const cellW = grid.cols ? m.screenW / grid.cols : null;
+  const cellH = grid.rows ? m.screenH / grid.rows : null;
+  console.log(`\n== ${label} ==`);
+  console.log(`grid ${grid.cols}x${grid.rows}  screen ${m.screenW.toFixed(1)}x${m.screenH.toFixed(1)}  dpr ${m.dpr}`);
+  console.log(`cellW ${cellW?.toFixed(2)}px  cellH ${cellH?.toFixed(2)}px  rowH(dom) ${m.rowH ?? '—'}`);
+  console.log(`canvases ${JSON.stringify(m.canvases)}`);
+  console.log(`JetBrains Mono loaded: ${m.jetbrainsLoaded}  symbol font: ${m.symbolLoaded}`);
+  console.log(`canvas measureText W=${m.measureTextW.toFixed(2)}px 10W=${m.measureText10.toFixed(2)}px`);
+  console.log(`computed ${m.computedFont ?? '—'}`);
+};
+
+console.log('mode after load:', JSON.stringify((await measure()).domRows ? 'dom' : 'webgl?'));
+report('after load (default = webgl on)', await measure());
+
+await toggle(); // → DOM
+const dom = await measure();
+report('after toggle OFF (dom)', dom);
+await page.locator('.xterm-screen').screenshot({ path: '/tmp/muxus-webgl-perf/size-dom.png' });
+
+await toggle(); // → WebGL
+const webgl = await measure();
+report('after toggle ON (webgl)', webgl);
+await page.locator('.xterm-screen').screenshot({ path: '/tmp/muxus-webgl-perf/size-webgl.png' });
+
+await browser.close();

--- a/hack/webgl-perf.mjs
+++ b/hack/webgl-perf.mjs
@@ -188,10 +188,13 @@ function progressPool(count) {
 function sustain(makeChunk, durationMs) {
   return new Promise((resolve) => {
     const t0 = performance.now();
+    const deadline = t0 + durationMs;
     let last = t0;
     let written = 0;
-    let acked = 0;
-    let ackedAtFeedEnd = 0;
+    // Counts bytes whose parse callback ran before the nominal deadline —
+    // callbacks delayed past it by a blocking parser task are drain, not
+    // feed throughput, even when the task ends before our timer fires.
+    let ackedInWindow = 0;
     let pending = 0;
     let stopped = false;
     let feedEnded = 0;
@@ -199,7 +202,10 @@ function sustain(makeChunk, durationMs) {
       const chunk = makeChunk(dt);
       if (!chunk) return;
       pending++;
-      term.write(chunk, () => { pending--; acked += chunk.length; });
+      term.write(chunk, () => {
+        pending--;
+        if (performance.now() <= deadline) ackedInWindow += chunk.length;
+      });
       written += chunk.length;
     };
     const feedOnce = () => {
@@ -209,10 +215,9 @@ function sustain(makeChunk, durationMs) {
         // Offer the final [last, deadline] slice too: when the parser blocks
         // the main thread past the deadline, skipping it short-changes
         // exactly the overloaded cells and flatters their fps/drain numbers.
-        offer((t0 + durationMs - last) / 1000);
+        offer((deadline - last) / 1000);
         stopped = true;
         feedEnded = performance.now();
-        ackedAtFeedEnd = acked;
         drain();
         return;
       }
@@ -222,7 +227,7 @@ function sustain(makeChunk, durationMs) {
     };
     const drain = () => {
       if (pending === 0) {
-        resolve({ written, ackedAtFeedEnd, wallMs: feedEnded - t0, drainMs: performance.now() - feedEnded });
+        resolve({ written, ackedInWindow, wallMs: feedEnded - t0, drainMs: performance.now() - feedEnded });
         return;
       }
       setTimeout(drain, 10);
@@ -289,16 +294,19 @@ async function runRate(phase, pool, offered, durationMs) {
   const e0 = clock();
   const heap0 = performance.memory ? performance.memory.usedJSHeapSize : null;
   const lt0 = longTasks;
-  const { ackedAtFeedEnd, wallMs, drainMs } = await sustain(makeChunk, durationMs);
+  const { ackedInWindow, wallMs, drainMs } = await sustain(makeChunk, durationMs);
   const tFeed = t0 + wallMs;
-  const stats = frameStats(t0, tFeed); // during the feed — renderer under load
+  // Let a few idle frames land AFTER the feed end before slicing the window:
+  // a stall spanning the boundary only becomes countable once its trailing
+  // frame exists in the log, and the drain can finish before the next vblank.
   await idleFrames(3);
+  const stats = frameStats(t0, tFeed); // during the feed — renderer under load
   return {
     phase,
     offered,
     startEpoch: e0,
     feedEndEpoch: clock() - (performance.now() - tFeed),
-    parseRate: isProgress ? ackedAtFeedEnd / barLen / (wallMs / 1000) : ackedAtFeedEnd / 1.048576e6 / (wallMs / 1000),
+    parseRate: isProgress ? ackedInWindow / barLen / (wallMs / 1000) : ackedInWindow / 1.048576e6 / (wallMs / 1000),
     drainMs,
     longTasks: longTasks - lt0,
     heapDelta: heap0 != null && performance.memory
@@ -471,13 +479,13 @@ const cpuSecondsBetween = (t0, t1) => {
 const results = [];
 try {
   for (const renderer of renderers) {
-    // deviceScaleFactor requires a fixed viewport; keep the physical window
-    // size so the simulated hi-dpi page area matches the dpr=1 runs.
-    const context = await browser.newContext(
-      DPR > 1
-        ? { viewport: { width: 1920, height: 1080 }, deviceScaleFactor: DPR }
-        : { viewport: null },
-    );
+    // Fixed viewport for every run: viewport:null defers to the OS window's
+    // inner size, which is neither guaranteed 1920x1080 nor equal across
+    // machines — that would make DPR runs differ in page area, not just DPR.
+    const context = await browser.newContext({
+      viewport: { width: 1920, height: 1080 },
+      deviceScaleFactor: DPR,
+    });
     const pg = await context.newPage();
     if (CPU_THROTTLE > 1) {
       const cdp = await context.newCDPSession(pg);

--- a/hack/webgl-perf.mjs
+++ b/hack/webgl-perf.mjs
@@ -402,6 +402,12 @@ function treeTicks(rootPid) {
 const renderers = process.argv.slice(2).length
   ? process.argv.slice(2)
   : ['dom', 'webgl'];
+// Condition simulation knobs: PERF_CPU_THROTTLE=4 slows the page main thread
+// via CDP (weak-CPU stand-in — GPU process raster is unaffected, which is
+// exactly the asymmetry the WebGL renderer could exploit); PERF_DPR=2 renders
+// at 2x device scale (hi-dpi stand-in — DOM text raster gets 4x the pixels).
+const CPU_THROTTLE = Math.max(1, Number(process.env.PERF_CPU_THROTTLE || 1));
+const DPR = Math.max(1, Number(process.env.PERF_DPR || 1));
 // Repetitions per phase cell; medians are reported so one GC storm cannot
 // masquerade as a renderer property.
 const REPS = Math.max(1, Number(process.env.REPS || 1));
@@ -465,8 +471,18 @@ const cpuSecondsBetween = (t0, t1) => {
 const results = [];
 try {
   for (const renderer of renderers) {
-    const context = await browser.newContext({ viewport: null });
+    // deviceScaleFactor requires a fixed viewport; keep the physical window
+    // size so the simulated hi-dpi page area matches the dpr=1 runs.
+    const context = await browser.newContext(
+      DPR > 1
+        ? { viewport: { width: 1920, height: 1080 }, deviceScaleFactor: DPR }
+        : { viewport: null },
+    );
     const pg = await context.newPage();
+    if (CPU_THROTTLE > 1) {
+      const cdp = await context.newCDPSession(pg);
+      await cdp.send('Emulation.setCPUThrottlingRate', { rate: CPU_THROTTLE });
+    }
     await pg.goto(`${origin}/?renderer=${renderer}&reps=${REPS}`);
     await pg.waitForFunction('window.__PERF && window.__PERF.done', null, { timeout: 900_000 });
     const result = await pg.evaluate('window.__PERF');
@@ -503,7 +519,7 @@ const row = (cells) =>
   cells.map((c, i) => String(c).padStart([8, 8, 6, 6, 6, 7, 8, 8, 8][i])).join(' ');
 
 console.log(`\nmuxus webgl terminal renderer benchmark`);
-console.log(`display ${DISPLAY}  ${HEADED ? 'headed (physical)' : 'headless (software GL expected)'}  reps=${REPS}\n`);
+console.log(`display ${DISPLAY}  ${HEADED ? 'headed (physical)' : 'headless (software GL expected)'}  reps=${REPS}  cpu_throttle=${CPU_THROTTLE}x  dpr=${DPR}x\n`);
 for (const r of results) {
   console.log(`renderer=${r.renderer}  gpu="${r.glRenderer ?? '— (dom)'}"${r.glError ? '  addon error: ' + r.glError : ''}`);
   console.log(`viewport ${r.viewport.w}x${r.viewport.h}@${r.viewport.dpr}x  document.hidden=${r.hidden}\n`);

--- a/hack/webgl-perf.mjs
+++ b/hack/webgl-perf.mjs
@@ -1,0 +1,544 @@
+// WebGL terminal renderer benchmark on a real display.
+//
+//   node hack/webgl-perf.mjs                 # DOM vs WebGL, physical monitor
+//   PERF_HEADLESS=1 node hack/webgl-perf.mjs # headless comparison (SwiftShader)
+//   PERF_DISPLAY=:1 node hack/webgl-perf.mjs # pick another X display
+//
+// The default DISPLAY is :0 — the lightdm session with the monitor cabled to
+// the RTX 3060. Headless Chromium renders WebGL with SwiftShader on the CPU,
+// so numbers from headless runs say nothing about the GPU renderer; this
+// harness opens a real window so the addon runs on the monitor's GPU.
+//
+// xterm is served straight from client/node_modules, so the benchmark runs the
+// same package versions the app ships with. Terminal options mirror the muxus
+// defaults (14pt, 10k scrollback, allowTransparency) at a fixed 220x48 grid.
+//
+// Method: xterm's write callback fires when a chunk is parsed, not painted, so
+// callback chaining only measures parser throughput. Instead each phase offers
+// data at a fixed rate for a fixed window (top-up write every 4ms, sized by
+// elapsed time so timer jitter cannot under-run the offered rate) and measures
+// what the terminal actually sustains:
+//
+//   log-flood    colored service-log lines at 8 / 24 / 40 MB/s for 6 s
+//   progress     in-place bar redraws at 10k / 50k / 200k updates/s for 6 s
+//   plain-cat    uncolored lines at 8 / 24 / 40 MB/s for 6 s
+//
+// Reported per rate: frame stats during the feed (60 Hz display: smooth =
+// 60 fps, tight p99), parse rate (acknowledged bytes), drain ms (backlog left
+// when the feed stops — how long output keeps arriving after the flood), and
+// Chromium process-tree CPU seconds.
+import { spawnSync } from 'node:child_process';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { chromium } from 'playwright-core';
+
+const XTERM_ROOT = path.resolve('client/node_modules/@xterm');
+const CHROME =
+  process.env.CHROME ||
+  path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
+const DISPLAY = process.env.PERF_DISPLAY ?? ':0';
+const HEADED = !process.env.PERF_HEADLESS;
+const OUT_DIR = path.join(os.tmpdir(), 'muxus-webgl-perf');
+
+// DPMS-blanked monitors still answer X requests, but Chromium stops getting
+// vblanks and throttles rAF to ~1 Hz, which poisons every frame metric. Wake
+// the display and hold off DPMS + screensaver for the run; the greeter's
+// original 600s timeouts are restored in the finally block below.
+function xset(...args) {
+  const { status } = spawnSync('xset', ['-display', DISPLAY, ...args], { stdio: 'ignore' });
+  if (status !== 0) console.warn(`xset ${args.join(' ')} -> rc=${status}`);
+}
+if (HEADED) {
+  xset('s', 'reset');
+  xset('dpms', 'force', 'on');
+  xset('dpms', '0', '0', '0');
+  xset('s', 'off');
+}
+
+const MIME = {
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.map': 'application/json',
+};
+
+const page = `<!doctype html>
+<html><head><meta charset="utf-8">
+<link rel="stylesheet" href="/xterm/xterm/css/xterm.css">
+<style>
+  html, body { margin: 0; height: 100%; background: #1e1e1e; }
+  #term { width: 100vw; height: 100vh; }
+</style>
+<script type="module">
+import { Terminal } from '/xterm/xterm/lib/xterm.mjs';
+import { WebglAddon } from '/xterm/addon-webgl/lib/addon-webgl.mjs';
+
+const renderer = new URLSearchParams(location.search).get('renderer');
+
+const term = new Terminal({
+  cols: 220, rows: 48,
+  fontSize: 14,
+  fontFamily: 'JetBrains Mono, DejaVu Sans Mono, monospace',
+  lineHeight: 1.0,
+  scrollback: 10_000,
+  cursorBlink: true,
+  cursorStyle: 'block',
+  allowProposedApi: true,
+  allowTransparency: true,
+  scrollOnEraseInDisplay: true,
+  theme: { background: '#1e1e1e', foreground: '#d4d4d4' },
+});
+term.open(document.getElementById('term'));
+
+let glRenderer = null;
+let glError = null;
+if (renderer === 'webgl') {
+  try { term.loadAddon(new WebglAddon()); } catch (e) { glError = String(e); }
+}
+{ // What GPU is actually behind contexts on this display?
+  try {
+    const c = document.createElement('canvas');
+    const g = c.getContext('webgl2') || c.getContext('webgl');
+    const ext = g.getExtension('WEBGL_debug_renderer_info');
+    glRenderer = ext ? g.getParameter(ext.UNMASKED_RENDERER_WEBGL) : g.getParameter(g.RENDERER);
+  } catch (e) { glRenderer = 'probe failed: ' + String(e); }
+}
+
+// rAF frame meter + long-task counter run for the whole page life.
+const frames = [];
+(function loop(t) { frames.push(t); requestAnimationFrame(loop); })(0);
+let longTasks = 0;
+new PerformanceObserver((l) => { longTasks += l.getEntries().length; })
+  .observe({ entryTypes: ['longtask'] });
+
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s ^= s << 13; s >>>= 0;
+    s ^= s >>> 17;
+    s ^= s << 5; s >>>= 0;
+    return s / 4294967296;
+  };
+}
+
+const pad = (n, w) => String(n).padStart(w, '0');
+const clock = () => performance.timeOrigin + performance.now();
+
+function logPool(totalBytes, chunkBytes) {
+  const r = rng(42);
+  const chunks = [];
+  let bytes = 0;
+  while (bytes < totalBytes) {
+    let buf = '';
+    while (buf.length < chunkBytes) {
+      const lvl = r();
+      const tag = lvl < 0.72 ? '\\x1b[32mINFO \\x1b[0m' : lvl < 0.9 ? '\\x1b[33mWARN \\x1b[0m' : '\\x1b[31mERROR\\x1b[0m';
+      buf += tag + ' 2026-08-27T08:' + pad((r() * 59) | 0, 2) + ':' + pad((r() * 59) | 0, 2) +
+        '.' + pad((r() * 999) | 0, 3) + 'Z svc=checkout req=req_' +
+        ((r() * 0xffffff) | 0).toString(16) + ' status=' + (200 + ((r() * 3) | 0)) +
+        ' latency=' + pad((r() * 400) | 0, 3) + 'ms bytes=' + ((r() * 48000) | 0) +
+        ' path=/api/v1/cart/items/' + ((r() * 9999) | 0) + ' shard=' + ((r() * 15) | 0) + '\\r\\n';
+    }
+    chunks.push(buf);
+    bytes += buf.length;
+  }
+  return chunks;
+}
+
+function plainPool(totalBytes, chunkBytes) {
+  const chunks = [];
+  let bytes = 0;
+  let i = 0;
+  while (bytes < totalBytes) {
+    let buf = '';
+    while (buf.length < chunkBytes) {
+      buf += pad(i, 9) + '  lorem ipsum dolor sit amet consectetur adipiscing' +
+        ' elit sed do eiusmod tempor incididunt ut labore et dolore ' + pad(i % 9973, 4) + '\\r\\n';
+      i++;
+    }
+    chunks.push(buf);
+    bytes += buf.length;
+  }
+  return chunks;
+}
+
+function progressPool(count) {
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const f = ((i * 30) / count) | 0;
+    const pct = ((i * 100) / count) | 0;
+    out.push(
+      '\\r\\x1b[2K\\x1b[36m[\\x1b[0m' + '#'.repeat(f) + '\\u00b7'.repeat(30 - f) +
+      '\\x1b[36m]\\x1b[0m ' + pad(pct, 3) + '% ' + pad((120 + (i % 60)) | 0, 3) +
+      'MB/s eta 00:' + pad(59 - ((i * 59 / count) | 0), 2)
+    );
+  }
+  return out;
+}
+
+// Offer data at a fixed rate and never wait for the terminal: top up every
+// 4ms with bytes proportional to elapsed time (jitter-corrected), so a parser
+// or renderer that cannot keep up builds a backlog instead of pacing the feed.
+// A write callback closing means the chunk is parsed; pending counts chunks
+// the parser has not caught up with. drainMs = backlog still flushing after
+// the feed stopped.
+function sustain(makeChunk, durationMs) {
+  return new Promise((resolve) => {
+    const t0 = performance.now();
+    let last = t0;
+    let written = 0;
+    let acked = 0;
+    let pending = 0;
+    let stopped = false;
+    let feedEnded = 0;
+    const feedOnce = () => {
+      if (stopped) return;
+      const now = performance.now();
+      if (now - t0 >= durationMs) {
+        stopped = true;
+        feedEnded = now;
+        drain();
+        return;
+      }
+      const chunk = makeChunk((now - last) / 1000);
+      last = now;
+      if (chunk) {
+        pending++;
+        term.write(chunk, () => { pending--; acked += chunk.length; });
+        written += chunk.length;
+      }
+      setTimeout(feedOnce, 4);
+    };
+    const drain = () => {
+      if (pending === 0) {
+        resolve({ written, acked, wallMs: feedEnded - t0, drainMs: performance.now() - feedEnded });
+        return;
+      }
+      setTimeout(drain, 10);
+    };
+    feedOnce();
+  });
+}
+
+function idleFrames(n) {
+  return new Promise((resolve) => {
+    let k = 0;
+    (function f() { if (++k >= n) { resolve(); return; } requestAnimationFrame(f); })();
+  });
+}
+
+function frameStats(t0, t1) {
+  const inWindow = frames.filter((t) => t >= t0 && t <= t1);
+  const deltas = [];
+  for (let i = 1; i < inWindow.length; i++) deltas.push(inWindow[i] - inWindow[i - 1]);
+  deltas.sort((a, b) => a - b);
+  const q = (p) => (deltas.length ? deltas[Math.min(deltas.length - 1, (p * deltas.length) | 0)] : null);
+  return {
+    fps: inWindow.length > 1 ? (inWindow.length - 1) / ((inWindow[inWindow.length - 1] - inWindow[0]) / 1000) : 0,
+    p50: q(0.5), p95: q(0.95), p99: q(0.99),
+    max: deltas.length ? deltas[deltas.length - 1] : null,
+    jank34: deltas.filter((d) => d > 34).length,
+  };
+}
+
+async function runRate(phase, pool, offered, durationMs) {
+  const isProgress = phase === 'progress';
+  // Byte phases: offered in bytes/s, chunks stitched from 32KB pool entries.
+  // Progress: offered in redraws/s, updates accumulated fractionally.
+  let poolIdx = 0;
+  let owed = 0;
+  let barIdx = 0;
+  const barLen = pool.length ? pool[0].length : 1;
+  const makeChunk = isProgress
+    ? (dt) => {
+        owed += offered * dt;
+        const n = Math.floor(owed);
+        owed -= n;
+        if (n <= 0) return null;
+        const parts = new Array(n);
+        for (let k = 0; k < n; k++) parts[k] = pool[barIdx++ % pool.length];
+        return parts.join('');
+      }
+    : (dt) => {
+        const target = Math.round(offered * dt);
+        if (target <= 0) return null;
+        let chunk = '';
+        while (chunk.length < target) chunk += pool[poolIdx++ % pool.length];
+        return chunk.slice(0, target);
+      };
+
+  await idleFrames(3);
+  const t0 = performance.now();
+  const e0 = clock();
+  const heap0 = performance.memory ? performance.memory.usedJSHeapSize : null;
+  const lt0 = longTasks;
+  const { acked, wallMs, drainMs } = await sustain(makeChunk, durationMs);
+  const tFeed = t0 + wallMs;
+  const stats = frameStats(t0, tFeed); // during the feed — renderer under load
+  await idleFrames(3);
+  return {
+    phase,
+    offered,
+    startEpoch: e0,
+    feedEndEpoch: clock() - (performance.now() - tFeed),
+    parseRate: isProgress ? acked / barLen / (wallMs / 1000) : acked / 1.048576e6 / (wallMs / 1000),
+    drainMs,
+    longTasks: longTasks - lt0,
+    heapDelta: heap0 != null && performance.memory
+      ? (performance.memory.usedJSHeapSize - heap0) / 1048576
+      : null,
+    ...stats,
+  };
+}
+
+const REPS = Number(new URLSearchParams(location.search).get('reps') || 1);
+const phases = [];
+await runRate('warmup', logPool(4 << 20, 32768), 12 << 20, 1500);
+term.reset();
+
+const logPool32 = logPool(32 << 20, 32768);
+const plainPool32 = plainPool(32 << 20, 32768);
+const bars = progressPool(1200);
+for (let rep = 0; rep < REPS; rep++) {
+  term.reset();
+  for (const mbps of [8, 24, 40]) {
+    phases.push({ rep, ...await runRate('log-flood', logPool32, mbps << 20, 6000) });
+  }
+  term.reset();
+  for (const ups of [10_000, 50_000, 200_000]) {
+    phases.push({ rep, ...await runRate('progress', bars, ups, 6000) });
+  }
+  term.reset();
+  for (const mbps of [8, 24, 40]) {
+    phases.push({ rep, ...await runRate('plain-cat', plainPool32, mbps << 20, 6000) });
+  }
+}
+
+window.__PERF = {
+  done: true,
+  renderer,
+  glRenderer,
+  glError,
+  viewport: { w: innerWidth, h: innerHeight, dpr: devicePixelRatio },
+  hidden: document.hidden,
+  phases,
+};
+</script>
+</head>
+<body><div id="term"></div></body>
+</html>`;
+
+// --- static server -----------------------------------------------------------
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://127.0.0.1');
+  if (url.pathname === '/') {
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end(page);
+    return;
+  }
+  if (!url.pathname.startsWith('/xterm/')) {
+    res.writeHead(404); res.end(); return;
+  }
+  const rel = path.normalize(decodeURIComponent(url.pathname.slice('/xterm/'.length)));
+  const file = path.join(XTERM_ROOT, rel);
+  if (!file.startsWith(XTERM_ROOT + path.sep)) {
+    res.writeHead(403); res.end(); return;
+  }
+  fs.readFile(file, (err, data) => {
+    if (err) { res.writeHead(404); res.end(); return; }
+    res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(data);
+  });
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+
+// --- CPU sampler (Chromium process tree, /proc ticks) ------------------------
+const CLK_TCK = 100;
+function treeTicks(rootPid) {
+  const procs = [];
+  for (const entry of fs.readdirSync('/proc')) {
+    if (!/^\d+$/.test(entry)) continue;
+    let stat;
+    try { stat = fs.readFileSync(`/proc/${entry}/stat`, 'utf8'); } catch { continue; }
+    const close = stat.lastIndexOf(')');
+    const rest = stat.slice(close + 2).split(' ');
+    procs.push({
+      pid: +stat.slice(0, stat.indexOf(' ')),
+      ppid: +rest[1],
+      ticks: +rest[11] + +rest[12],
+    });
+  }
+  const byPid = new Map(procs.map((p) => [p.pid, p]));
+  const isDescendant = (pid) => {
+    for (let cur = byPid.get(pid); cur; cur = byPid.get(cur.ppid)) {
+      if (cur.pid === rootPid) return true;
+    }
+    return false;
+  };
+  let total = 0;
+  for (const p of procs) if (isDescendant(p.pid)) total += p.ticks;
+  return total;
+}
+
+// --- run ----------------------------------------------------------------------
+const renderers = process.argv.slice(2).length
+  ? process.argv.slice(2)
+  : ['dom', 'webgl'];
+// Repetitions per phase cell; medians are reported so one GC storm cannot
+// masquerade as a renderer property.
+const REPS = Math.max(1, Number(process.env.REPS || 1));
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+// playwright-core 1.62 dropped browser.process(). The browser is a direct
+// child of this node script, so identify it by parent pid + executable.
+function findBrowserPid() {
+  for (const entry of fs.readdirSync('/proc')) {
+    if (!/^\d+$/.test(entry)) continue;
+    try {
+      const stat = fs.readFileSync(`/proc/${entry}/stat`, 'utf8');
+      const close = stat.lastIndexOf(')');
+      const ppid = +stat.slice(close + 2).split(' ')[1];
+      const cmd = fs.readFileSync(`/proc/${entry}/cmdline`, 'utf8');
+      if (ppid === process.pid && cmd.startsWith(CHROME)) return +entry;
+    } catch { /* process exited between reads */ }
+  }
+  return null;
+}
+
+const browser = await chromium.launch({
+  executablePath: CHROME,
+  headless: !HEADED,
+  env: { ...process.env, DISPLAY },
+  args: [
+    '--no-sandbox',
+    '--enable-precise-memory-info',
+    '--disable-dev-shm-usage',
+    '--window-position=0,0',
+    '--window-size=1920,1080',
+    // A backgrounded or occluded window must not throttle rAF — that would
+    // poison the frame numbers on a greeter session nobody looks at.
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+    '--disable-background-timer-throttling',
+  ],
+});
+
+let rootPid = null;
+const samples = []; // { t: epoch ms, ticks }
+const sampler = setInterval(() => {
+  rootPid ??= findBrowserPid();
+  if (rootPid) samples.push({ t: Date.now(), ticks: treeTicks(rootPid) });
+}, 200);
+
+const cpuSecondsBetween = (t0, t1) => {
+  if (samples.length < 2) return null;
+  const ticksAt = (t) => {
+    let a = samples[0], b = samples[samples.length - 1];
+    for (const s of samples) {
+      if (s.t <= t) a = s;
+      if (s.t >= t) { b = s; break; }
+    }
+    if (a === b) return a.ticks;
+    return a.ticks + ((b.ticks - a.ticks) * (t - a.t)) / (b.t - a.t);
+  };
+  return (ticksAt(t1) - ticksAt(t0)) / CLK_TCK;
+};
+
+const results = [];
+try {
+  for (const renderer of renderers) {
+    const context = await browser.newContext({ viewport: null });
+    const pg = await context.newPage();
+    await pg.goto(`${origin}/?renderer=${renderer}&reps=${REPS}`);
+    await pg.waitForFunction('window.__PERF && window.__PERF.done', null, { timeout: 900_000 });
+    const result = await pg.evaluate('window.__PERF');
+    await pg.screenshot({ path: path.join(OUT_DIR, `${renderer}.png`) });
+    for (const phase of result.phases) {
+      phase.cpuSeconds = cpuSecondsBetween(phase.startEpoch, phase.feedEndEpoch);
+    }
+    results.push(result);
+    await context.close();
+  }
+} finally {
+  clearInterval(sampler);
+  await browser.close();
+  server.close();
+  if (HEADED) {
+    xset('dpms', '600', '600', '600');
+    xset('s', '600', '600');
+  }
+}
+
+// --- report --------------------------------------------------------------------
+// Cells aggregate the REPS repetitions: median for typical behavior, min fps
+// and max p99 for worst case. Rows that dipped below 50 fps in any rep are
+// listed with that rep's heap delta — a collapse coinciding with a large
+// negative delta (post-GC) or preceded by growth points at GC, not renderer
+// architecture.
+const median = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+const fmt = (v) => (v == null ? '—' : v.toFixed(1));
+const row = (cells) =>
+  cells.map((c, i) => String(c).padStart([8, 8, 6, 6, 6, 7, 8, 8, 8][i])).join(' ');
+
+console.log(`\nmuxus webgl terminal renderer benchmark`);
+console.log(`display ${DISPLAY}  ${HEADED ? 'headed (physical)' : 'headless (software GL expected)'}  reps=${REPS}\n`);
+for (const r of results) {
+  console.log(`renderer=${r.renderer}  gpu="${r.glRenderer ?? '— (dom)'}"${r.glError ? '  addon error: ' + r.glError : ''}`);
+  console.log(`viewport ${r.viewport.w}x${r.viewport.h}@${r.viewport.dpr}x  document.hidden=${r.hidden}\n`);
+  console.log(row(['offered', 'parse', 'm_fps', 'lo_fps', 'm_p99', 'hi_p99', 'm_jank', 'm_long', 'm_cpu', 'm_drain']));
+  const collapses = [];
+  const cells = new Map();
+  for (const p of r.phases) {
+    if (p.phase === 'warmup') continue;
+    const key = `${p.phase}@${p.offered}`;
+    if (!cells.has(key)) cells.set(key, []);
+    cells.get(key).push(p);
+    if (p.fps < 50) collapses.push(p);
+  }
+  for (const ps of cells.values()) {
+    const [phase, offered] = [ps[0].phase, ps[0].offered];
+    const offeredLabel =
+      phase === 'progress'
+        ? (offered / 1000) + 'ku/s'
+        : (offered / (1 << 20)) + 'MB/s';
+    const parseLabel =
+      phase === 'progress'
+        ? fmt(median(ps.map((p) => p.parseRate)) / 1000) + 'ku/s'
+        : fmt(median(ps.map((p) => p.parseRate))) + 'MB/s';
+    console.log(
+      phase.padEnd(11) + ' ' +
+      row([
+        offeredLabel,
+        parseLabel,
+        fmt(median(ps.map((p) => p.fps))),
+        fmt(Math.min(...ps.map((p) => p.fps))),
+        fmt(median(ps.map((p) => p.p99))),
+        fmt(Math.max(...ps.map((p) => p.p99))),
+        median(ps.map((p) => p.jank34)),
+        median(ps.map((p) => p.longTasks)),
+        fmt(median(ps.filter((p) => p.cpuSeconds != null).map((p) => p.cpuSeconds))),
+        fmt(median(ps.map((p) => p.drainMs))),
+      ]),
+    );
+  }
+  if (collapses.length) {
+    console.log('  collapsed reps (fps < 50):');
+    for (const p of collapses) {
+      console.log(
+        `    ${p.phase} ${(p.offered / (p.phase === 'progress' ? 1000 : 1 << 20)).toFixed(0)}${p.phase === 'progress' ? 'ku/s' : 'MB/s'}` +
+        ` rep${p.rep}: fps=${fmt(p.fps)} p99=${fmt(p.p99)}ms longtsk=${p.longTasks} heapΔ=${fmt(p.heapDelta)}MB`,
+      );
+    }
+  }
+  console.log('');
+}
+const reportPath = path.join(OUT_DIR, 'results.json');
+fs.writeFileSync(reportPath, JSON.stringify(results, null, 2));
+console.log(`results: ${reportPath}`);

--- a/hack/webgl-perf.mjs
+++ b/hack/webgl-perf.mjs
@@ -183,37 +183,46 @@ function progressPool(count) {
 // or renderer that cannot keep up builds a backlog instead of pacing the feed.
 // A write callback closing means the chunk is parsed; pending counts chunks
 // the parser has not caught up with. drainMs = backlog still flushing after
-// the feed stopped.
+// the feed stopped. parseRate counts only chunks acknowledged DURING the
+// feed window — chunks parsed while draining are not feed throughput.
 function sustain(makeChunk, durationMs) {
   return new Promise((resolve) => {
     const t0 = performance.now();
     let last = t0;
     let written = 0;
     let acked = 0;
+    let ackedAtFeedEnd = 0;
     let pending = 0;
     let stopped = false;
     let feedEnded = 0;
+    const offer = (dt) => {
+      const chunk = makeChunk(dt);
+      if (!chunk) return;
+      pending++;
+      term.write(chunk, () => { pending--; acked += chunk.length; });
+      written += chunk.length;
+    };
     const feedOnce = () => {
       if (stopped) return;
       const now = performance.now();
       if (now - t0 >= durationMs) {
+        // Offer the final [last, deadline] slice too: when the parser blocks
+        // the main thread past the deadline, skipping it short-changes
+        // exactly the overloaded cells and flatters their fps/drain numbers.
+        offer((t0 + durationMs - last) / 1000);
         stopped = true;
-        feedEnded = now;
+        feedEnded = performance.now();
+        ackedAtFeedEnd = acked;
         drain();
         return;
       }
-      const chunk = makeChunk((now - last) / 1000);
+      offer((now - last) / 1000);
       last = now;
-      if (chunk) {
-        pending++;
-        term.write(chunk, () => { pending--; acked += chunk.length; });
-        written += chunk.length;
-      }
       setTimeout(feedOnce, 4);
     };
     const drain = () => {
       if (pending === 0) {
-        resolve({ written, acked, wallMs: feedEnded - t0, drainMs: performance.now() - feedEnded });
+        resolve({ written, ackedAtFeedEnd, wallMs: feedEnded - t0, drainMs: performance.now() - feedEnded });
         return;
       }
       setTimeout(drain, 10);
@@ -230,13 +239,19 @@ function idleFrames(n) {
 }
 
 function frameStats(t0, t1) {
-  const inWindow = frames.filter((t) => t >= t0 && t <= t1);
+  // Count every inter-frame gap overlapping the window — including stalls
+  // that begin before t0 or end after t1. Filtering to frames inside the
+  // window silently drops exactly those boundary-spanning stalls, which are
+  // the overloaded cells' worst latencies.
   const deltas = [];
-  for (let i = 1; i < inWindow.length; i++) deltas.push(inWindow[i] - inWindow[i - 1]);
+  for (let i = 1; i < frames.length; i++) {
+    const a = frames[i - 1], b = frames[i];
+    if (a < t1 && b > t0) deltas.push(b - a);
+  }
   deltas.sort((a, b) => a - b);
   const q = (p) => (deltas.length ? deltas[Math.min(deltas.length - 1, (p * deltas.length) | 0)] : null);
   return {
-    fps: inWindow.length > 1 ? (inWindow.length - 1) / ((inWindow[inWindow.length - 1] - inWindow[0]) / 1000) : 0,
+    fps: deltas.length / ((t1 - t0) / 1000),
     p50: q(0.5), p95: q(0.95), p99: q(0.99),
     max: deltas.length ? deltas[deltas.length - 1] : null,
     jank34: deltas.filter((d) => d > 34).length,
@@ -274,7 +289,7 @@ async function runRate(phase, pool, offered, durationMs) {
   const e0 = clock();
   const heap0 = performance.memory ? performance.memory.usedJSHeapSize : null;
   const lt0 = longTasks;
-  const { acked, wallMs, drainMs } = await sustain(makeChunk, durationMs);
+  const { ackedAtFeedEnd, wallMs, drainMs } = await sustain(makeChunk, durationMs);
   const tFeed = t0 + wallMs;
   const stats = frameStats(t0, tFeed); // during the feed — renderer under load
   await idleFrames(3);
@@ -283,7 +298,7 @@ async function runRate(phase, pool, offered, durationMs) {
     offered,
     startEpoch: e0,
     feedEndEpoch: clock() - (performance.now() - tFeed),
-    parseRate: isProgress ? acked / barLen / (wallMs / 1000) : acked / 1.048576e6 / (wallMs / 1000),
+    parseRate: isProgress ? ackedAtFeedEnd / barLen / (wallMs / 1000) : ackedAtFeedEnd / 1.048576e6 / (wallMs / 1000),
     drainMs,
     longTasks: longTasks - lt0,
     heapDelta: heap0 != null && performance.memory

--- a/hack/webgl-toggle-smoke.mjs
+++ b/hack/webgl-toggle-smoke.mjs
@@ -1,13 +1,16 @@
 // One-off smoke: does the GPU renderer toggle actually swap the live terminal?
-//   node /tmp/webgl-toggle-smoke.mjs
+//   node hack/webgl-toggle-smoke.mjs
 // Headed on :0, drives the real UI: connect demo host, open Settings,
-// flip "GPU renderer (WebGL)" off and on, assert the xterm layers swap.
+// flip "GPU renderer (WebGL)" on and off, assert the xterm layers swap.
+// Set CHROME to override the browser.
 import os from 'node:os';
 import path from 'node:path';
 import { chromium } from 'playwright-core';
 import { startDemoEnv } from './demo-env.mjs';
 
-const CHROME = path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
+const CHROME =
+  process.env.CHROME ||
+  path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
 const env = await startDemoEnv();
 
 const layers = (page) =>
@@ -61,14 +64,14 @@ try {
   await page.locator('[role="treeitem"][aria-label="web-01"]').first().click();
   await page.waitForSelector('.xterm-screen');
   await page.waitForSelector('.xterm-screen canvas, .xterm-rows > div');
-  await page.waitForTimeout(1500); // lazy addon import + first prompt
+  await page.waitForTimeout(1500); // first prompt
 
   // The WebGL text canvas is classless; DOM mode has no canvases at all.
   const isWebgl = (s) => s.domRows === 0 && (s.canvases?.length ?? 0) > 0;
   const isDom = (s) => s.domRows > 0 && (s.canvases?.length ?? 0) === 0;
 
   const initial = await layers(page);
-  expect('default pref renders on GPU', isWebgl(initial), JSON.stringify(initial));
+  expect('default pref renders on DOM', isDom(initial), JSON.stringify(initial));
 
   const toggle = async () => {
     await page.click('[aria-label="Settings"]');
@@ -92,12 +95,19 @@ try {
   };
 
   await toggle();
+  await page.waitForTimeout(1200); // lazy addon import
+  const on = await layers(page);
+  expect('toggle on → WebGL renderer live', isWebgl(on), JSON.stringify(on));
+  await page.screenshot({ path: '/tmp/muxus-webgl-perf/toggle-on.png' });
+
+  await toggle();
   await page.waitForTimeout(600);
   const off = await layers(page);
   expect('toggle off → DOM renderer live', isDom(off), JSON.stringify(off));
   await page.screenshot({ path: '/tmp/muxus-webgl-perf/toggle-off.png' });
 
-  // The session itself must survive the renderer swap.
+  // The session itself must survive the round-trip; read the echo from the
+  // DOM rows, which only exist while the DOM renderer is active.
   await page.locator('.xterm-screen').first().click();
   await page.keyboard.type('echo renderer-swap-ok');
   await page.keyboard.press('Enter');
@@ -108,13 +118,7 @@ try {
       () => document.querySelector('.xterm-rows')?.textContent?.includes('renderer-swap-ok') ?? false,
     );
   }
-  expect('session alive after swap to DOM', echoed, '');
-
-  await toggle();
-  await page.waitForTimeout(1200); // lazy import again
-  const on = await layers(page);
-  expect('toggle on → WebGL renderer live', isWebgl(on), JSON.stringify(on));
-  await page.screenshot({ path: '/tmp/muxus-webgl-perf/toggle-on.png' });
+  expect('session alive after renderer round-trip', echoed, '');
 
   expect('no console errors', consoleErrors.length === 0, consoleErrors.join(' | '));
   await browser.close();

--- a/hack/webgl-toggle-smoke.mjs
+++ b/hack/webgl-toggle-smoke.mjs
@@ -5,7 +5,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import { chromium } from 'playwright-core';
-import { startDemoEnv } from '/home/coderred/Projects/muxus/hack/demo-env.mjs';
+import { startDemoEnv } from './demo-env.mjs';
 
 const CHROME = path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
 const env = await startDemoEnv();

--- a/hack/webgl-toggle-smoke.mjs
+++ b/hack/webgl-toggle-smoke.mjs
@@ -1,0 +1,124 @@
+// One-off smoke: does the GPU renderer toggle actually swap the live terminal?
+//   node /tmp/webgl-toggle-smoke.mjs
+// Headed on :0, drives the real UI: connect demo host, open Settings,
+// flip "GPU renderer (WebGL)" off and on, assert the xterm layers swap.
+import os from 'node:os';
+import path from 'node:path';
+import { chromium } from 'playwright-core';
+import { startDemoEnv } from '/home/coderred/Projects/muxus/hack/demo-env.mjs';
+
+const CHROME = path.join(os.homedir(), '.cache/ms-playwright/chromium-1223/chrome-linux64/chrome');
+const env = await startDemoEnv();
+
+const layers = (page) =>
+  page.evaluate(() => {
+    const screen = document.querySelector('.xterm-screen');
+    if (!screen) return { missing: true };
+    return {
+      canvases: [...screen.querySelectorAll('canvas')].map((c) => c.className),
+      domRows: screen.querySelectorAll('.xterm-rows > div').length,
+    };
+  });
+
+let failures = 0;
+function expect(label, cond, detail) {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${label}  ${detail}`);
+  if (!cond) failures++;
+}
+
+try {
+  const browser = await chromium.launch({
+    executablePath: CHROME,
+    headless: false,
+    env: { ...process.env, DISPLAY: ':0' },
+    args: [
+      '--no-sandbox',
+      '--window-position=0,0',
+      '--window-size=1920,1080',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+      '--disable-background-timer-throttling',
+    ],
+  });
+  const page = await (await browser.newContext({ viewport: null })).newPage();
+  const consoleErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return;
+    // Pre-existing noise: CSP frame-ancestors is ignored in <meta> delivery.
+    if (msg.text().includes('frame-ancestors')) return;
+    consoleErrors.push(msg.text());
+  });
+
+  // Same clean start as the docs tour: no workspace restore.
+  await page.route('**/api/workspaces/latest', (r) => r.fulfill({ json: { workspace: null } }));
+  await page.route('**/api/workspaces/startup', (r) =>
+    r.request().method() === 'GET' ? r.fulfill({ json: { workspace: null } }) : r.continue(),
+  );
+  await page.goto(`${env.url}/?token=${env.token}`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[aria-label="Add host"]');
+
+  // Connect a demo host and wait for a live terminal.
+  await page.locator('[role="treeitem"][aria-label="web-01"]').first().click();
+  await page.waitForSelector('.xterm-screen');
+  await page.waitForSelector('.xterm-screen canvas, .xterm-rows > div');
+  await page.waitForTimeout(1500); // lazy addon import + first prompt
+
+  // The WebGL text canvas is classless; DOM mode has no canvases at all.
+  const isWebgl = (s) => s.domRows === 0 && (s.canvases?.length ?? 0) > 0;
+  const isDom = (s) => s.domRows > 0 && (s.canvases?.length ?? 0) === 0;
+
+  const initial = await layers(page);
+  expect('default pref renders on GPU', isWebgl(initial), JSON.stringify(initial));
+
+  const toggle = async () => {
+    await page.click('[aria-label="Settings"]');
+    // The dialog container intercepts pointer events during the paper
+    // transition, so click through the DOM instead of coordinates.
+    await page.waitForSelector('.MuiDialog-paper [role="button"]:has-text("Terminal")');
+    await page.waitForTimeout(600);
+    await page.evaluate(() =>
+      [...document.querySelectorAll('.MuiDialog-paper [role="button"]')]
+        .find((b) => b.textContent.trim() === 'Terminal')
+        .click(),
+    );
+    await page.waitForSelector('.MuiDialog-paper >> text=GPU renderer (WebGL)');
+    await page.evaluate(() =>
+      [...document.querySelectorAll('.MuiDialog-paper .MuiFormControlLabel-root')]
+        .find((l) => l.textContent.includes('GPU renderer'))
+        .querySelector('input[type="checkbox"]')
+        .click(),
+    );
+    await page.keyboard.press('Escape');
+  };
+
+  await toggle();
+  await page.waitForTimeout(600);
+  const off = await layers(page);
+  expect('toggle off → DOM renderer live', isDom(off), JSON.stringify(off));
+  await page.screenshot({ path: '/tmp/muxus-webgl-perf/toggle-off.png' });
+
+  // The session itself must survive the renderer swap.
+  await page.locator('.xterm-screen').first().click();
+  await page.keyboard.type('echo renderer-swap-ok');
+  await page.keyboard.press('Enter');
+  let echoed = false;
+  for (let i = 0; i < 10 && !echoed; i++) {
+    await page.waitForTimeout(300);
+    echoed = await page.evaluate(
+      () => document.querySelector('.xterm-rows')?.textContent?.includes('renderer-swap-ok') ?? false,
+    );
+  }
+  expect('session alive after swap to DOM', echoed, '');
+
+  await toggle();
+  await page.waitForTimeout(1200); // lazy import again
+  const on = await layers(page);
+  expect('toggle on → WebGL renderer live', isWebgl(on), JSON.stringify(on));
+  await page.screenshot({ path: '/tmp/muxus-webgl-perf/toggle-on.png' });
+
+  expect('no console errors', consoleErrors.length === 0, consoleErrors.join(' | '));
+  await browser.close();
+} finally {
+  await env.stop();
+}
+process.exit(failures ? 1 : 0);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@xterm/addon-web-links':
         specifier: ^0.13.0-beta.292
         version: 0.13.0-beta.292(@xterm/xterm@6.1.0-beta.292)
+      '@xterm/addon-webgl':
+        specifier: 0.20.0-beta.291
+        version: 0.20.0-beta.291(@xterm/xterm@6.1.0-beta.292)
       '@xterm/xterm':
         specifier: ^6.1.0-beta.292
         version: 6.1.0-beta.292
@@ -1634,6 +1637,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-clipboard@0.3.0-beta.292':
     resolution: {integrity: sha512-UNjPtLHO9do8lDoYcfuipBtQzjjex2iOudN7G+2ExqcvecVnex6v0UGxUttgg0xN+a6TTEZkdIaWIi/kZnjtoA==}
@@ -1667,6 +1671,11 @@ packages:
 
   '@xterm/addon-web-links@0.13.0-beta.292':
     resolution: {integrity: sha512-1k3i3N8Jm0ZU9oQD5X9WNiWOMRkHFkgFZT9ZoUNHteBksrUbWGVnjZLXxRBfhvYUPYD5pzwrq/i6OtQzggJRXA==}
+    peerDependencies:
+      '@xterm/xterm': ^6.1.0-beta.292
+
+  '@xterm/addon-webgl@0.20.0-beta.291':
+    resolution: {integrity: sha512-gH7r5g8f2NWMhBtaeApuwLQTJmX4uq7zT0okjeNWkFAD0nxzbUPB+kt6sogZZ5K90XYPt2OLu/bhuvF6DmKqOQ==}
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.292
 
@@ -4591,6 +4600,10 @@ snapshots:
       '@xterm/xterm': 6.1.0-beta.292
 
   '@xterm/addon-web-links@0.13.0-beta.292(@xterm/xterm@6.1.0-beta.292)':
+    dependencies:
+      '@xterm/xterm': 6.1.0-beta.292
+
+  '@xterm/addon-webgl@0.20.0-beta.291(@xterm/xterm@6.1.0-beta.292)':
     dependencies:
       '@xterm/xterm': 6.1.0-beta.292
 

--- a/tests/unit/client/data-transfer.test.ts
+++ b/tests/unit/client/data-transfer.test.ts
@@ -821,6 +821,16 @@ describe('restoring the OSC 52 clipboard preference', () => {
   });
 });
 
+describe('restoring the GPU renderer preference', () => {
+  const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
+
+  it('restores only boolean renderer choices', () => {
+    expect(sanitizePreferences(prefs({ webglRenderer: true })))
+      .toMatchObject({ webglRenderer: true });
+    expect(sanitizePreferences(prefs({ webglRenderer: 'off' })).webglRenderer).toBeUndefined();
+  });
+});
+
 describe('restoring the update notification preference', () => {
   const prefs = (patch: Record<string, unknown>) => patch as unknown as BackupPreferences;
 

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -100,6 +100,19 @@ describe('split pane focus preferences', () => {
   });
 });
 
+describe('GPU renderer preference', () => {
+  it('defaults to the DOM renderer', () => {
+    expect(usePrefsStore.getInitialState().webglRenderer).toBe(false);
+  });
+
+  it('keeps a boolean choice and drops malformed persisted values', () => {
+    expect(migratePrefsState({ webglRenderer: true }, 12)).toEqual({ webglRenderer: true });
+    expect(migratePrefsState({ webglRenderer: 'off', monoFontSize: 16 }, 12)).toEqual({
+      monoFontSize: 16,
+    });
+  });
+});
+
 describe('tab number visibility preference', () => {
   it('defaults to revealing numbers while Alt is held', () => {
     expect(usePrefsStore.getInitialState().tabNumberVisibility).toBe('shortcut');


### PR DESCRIPTION
## Summary

- add a **GPU renderer (WebGL)** switch to Settings → Terminal → Renderer, backed by a new `webglRenderer` preference (default on)
- swap the renderer live in open terminals — load or dispose the `WebglAddon` in place, no session reopen, terminal state preserved (no remount, per the flat pane canvas constraint)
- refit after every swap: the WebGL renderer floors cell width to whole device pixels (14px JetBrains Mono: 8.4px → 8.0) while the DOM renderer keeps the fractional width, so an unrefit swap leaves the grid sized for the other renderer
- keep the addon a lazy async chunk outside the eager xterm bundle; context loss still falls back to the DOM renderer
- pin `@xterm/addon-webgl` to exactly `0.20.0-beta.291` — the webgl release whose peer range (`^6.1.0-beta.292`) accepts the beta.292 core (addon beta.292 already demands `^6.1.0-beta.293`)
- include the physical-display benchmark, UI smoke, and cell-geometry probe harnesses under `hack/`

## Why

The WebGL addon was previously loaded unconditionally at mount: invisible, untoggleable, and — once loadable — leaving the terminal grid sized for the wrong renderer, because the two renderers disagree on cell width.

Measurement on a physical display (harness included, 5-rep medians): both renderers hold ~59.5 fps with identical parse throughput up to 40MB/s, but their costs differ — DOM CPU scales with load (0.6–6.3 CPU-s per 6s phase, cheapest at idle) while WebGL pays a flat ~1 core. Under simulated CPU pressure (2× CDP throttle, 24MB/s) the picture flips: WebGL holds 25–31 fps at p99 83–183ms where DOM drops to 14–20 fps at up to 950ms, because DOM painting competes with the throttled main thread while WebGL paints on the GPU. The default stays on: the tax is imperceptible where it costs, the win is decisive where it matters.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (931 tests)
- `pnpm build` — addon stays a separate ~250KB async chunk
- `pnpm check:bundle`
- `node hack/webgl-toggle-smoke.mjs` — real-UI smoke on a physical display: GPU default → live DOM swap → session echo survives → back to GPU, zero console errors (5/5)
- `node hack/webgl-perf.mjs` — headed runs on a physical monitor (DPMS-guarded; a sleeping display throttles rAF and poisons frame metrics), baseline plus CPU-throttle and hi-DPI simulations
- two independent review rounds against the branch; all findings (peer-version drift, benchmark methodology gaps, token hygiene) addressed in-branch

## Screenshot

Settings → Terminal → Renderer (the toggle applies live to open terminals):

![Settings > Terminal > Renderer — GPU renderer (WebGL) toggle](https://gist.githubusercontent.com/coderredlab/07646017493575090f7524106fce5463/raw/settings-renderer.png)
