### PR TITLE
feat: paste clipboard images into SSH terminals

### DIFF
--- a/client/src/clipboard.ts
+++ b/client/src/clipboard.ts
@@ -1,3 +1,9 @@
+export type ClipboardContent =
+  | { kind: 'text'; text: string }
+  | { kind: 'image'; png: Uint8Array<ArrayBuffer> }
+  | { kind: 'empty' }
+  | { kind: 'unavailable' };
+
 /**
  * Read text from the clipboard. The async Clipboard API has no legacy read
  * fallback (execCommand('paste') never worked reliably), so this returns null
@@ -12,9 +18,14 @@ export async function readFromClipboard(): Promise<string | null> {
   }
 }
 
-/** Read an image through the packaged Electron bridge; regular browsers have no image fallback. */
-export function readImagePngFromClipboard(): Promise<Uint8Array<ArrayBuffer> | undefined> {
-  return window.muxusDesktop?.readClipboardImagePng() ?? Promise.resolve(undefined);
+/** Capture one clipboard snapshot; the packaged app reads text and image synchronously. */
+export async function readClipboardContent(): Promise<ClipboardContent> {
+  if (window.muxusDesktop?.readClipboardContent) {
+    return (await window.muxusDesktop.readClipboardContent()) ?? { kind: 'unavailable' };
+  }
+  const text = await readFromClipboard();
+  if (text === null) return { kind: 'unavailable' };
+  return text ? { kind: 'text', text } : { kind: 'empty' };
 }
 
 /**

--- a/client/src/clipboard.ts
+++ b/client/src/clipboard.ts
@@ -12,6 +12,11 @@ export async function readFromClipboard(): Promise<string | null> {
   }
 }
 
+/** Read an image through the packaged Electron bridge; regular browsers have no image fallback. */
+export function readImagePngFromClipboard(): Promise<Uint8Array<ArrayBuffer> | undefined> {
+  return window.muxusDesktop?.readClipboardImagePng() ?? Promise.resolve(undefined);
+}
+
 /**
  * Copy text to the clipboard. The async Clipboard API only exists in secure
  * contexts (https/localhost/Electron); when the UI is served over plain http

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -39,7 +39,11 @@ import {
   wsUrl,
 } from '../api/http.js';
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
-import { copyToClipboard, readFromClipboard } from '../clipboard.js';
+import {
+  copyToClipboard,
+  readFromClipboard,
+  readImagePngFromClipboard,
+} from '../clipboard.js';
 import { loadMonacoTextEditor, loadRemoteEditorWorkspace } from '../lazy-features.js';
 import { IS_MAC } from '../platform.js';
 import { exportFilename, saveTextFile } from '../save-file.js';
@@ -84,6 +88,10 @@ import {
   terminalRightClickIntent,
   xtermRightClickSelectsWord,
 } from '../terminal/right-click.js';
+import {
+  pasteTerminalClipboard,
+  uploadTerminalClipboardImage,
+} from '../terminal/clipboard-paste.js';
 import {
   AuthPromptDialog,
   type AuthPromptRequest,
@@ -373,13 +381,36 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   };
 
   const pasteFromClipboard = () => {
-    void readFromClipboard().then((text) => {
-      if (text === null) {
-        showToast('warning', 'Clipboard read unavailable or denied — allow clipboard access, or paste with the keyboard.');
-        return;
-      }
-      if (text) pasteText(text);
-    });
+    void pasteTerminalClipboard({
+      readText: readFromClipboard,
+      readImagePng: readImagePngFromClipboard,
+      uploadImage: async (png) => {
+        const current = useTabsStore.getState().tabs.find((candidate) => candidate.id === tab.id);
+        if (current?.profile?.kind !== 'ssh') {
+          throw new Error('Image paste is available in SSH terminals.');
+        }
+        if (current.sftpAvailable === false) {
+          throw new Error('Image paste requires SFTP, which is disabled for this host.');
+        }
+        if (!current.connId) {
+          throw new Error('Reconnect the SSH session before pasting an image.');
+        }
+        return uploadTerminalClipboardImage(current.connId, png);
+      },
+      pasteText,
+    })
+      .then((result) => {
+        if (result.status === 'skipped' && result.reason === 'unavailable') {
+          showToast(
+            'warning',
+            'Clipboard read unavailable or denied — allow clipboard access, or paste with the keyboard.',
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        const detail = error instanceof Error ? error.message : String(error);
+        showToast('error', `Could not paste the image. ${detail}`);
+      });
   };
 
   // Right-click behavior is a preference: the terminal-emulator convention
@@ -657,6 +688,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         return Math.round(((base + zoomRef.current) / base) * 100);
       },
       paste: (text) => pasteText(text),
+      pasteClipboard: pasteFromClipboard,
       setLogging: (patch) => {
         const socket = wsRef.current;
         if (!socket || socket.readyState !== WebSocket.OPEN) return false;
@@ -667,7 +699,13 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
 
     const onNativePaste = (event: ClipboardEvent) => {
       const text = event.clipboardData?.getData('text/plain');
-      if (!text || !usePrefsStore.getState().pasteWarnMultiline || !requiresPasteConfirmation(text)) return;
+      if (!text) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        pasteFromClipboard();
+        return;
+      }
+      if (!usePrefsStore.getState().pasteWarnMultiline || !requiresPasteConfirmation(text)) return;
       event.preventDefault();
       event.stopImmediatePropagation();
       setSearchOpen(false);

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -41,8 +41,7 @@ import {
 import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
 import {
   copyToClipboard,
-  readFromClipboard,
-  readImagePngFromClipboard,
+  readClipboardContent,
 } from '../clipboard.js';
 import { loadMonacoTextEditor, loadRemoteEditorWorkspace } from '../lazy-features.js';
 import { IS_MAC } from '../platform.js';
@@ -89,7 +88,10 @@ import {
   xtermRightClickSelectsWord,
 } from '../terminal/right-click.js';
 import {
+  isCurrentTerminalImagePasteTarget,
   pasteTerminalClipboard,
+  type TerminalClipboardPayload,
+  TerminalClipboardPasteQueue,
   uploadTerminalClipboardImage,
 } from '../terminal/clipboard-paste.js';
 import {
@@ -228,12 +230,19 @@ async function openLinkedTerminalFile(tabId: string, candidate: string): Promise
   useTabsStore.getState().openEditor(tabId, path);
 }
 
+interface PendingPaste {
+  text: string;
+  broadcast: boolean;
+  resolve: () => void;
+}
+
 export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; active: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const searchRef = useRef<SearchAddon | null>(null);
+  const terminalInputReadyRef = useRef(false);
   const serializeRef = useRef<SerializeAddon | null>(null);
   const imageRef = useRef<ImageAddon | null>(null);
   const keywordHighlighterRef = useRef<KeywordHighlighter | null>(null);
@@ -249,10 +258,14 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   const carryBufferRef = useRef<string | null>(null);
   /** Stored history is fetched at most once per mounted tab. */
   const snapshotFetchedRef = useRef(false);
+  const suppressNextInputBroadcastRef = useRef(false);
+  const clipboardPasteQueueRef = useRef<TerminalClipboardPasteQueue | null>(null);
+  const clipboardPasteQueue = (clipboardPasteQueueRef.current ??= new TerminalClipboardPasteQueue());
+  const pendingPasteResolverRef = useRef<(() => void) | null>(null);
   const theme = useTheme();
   const [authPrompt, setAuthPrompt] = useState<AuthPromptRequest | null>(null);
   const [hostKey, setHostKey] = useState<HostKeyRequest | null>(null);
-  const [pendingPaste, setPendingPaste] = useState<string | null>(null);
+  const [pendingPaste, setPendingPaste] = useState<PendingPaste | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchCase, setSearchCase] = useState(false);
@@ -264,6 +277,14 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     left: number;
     selection: string;
   } | null>(null);
+  useEffect(
+    () => () => {
+      clipboardPasteQueueRef.current?.cancelAll();
+      pendingPasteResolverRef.current?.();
+      pendingPasteResolverRef.current = null;
+    },
+    [],
+  );
   const [generation, setGeneration] = useState(tab.connectOnMount ? 1 : 0);
   const reconnectRequest = useTabsStore(
     (s) => s.tabs.find((candidate) => candidate.id === tab.id)?.reconnectRequest ?? 0,
@@ -350,13 +371,23 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     [searchCase, searchWord, searchRegex],
   );
 
-  const pasteText = (text: string) => {
+  const pasteToTerminal = (text: string, broadcast: boolean) => {
+    const term = termRef.current;
+    if (!term) return;
+    if (!broadcast) suppressNextInputBroadcastRef.current = true;
+    term.paste(text);
+  };
+
+  const pasteText = (text: string, broadcast = true): Promise<void> => {
     if (usePrefsStore.getState().pasteWarnMultiline && requiresPasteConfirmation(text)) {
       setSearchOpen(false);
-      setPendingPaste(text);
-      return;
+      const { promise, resolve } = Promise.withResolvers<void>();
+      pendingPasteResolverRef.current = resolve;
+      setPendingPaste({ text, broadcast, resolve });
+      return promise;
     }
-    termRef.current?.paste(text);
+    pasteToTerminal(text, broadcast);
+    return Promise.resolve();
   };
 
   /** Refit, unless the pane is hidden and there is nothing to measure. */
@@ -380,25 +411,51 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     }
   };
 
-  const pasteFromClipboard = () => {
-    void pasteTerminalClipboard({
-      readText: readFromClipboard,
-      readImagePng: readImagePngFromClipboard,
-      uploadImage: async (png) => {
-        const current = useTabsStore.getState().tabs.find((candidate) => candidate.id === tab.id);
-        if (current?.profile?.kind !== 'ssh') {
-          throw new Error('Image paste is available in SSH terminals.');
-        }
-        if (current.sftpAvailable === false) {
-          throw new Error('Image paste requires SFTP, which is disabled for this host.');
-        }
-        if (!current.connId) {
-          throw new Error('Reconnect the SSH session before pasting an image.');
-        }
-        return uploadTerminalClipboardImage(current.connId, png);
-      },
-      pasteText,
-    })
+  const pasteFromClipboard = (
+    capture: (signal: AbortSignal) => Promise<TerminalClipboardPayload> = () =>
+      readClipboardContent(),
+  ) => {
+    const operation = clipboardPasteQueue.enqueue(capture, (clipboard, signal) => {
+      let uploadedConnectionId: string | undefined;
+      return pasteTerminalClipboard(clipboard, {
+        uploadImage: async (png) => {
+          const current = useTabsStore
+            .getState()
+            .tabs.find((candidate) => candidate.id === tab.id);
+          if (current?.profile?.kind !== 'ssh') {
+            throw new Error('Image paste is available in SSH terminals.');
+          }
+          if (current.sftpAvailable === false) {
+            throw new Error('Image paste requires SFTP, which is disabled for this host.');
+          }
+          if (!current.connId) {
+            throw new Error('Reconnect the SSH session before pasting an image.');
+          }
+          uploadedConnectionId = current.connId;
+          return uploadTerminalClipboardImage(current.connId, png, signal);
+        },
+        pasteText,
+        pasteImagePath: async (path) => {
+          signal.throwIfAborted();
+          const current = useTabsStore
+            .getState()
+            .tabs.find((candidate) => candidate.id === tab.id);
+          if (
+            !isCurrentTerminalImagePasteTarget({
+              connectionId: current?.connId,
+              expectedConnectionId: uploadedConnectionId,
+              inputReady: terminalInputReadyRef.current,
+              socketOpen: wsRef.current?.readyState === WebSocket.OPEN,
+              ssh: current?.profile?.kind === 'ssh',
+            })
+          ) {
+            throw new Error('The SSH session disconnected before the image path was pasted.');
+          }
+          await pasteText(path, false);
+        },
+      });
+    });
+    void operation
       .then((result) => {
         if (result.status === 'skipped' && result.reason === 'unavailable') {
           showToast(
@@ -408,8 +465,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         }
       })
       .catch((error: unknown) => {
+        if (error instanceof Error && error.name === 'AbortError') return;
         const detail = error instanceof Error ? error.message : String(error);
-        showToast('error', `Could not paste the image. ${detail}`);
+        showToast('error', `Could not paste clipboard content. ${detail}`);
       });
   };
 
@@ -457,6 +515,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+    terminalInputReadyRef.current = false;
     const shouldConnect = generation > 0;
     const reconnectCwd =
       tab.profile.kind === 'ssh' && tab.reconnectRequest > 0
@@ -687,7 +746,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         const base = usePrefsStore.getState().monoFontSize;
         return Math.round(((base + zoomRef.current) / base) * 100);
       },
-      paste: (text) => pasteText(text),
+      paste: (text) =>
+        pasteFromClipboard(() => Promise.resolve({ kind: 'text', text })),
       pasteClipboard: pasteFromClipboard,
       setLogging: (patch) => {
         const socket = wsRef.current;
@@ -698,18 +758,14 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     });
 
     const onNativePaste = (event: ClipboardEvent) => {
-      const text = event.clipboardData?.getData('text/plain');
-      if (!text) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        pasteFromClipboard();
-        return;
-      }
-      if (!usePrefsStore.getState().pasteWarnMultiline || !requiresPasteConfirmation(text)) return;
       event.preventDefault();
       event.stopImmediatePropagation();
-      setSearchOpen(false);
-      setPendingPaste(text);
+      const text = event.clipboardData?.getData('text/plain');
+      if (text) {
+        pasteFromClipboard(() => Promise.resolve({ kind: 'text', text }));
+      } else {
+        pasteFromClipboard();
+      }
     };
     el.addEventListener('paste', onNativePaste, true);
 
@@ -1005,6 +1061,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
             break;
           case 'ready': {
             ready = true;
+            terminalInputReadyRef.current = true;
             if (!attachingExistingSession || readyAt === 0) readyAt = Date.now();
             if (!attachingExistingSession) rendererReattachAttempts = 0;
             if (rendererStableTimer !== undefined) clearTimeout(rendererStableTimer);
@@ -1075,6 +1132,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         socketFailed = true;
       };
       socket.onclose = (event) => {
+        terminalInputReadyRef.current = false;
         if (wsRef.current === socket) wsRef.current = null;
         if (disposed) return;
         clearTransientStatus();
@@ -1237,8 +1295,13 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
     const onData = term.onData((data) => {
       const normalized = normalizeTerminalKeyboardInput(data, inputKeyEvent, IS_MAC);
       inputKeyEvent = undefined;
-      if (sendInput(normalized)) broadcastTerminalInput(tab.id, normalized);
-      else reconnectFromTerminalInput();
+      const broadcast = !suppressNextInputBroadcastRef.current;
+      suppressNextInputBroadcastRef.current = false;
+      if (sendInput(normalized)) {
+        if (broadcast) broadcastTerminalInput(tab.id, normalized);
+      } else {
+        reconnectFromTerminalInput();
+      }
     });
     const onBinary = term.onBinary((data) => {
       const bytes = new Uint8Array(data.length);
@@ -1326,6 +1389,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       imageRef.current = null;
       keywordHighlighterRef.current = null;
       termRef.current = null;
+      terminalInputReadyRef.current = false;
       wsRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1676,11 +1740,17 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
       <HostKeyDialog request={hostKey} onAnswer={answerHostKey} />
       {pendingPaste !== null ? (
         <PasteConfirmDialog
-          initialText={pendingPaste}
-          onCancel={() => setPendingPaste(null)}
+          initialText={pendingPaste.text}
+          onCancel={() => {
+            setPendingPaste(null);
+            pendingPasteResolverRef.current = null;
+            pendingPaste.resolve();
+          }}
           onConfirm={(text) => {
             setPendingPaste(null);
-            termRef.current?.paste(text);
+            pendingPasteResolverRef.current = null;
+            pasteToTerminal(text, pendingPaste.broadcast);
+            pendingPaste.resolve();
             termRef.current?.focus();
           }}
         />

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -5,6 +5,11 @@ import type {
   UpdateCheckResult,
 } from '@muxus/shared';
 
+type DesktopClipboardContent =
+  | { kind: 'text'; text: string }
+  | { kind: 'image'; png: Uint8Array<ArrayBuffer> }
+  | { kind: 'empty' };
+
 declare global {
   /** Bridge exposed by the Electron preload (absent in regular browsers). */
   interface Window {
@@ -25,8 +30,8 @@ declare global {
       setZoomFactor(factor: number): void;
       getAppInfo(): Promise<AppInfo | undefined>;
       checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult>;
-      /** Read an OS clipboard image as validated PNG bytes. */
-      readClipboardImagePng(): Promise<Uint8Array<ArrayBuffer> | undefined>;
+      /** Capture OS clipboard text or a validated PNG in one main-process snapshot. */
+      readClipboardContent(): Promise<DesktopClipboardContent | undefined>;
       /** Choose an SSH private key with the operating system's file picker. */
       selectPrivateKey(): Promise<string | undefined>;
       /** Read bookmark-only sessions from the current Windows user's MobaXterm install. */

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -25,6 +25,8 @@ declare global {
       setZoomFactor(factor: number): void;
       getAppInfo(): Promise<AppInfo | undefined>;
       checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult>;
+      /** Read an OS clipboard image as validated PNG bytes. */
+      readClipboardImagePng(): Promise<Uint8Array<ArrayBuffer> | undefined>;
       /** Choose an SSH private key with the operating system's file picker. */
       selectPrivateKey(): Promise<string | undefined>;
       /** Read bookmark-only sessions from the current Windows user's MobaXterm install. */

--- a/client/src/keymap/commands.ts
+++ b/client/src/keymap/commands.ts
@@ -1,4 +1,4 @@
-import { copyToClipboard, readFromClipboard } from '../clipboard.js';
+import { copyToClipboard } from '../clipboard.js';
 import { IS_MAC } from '../platform.js';
 import { requestCloseRemoteEditor } from '../editor/remote-editor-registry.js';
 import {
@@ -288,9 +288,7 @@ export const KEY_COMMANDS: readonly KeyCommand[] = [
     run: () => {
       const handle = activeTerminal();
       if (!handle) return false;
-      void readFromClipboard().then((text) => {
-        if (text) handle.paste(text);
-      });
+      handle.pasteClipboard();
       return true;
     },
   },

--- a/client/src/terminal/clipboard-paste.ts
+++ b/client/src/terminal/clipboard-paste.ts
@@ -1,58 +1,164 @@
-import { apiFetchRaw } from '../api/http.js';
+import { apiFetch } from '../api/http.js';
+
+export type TerminalClipboardPayload =
+  | { kind: 'text'; text: string }
+  | { kind: 'image'; png: Uint8Array<ArrayBuffer> }
+  | { kind: 'empty' }
+  | { kind: 'unavailable' };
 
 export type TerminalClipboardPasteResult =
   | { status: 'pasted'; kind: 'image-path' | 'text' }
   | { status: 'skipped'; reason: 'empty' | 'unavailable' };
 
-interface TerminalClipboardPasteOptions {
-  readText: () => Promise<string | null>;
-  readImagePng: () => Promise<Uint8Array<ArrayBuffer> | undefined>;
+
+interface PasteTerminalClipboardOptions {
   uploadImage: (png: Uint8Array<ArrayBuffer>) => Promise<string>;
-  pasteText: (text: string) => void;
+  pasteText: (text: string) => void | Promise<void>;
+  pasteImagePath: (path: string) => void | Promise<void>;
 }
 
-export function remoteClipboardImagePath(
-  timestamp = Date.now(),
-  id: string = crypto.randomUUID(),
-): string {
-  return `/tmp/muxus-paste-${timestamp}-${id}.png`;
+interface TerminalImagePasteTarget {
+  connectionId?: string;
+  expectedConnectionId?: string;
+  inputReady: boolean;
+  socketOpen: boolean;
+  ssh: boolean;
 }
+
+export function isCurrentTerminalImagePasteTarget({
+  connectionId,
+  expectedConnectionId,
+  inputReady,
+  socketOpen,
+  ssh,
+}: TerminalImagePasteTarget): boolean {
+  return (
+    ssh &&
+    inputReady &&
+    socketOpen &&
+    expectedConnectionId !== undefined &&
+    connectionId === expectedConnectionId
+  );
+}
+
+interface TerminalClipboardPasteQueueLimits {
+  maxPendingImageBytes: number;
+  maxPendingPastes: number;
+}
+
+const DEFAULT_QUEUE_LIMITS: TerminalClipboardPasteQueueLimits = {
+  maxPendingImageBytes: 36 * 1024 * 1024,
+  maxPendingPastes: 8,
+};
+
+type CapturedClipboardPayload =
+  | { ok: true; payload: TerminalClipboardPayload }
+  | { ok: false; error: unknown };
+
+export class TerminalClipboardPasteQueue {
+  private tail: Promise<void> = Promise.resolve();
+  private readonly controllers = new Set<AbortController>();
+  private pendingImageBytes = 0;
+  private pendingPastes = 0;
+
+  constructor(
+    private readonly limits: TerminalClipboardPasteQueueLimits = DEFAULT_QUEUE_LIMITS,
+  ) {}
+
+  cancelAll(): void {
+    for (const controller of this.controllers) controller.abort();
+  }
+
+  enqueue<TResult>(
+    capture: (signal: AbortSignal) => Promise<TerminalClipboardPayload>,
+    apply: (payload: TerminalClipboardPayload, signal: AbortSignal) => Promise<TResult>,
+  ): Promise<TResult> {
+    if (this.pendingPastes >= this.limits.maxPendingPastes) {
+      return Promise.reject(new Error('Too many clipboard pastes are waiting.'));
+    }
+    this.pendingPastes++;
+
+    const controller = new AbortController();
+    this.controllers.add(controller);
+    let payloadPromise: Promise<TerminalClipboardPayload>;
+    try {
+      payloadPromise = capture(controller.signal);
+    } catch (error) {
+      payloadPromise = Promise.reject(error);
+    }
+
+    let reservedImageBytes = 0;
+    const captured = payloadPromise.then<CapturedClipboardPayload, CapturedClipboardPayload>(
+      (payload) => {
+        if (payload.kind === 'image') {
+          if (
+            this.pendingImageBytes + payload.png.byteLength >
+            this.limits.maxPendingImageBytes
+          ) {
+            return { ok: false, error: new Error('Too much clipboard image data is waiting.') };
+          }
+          reservedImageBytes = payload.png.byteLength;
+          this.pendingImageBytes += reservedImageBytes;
+        }
+        return { ok: true, payload };
+      },
+      (error: unknown) => ({ ok: false, error }),
+    );
+
+    const operation = this.tail.then(async () => {
+      controller.signal.throwIfAborted();
+      const clipboard = await captured;
+      controller.signal.throwIfAborted();
+      if (!clipboard.ok) throw clipboard.error;
+      const result = await apply(clipboard.payload, controller.signal);
+      controller.signal.throwIfAborted();
+      return result;
+    });
+    const settled = operation.finally(() => {
+      this.controllers.delete(controller);
+      this.pendingPastes--;
+      this.pendingImageBytes -= reservedImageBytes;
+    });
+    this.tail = settled.then(
+      () => undefined,
+      () => undefined,
+    );
+    return settled;
+  }
+}
+
 
 export async function uploadTerminalClipboardImage(
   connId: string,
   png: Uint8Array<ArrayBuffer>,
+  signal?: AbortSignal,
 ): Promise<string> {
-  const remotePath = remoteClipboardImagePath();
-  await apiFetchRaw(
-    `/api/sftp/${encodeURIComponent(connId)}/upload?path=${encodeURIComponent(remotePath)}`,
+  const response = await apiFetch<{ path: string }>(
+    `/api/sftp/${encodeURIComponent(connId)}/clipboard-image`,
     {
       method: 'POST',
       headers: { 'content-type': 'application/octet-stream' },
       body: png,
+      signal,
     },
   );
-  return remotePath;
+  return response.path;
 }
 
-/** Paste text when present; image-only clipboards become an uploaded remote path. */
-export async function pasteTerminalClipboard({
-  readText,
-  readImagePng,
-  uploadImage,
-  pasteText,
-}: TerminalClipboardPasteOptions): Promise<TerminalClipboardPasteResult> {
-  const text = await readText();
-  if (text) {
-    pasteText(text);
+/** Paste captured text or upload a captured image and paste its remote path. */
+export async function pasteTerminalClipboard(
+  payload: TerminalClipboardPayload,
+  { uploadImage, pasteText, pasteImagePath }: PasteTerminalClipboardOptions,
+): Promise<TerminalClipboardPasteResult> {
+  if (payload.kind === 'text') {
+    await pasteText(payload.text);
     return { status: 'pasted', kind: 'text' };
   }
-
-  const png = await readImagePng();
-  if (!png) {
-    return { status: 'skipped', reason: text === null ? 'unavailable' : 'empty' };
+  if (payload.kind === 'empty' || payload.kind === 'unavailable') {
+    return { status: 'skipped', reason: payload.kind };
   }
 
-  const remotePath = await uploadImage(png);
-  pasteText(remotePath);
+  const remotePath = await uploadImage(payload.png);
+  await pasteImagePath(remotePath);
   return { status: 'pasted', kind: 'image-path' };
 }

--- a/client/src/terminal/clipboard-paste.ts
+++ b/client/src/terminal/clipboard-paste.ts
@@ -1,0 +1,58 @@
+import { apiFetchRaw } from '../api/http.js';
+
+export type TerminalClipboardPasteResult =
+  | { status: 'pasted'; kind: 'image-path' | 'text' }
+  | { status: 'skipped'; reason: 'empty' | 'unavailable' };
+
+interface TerminalClipboardPasteOptions {
+  readText: () => Promise<string | null>;
+  readImagePng: () => Promise<Uint8Array<ArrayBuffer> | undefined>;
+  uploadImage: (png: Uint8Array<ArrayBuffer>) => Promise<string>;
+  pasteText: (text: string) => void;
+}
+
+export function remoteClipboardImagePath(
+  timestamp = Date.now(),
+  id: string = crypto.randomUUID(),
+): string {
+  return `/tmp/muxus-paste-${timestamp}-${id}.png`;
+}
+
+export async function uploadTerminalClipboardImage(
+  connId: string,
+  png: Uint8Array<ArrayBuffer>,
+): Promise<string> {
+  const remotePath = remoteClipboardImagePath();
+  await apiFetchRaw(
+    `/api/sftp/${encodeURIComponent(connId)}/upload?path=${encodeURIComponent(remotePath)}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/octet-stream' },
+      body: png,
+    },
+  );
+  return remotePath;
+}
+
+/** Paste text when present; image-only clipboards become an uploaded remote path. */
+export async function pasteTerminalClipboard({
+  readText,
+  readImagePng,
+  uploadImage,
+  pasteText,
+}: TerminalClipboardPasteOptions): Promise<TerminalClipboardPasteResult> {
+  const text = await readText();
+  if (text) {
+    pasteText(text);
+    return { status: 'pasted', kind: 'text' };
+  }
+
+  const png = await readImagePng();
+  if (!png) {
+    return { status: 'skipped', reason: text === null ? 'unavailable' : 'empty' };
+  }
+
+  const remotePath = await uploadImage(png);
+  pasteText(remotePath);
+  return { status: 'pasted', kind: 'image-path' };
+}

--- a/client/src/terminal/terminal-registry.ts
+++ b/client/src/terminal/terminal-registry.ts
@@ -36,6 +36,8 @@ export interface TerminalHandle {
   /** Current zoom as a percentage (100 = preference font size). */
   zoomPercent(): number;
   paste(text: string): void;
+  /** Read and paste the current clipboard, including SSH image uploads. */
+  pasteClipboard(): void;
   /** Start/stop/pause persistence or change input capture for this live session. */
   setLogging(patch: {
     enabled?: boolean;

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -96,6 +96,11 @@ interface AppInfo {
   version: string;
 }
 
+type DesktopClipboardContent =
+  | { kind: 'text'; text: string }
+  | { kind: 'image'; png: Uint8Array<ArrayBuffer> }
+  | { kind: 'empty' };
+
 interface UpdateManifest {
   version?: unknown;
   releaseName?: unknown;
@@ -593,12 +598,14 @@ ipcMain.handle('muxus:check-for-update', async (event, options?: { force?: unkno
 });
 
 ipcMain.handle(
-  'muxus:read-clipboard-image-png',
-  (event): Uint8Array<ArrayBuffer> | undefined => {
+  'muxus:read-clipboard-content',
+  (event): DesktopClipboardContent | undefined => {
     if (!isManagedWindowSender(event)) return undefined;
-    const image = clipboard.readImage();
-    if (image.isEmpty()) return undefined;
+    const text = clipboard.readText();
+    if (text) return { kind: 'text', text };
 
+    const image = clipboard.readImage();
+    if (image.isEmpty()) return { kind: 'empty' };
     const { width, height } = image.getSize();
     const pixels = width * height;
     if (
@@ -614,7 +621,7 @@ ipcMain.handle(
     if (png.byteLength > CLIPBOARD_IMAGE_MAX_BYTES) {
       throw new Error('The clipboard image is too large to paste.');
     }
-    return Uint8Array.from(png);
+    return { kind: 'image', png: Uint8Array.from(png) };
   },
 );
 

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   app,
+  clipboard,
   BrowserWindow,
   dialog,
   type IpcMainEvent,
@@ -70,6 +71,8 @@ const EXTERNAL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
 const TITLEBAR_HEIGHT = 52;
 const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/muxus/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
+const CLIPBOARD_IMAGE_MAX_BYTES = 18 * 1024 * 1024;
+const CLIPBOARD_IMAGE_MAX_PIXELS = 32 * 1024 * 1024;
 
 let primaryWindow: BrowserWindow | undefined;
 let appUrl: string | undefined;
@@ -588,6 +591,32 @@ ipcMain.handle('muxus:check-for-update', async (event, options?: { force?: unkno
   updateCheck ??= checkForUpdate();
   return updateCheck;
 });
+
+ipcMain.handle(
+  'muxus:read-clipboard-image-png',
+  (event): Uint8Array<ArrayBuffer> | undefined => {
+    if (!isManagedWindowSender(event)) return undefined;
+    const image = clipboard.readImage();
+    if (image.isEmpty()) return undefined;
+
+    const { width, height } = image.getSize();
+    const pixels = width * height;
+    if (
+      width <= 0 ||
+      height <= 0 ||
+      !Number.isFinite(pixels) ||
+      pixels > CLIPBOARD_IMAGE_MAX_PIXELS
+    ) {
+      throw new Error('The clipboard image is too large to paste.');
+    }
+
+    const png = image.toPNG();
+    if (png.byteLength > CLIPBOARD_IMAGE_MAX_BYTES) {
+      throw new Error('The clipboard image is too large to paste.');
+    }
+    return Uint8Array.from(png);
+  },
+);
 
 ipcMain.handle('muxus:select-private-key', async (event): Promise<string | undefined> => {
   const win = senderWindow(event);

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -39,6 +39,11 @@ interface LocalFontData {
 
 type QueryLocalFonts = () => Promise<LocalFontData[]>;
 
+type DesktopClipboardContent =
+  | { kind: 'text'; text: string }
+  | { kind: 'image'; png: Uint8Array<ArrayBuffer> }
+  | { kind: 'empty' };
+
 let localFontFamilies: Promise<string[] | undefined> | undefined;
 
 /**
@@ -111,9 +116,9 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   checkForUpdate(options?: { force?: boolean }) {
     return ipcRenderer.invoke('muxus:check-for-update', options);
   },
-  /** Read an OS clipboard image as validated PNG bytes. */
-  readClipboardImagePng(): Promise<Uint8Array<ArrayBuffer> | undefined> {
-    return ipcRenderer.invoke('muxus:read-clipboard-image-png');
+  /** Capture OS clipboard text or a validated PNG in one main-process snapshot. */
+  readClipboardContent(): Promise<DesktopClipboardContent | undefined> {
+    return ipcRenderer.invoke('muxus:read-clipboard-content');
   },
   /** Open a native single-file picker and return only the user-selected path. */
   selectPrivateKey(): Promise<string | undefined> {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -111,6 +111,10 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   checkForUpdate(options?: { force?: boolean }) {
     return ipcRenderer.invoke('muxus:check-for-update', options);
   },
+  /** Read an OS clipboard image as validated PNG bytes. */
+  readClipboardImagePng(): Promise<Uint8Array<ArrayBuffer> | undefined> {
+    return ipcRenderer.invoke('muxus:read-clipboard-image-png');
+  },
   /** Open a native single-file picker and return only the user-selected path. */
   selectPrivateKey(): Promise<string | undefined> {
     return ipcRenderer.invoke('muxus:select-private-key');

--- a/server/src/routes/sftp.ts
+++ b/server/src/routes/sftp.ts
@@ -20,6 +20,8 @@ const MAX_RECURSIVE_DELETE = 10_000;
 /** Monaco is a text editor, not a way to accidentally buffer huge remote artifacts. */
 const MAX_EDITOR_BYTES = 8 * 1024 * 1024;
 const DOWNLOAD_TICKET_TTL_MS = 2 * 60 * 1000;
+const CLIPBOARD_IMAGE_MODE = 0o600;
+const CLIPBOARD_IMAGE_TEMP_DIR = '/tmp';
 
 interface ConnParams {
   connId: string;
@@ -303,6 +305,31 @@ export function registerSftpRoutes(app: FastifyInstance, ctx: AppContext): void 
           throw err;
         }
         return { ok: true };
+      });
+    } catch (err) {
+      return sendError(reply, err);
+    }
+  });
+
+  app.post('/api/sftp/:connId/clipboard-image', async (req, reply) => {
+    try {
+      return await withSftp(req, async (sftp) => {
+        const body = req.body;
+        if (!body || typeof (body as NodeJS.ReadableStream).pipe !== 'function') {
+          throw new HttpProblem(400, 'expected an application/octet-stream body');
+        }
+        const file = path.join(
+          CLIPBOARD_IMAGE_TEMP_DIR,
+          `muxus-paste-${Date.now()}-${randomBytes(16).toString('hex')}.png`,
+        );
+        await atomicStreamUpload(
+          sftp,
+          file,
+          body as NodeJS.ReadableStream,
+          false,
+          CLIPBOARD_IMAGE_MODE,
+        );
+        return { path: file };
       });
     } catch (err) {
       return sendError(reply, err);

--- a/tests/unit/client/multi-exec.test.ts
+++ b/tests/unit/client/multi-exec.test.ts
@@ -28,6 +28,7 @@ function handle(sendInput: TerminalHandle['sendInput']): TerminalHandle {
     zoomReset: vi.fn(),
     zoomPercent: () => 100,
     paste: vi.fn(),
+    pasteClipboard: vi.fn(),
     setLogging: vi.fn(() => true),
     persistSnapshot: vi.fn(async () => undefined),
     prepareTransfer: vi.fn(async () => true),

--- a/tests/unit/client/terminal-clipboard-paste.test.ts
+++ b/tests/unit/client/terminal-clipboard-paste.test.ts
@@ -1,73 +1,220 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  isCurrentTerminalImagePasteTarget,
   pasteTerminalClipboard,
-  remoteClipboardImagePath,
+  TerminalClipboardPasteQueue,
 } from '../../../client/src/terminal/clipboard-paste.js';
 
 describe('terminal clipboard paste', () => {
-  it('pastes clipboard text without reading or uploading an image', async () => {
-    const readImagePng = vi.fn();
-    const uploadImage = vi.fn();
-    const pasteText = vi.fn();
-
-    await expect(
-      pasteTerminalClipboard({
-        readText: async () => 'echo hello',
-        readImagePng,
-        uploadImage,
-        pasteText,
-      }),
-    ).resolves.toEqual({ status: 'pasted', kind: 'text' });
-    expect(pasteText).toHaveBeenCalledWith('echo hello');
-    expect(readImagePng).not.toHaveBeenCalled();
-    expect(uploadImage).not.toHaveBeenCalled();
-  });
-
-  it('uploads an image-only clipboard and pastes its remote path', async () => {
-    const png = new Uint8Array([137, 80, 78, 71]);
-    const pasteText = vi.fn();
-    const uploadImage = vi.fn(async () => '/tmp/muxus-paste.png');
-
-    await expect(
-      pasteTerminalClipboard({
-        readText: async () => '',
-        readImagePng: async () => png,
-        uploadImage,
-        pasteText,
-      }),
-    ).resolves.toEqual({ status: 'pasted', kind: 'image-path' });
-    expect(uploadImage).toHaveBeenCalledWith(png);
-    expect(pasteText).toHaveBeenCalledWith('/tmp/muxus-paste.png');
-  });
-
-  it('reports unavailable clipboard access when neither text nor image can be read', async () => {
-    await expect(
-      pasteTerminalClipboard({
-        readText: async () => null,
-        readImagePng: async () => undefined,
+  it('waits for text paste confirmation before completing', async () => {
+    const confirmation = Promise.withResolvers<void>();
+    const pasteText = vi.fn(() => confirmation.promise);
+    const operation = pasteTerminalClipboard(
+      { kind: 'text', text: 'one\ntwo' },
+      {
         uploadImage: vi.fn(),
-        pasteText: vi.fn(),
-      }),
+        pasteText,
+        pasteImagePath: vi.fn(),
+      },
+    );
+    let settled = false;
+    void operation.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(pasteText).toHaveBeenCalledWith('one\ntwo');
+    expect(settled).toBe(false);
+    confirmation.resolve();
+    await expect(operation).resolves.toEqual({ status: 'pasted', kind: 'text' });
+  });
+
+  it('reports captured unavailable clipboard access without applying input', async () => {
+    await expect(
+      pasteTerminalClipboard(
+        { kind: 'unavailable' },
+        {
+          uploadImage: vi.fn(),
+          pasteText: vi.fn(),
+          pasteImagePath: vi.fn(),
+        },
+      ),
     ).resolves.toEqual({ status: 'skipped', reason: 'unavailable' });
+  });
+
+  it('accepts an input-ready SSH target before its display status settles', () => {
+    expect(
+      isCurrentTerminalImagePasteTarget({
+        connectionId: 'connection-1',
+        expectedConnectionId: 'connection-1',
+        inputReady: true,
+        socketOpen: true,
+        ssh: true,
+      }),
+    ).toBe(true);
+    expect(
+      isCurrentTerminalImagePasteTarget({
+        connectionId: 'connection-1',
+        expectedConnectionId: 'connection-1',
+        inputReady: false,
+        socketOpen: true,
+        ssh: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('pastes an uploaded image path through the non-broadcast callback', async () => {
+    const png = new Uint8Array([1]);
+    const pasteText = vi.fn();
+    const pasteImagePath = vi.fn();
+
+    await expect(
+      pasteTerminalClipboard(
+        { kind: 'image', png },
+        {
+          uploadImage: async () => '/tmp/muxus-paste.png',
+          pasteText,
+          pasteImagePath,
+        },
+      ),
+    ).resolves.toEqual({ status: 'pasted', kind: 'image-path' });
+    expect(pasteImagePath).toHaveBeenCalledWith('/tmp/muxus-paste.png');
+    expect(pasteText).not.toHaveBeenCalled();
   });
 
   it('does not hide image upload failures', async () => {
     const failure = new Error('SFTP is disabled');
     await expect(
-      pasteTerminalClipboard({
-        readText: async () => '',
-        readImagePng: async () => new Uint8Array([1]),
-        uploadImage: async () => {
-          throw failure;
+      pasteTerminalClipboard(
+        { kind: 'image', png: new Uint8Array([1]) },
+        {
+          uploadImage: async () => {
+            throw failure;
+          },
+          pasteText: vi.fn(),
+          pasteImagePath: vi.fn(),
         },
-        pasteText: vi.fn(),
-      }),
+      ),
     ).rejects.toBe(failure);
   });
 
-  it('creates a collision-resistant PNG path in the remote temp directory', () => {
-    expect(remoteClipboardImagePath(1234, 'fixed-id')).toBe(
-      '/tmp/muxus-paste-1234-fixed-id.png',
+  it('applies captured clipboard payloads in invocation order', async () => {
+    const queue = new TerminalClipboardPasteQueue();
+    const applied: string[] = [];
+    const firstStarted = Promise.withResolvers<void>();
+    const firstGate = Promise.withResolvers<void>();
+
+    const first = queue.enqueue(
+      () => Promise.resolve({ kind: 'text' as const, text: 'first' }),
+      async (payload) => {
+        if (payload.kind !== 'text') throw new Error('expected text payload');
+        applied.push(`start:${payload.text}`);
+        firstStarted.resolve();
+        await firstGate.promise;
+        applied.push(`finish:${payload.text}`);
+      },
     );
+    const second = queue.enqueue(
+      () => Promise.resolve({ kind: 'text' as const, text: 'second' }),
+      async (payload) => {
+        if (payload.kind !== 'text') throw new Error('expected text payload');
+        applied.push(`start:${payload.text}`);
+        applied.push(`finish:${payload.text}`);
+      },
+    );
+
+    await firstStarted.promise;
+    expect(applied).toEqual(['start:first']);
+    firstGate.resolve();
+    await Promise.all([first, second]);
+    expect(applied).toEqual([
+      'start:first',
+      'finish:first',
+      'start:second',
+      'finish:second',
+    ]);
+  });
+
+  it('rejects image payloads beyond the pending byte budget', async () => {
+    const queue = new TerminalClipboardPasteQueue({
+      maxPendingImageBytes: 4,
+      maxPendingPastes: 2,
+    });
+    const firstStarted = Promise.withResolvers<void>();
+    const firstGate = Promise.withResolvers<void>();
+    const first = queue.enqueue(
+      () => Promise.resolve({ kind: 'image' as const, png: new Uint8Array(3) }),
+      async () => {
+        firstStarted.resolve();
+        await firstGate.promise;
+      },
+    );
+    const second = queue.enqueue(
+      () => Promise.resolve({ kind: 'image' as const, png: new Uint8Array(3) }),
+      async () => undefined,
+    );
+
+    await firstStarted.promise;
+    firstGate.resolve();
+    await first;
+    await expect(second).rejects.toThrow('Too much clipboard image data is waiting.');
+  });
+
+  it('rejects clipboard input beyond the pending operation limit', async () => {
+    const queue = new TerminalClipboardPasteQueue({
+      maxPendingImageBytes: 4,
+      maxPendingPastes: 1,
+    });
+    const firstGate = Promise.withResolvers<void>();
+    const first = queue.enqueue(
+      () => Promise.resolve({ kind: 'text' as const, text: 'first' }),
+      async () => firstGate.promise,
+    );
+
+    const rejectedCapture = vi.fn(
+      async () => ({ kind: 'text' as const, text: 'second' }),
+    );
+    await expect(
+      queue.enqueue(rejectedCapture, async () => undefined),
+    ).rejects.toThrow('Too many clipboard pastes are waiting.');
+    expect(rejectedCapture).not.toHaveBeenCalled();
+    firstGate.resolve();
+    await first;
+  });
+
+  it('aborts an active clipboard operation when the queue is cancelled', async () => {
+    const queue = new TerminalClipboardPasteQueue();
+    const started = Promise.withResolvers<void>();
+    const operation = queue.enqueue(
+      () => Promise.resolve({ kind: 'text' as const, text: 'waiting' }),
+      async (_payload, signal) => {
+        const aborted = Promise.withResolvers<void>();
+        signal.addEventListener(
+          'abort',
+          () => aborted.reject(signal.reason),
+          { once: true },
+        );
+        started.resolve();
+        return aborted.promise;
+      },
+    );
+
+    await started.promise;
+    queue.cancelAll();
+    await expect(operation).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('prioritizes cancellation over a late clipboard capture error', async () => {
+    const queue = new TerminalClipboardPasteQueue();
+    const capture = Promise.withResolvers<{ kind: 'text'; text: string }>();
+    const operation = queue.enqueue(
+      () => capture.promise,
+      async () => undefined,
+    );
+
+    await Promise.resolve();
+    queue.cancelAll();
+    capture.reject(new Error('clipboard permission denied'));
+    await expect(operation).rejects.toMatchObject({ name: 'AbortError' });
   });
 });

--- a/tests/unit/client/terminal-clipboard-paste.test.ts
+++ b/tests/unit/client/terminal-clipboard-paste.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  pasteTerminalClipboard,
+  remoteClipboardImagePath,
+} from '../../../client/src/terminal/clipboard-paste.js';
+
+describe('terminal clipboard paste', () => {
+  it('pastes clipboard text without reading or uploading an image', async () => {
+    const readImagePng = vi.fn();
+    const uploadImage = vi.fn();
+    const pasteText = vi.fn();
+
+    await expect(
+      pasteTerminalClipboard({
+        readText: async () => 'echo hello',
+        readImagePng,
+        uploadImage,
+        pasteText,
+      }),
+    ).resolves.toEqual({ status: 'pasted', kind: 'text' });
+    expect(pasteText).toHaveBeenCalledWith('echo hello');
+    expect(readImagePng).not.toHaveBeenCalled();
+    expect(uploadImage).not.toHaveBeenCalled();
+  });
+
+  it('uploads an image-only clipboard and pastes its remote path', async () => {
+    const png = new Uint8Array([137, 80, 78, 71]);
+    const pasteText = vi.fn();
+    const uploadImage = vi.fn(async () => '/tmp/muxus-paste.png');
+
+    await expect(
+      pasteTerminalClipboard({
+        readText: async () => '',
+        readImagePng: async () => png,
+        uploadImage,
+        pasteText,
+      }),
+    ).resolves.toEqual({ status: 'pasted', kind: 'image-path' });
+    expect(uploadImage).toHaveBeenCalledWith(png);
+    expect(pasteText).toHaveBeenCalledWith('/tmp/muxus-paste.png');
+  });
+
+  it('reports unavailable clipboard access when neither text nor image can be read', async () => {
+    await expect(
+      pasteTerminalClipboard({
+        readText: async () => null,
+        readImagePng: async () => undefined,
+        uploadImage: vi.fn(),
+        pasteText: vi.fn(),
+      }),
+    ).resolves.toEqual({ status: 'skipped', reason: 'unavailable' });
+  });
+
+  it('does not hide image upload failures', async () => {
+    const failure = new Error('SFTP is disabled');
+    await expect(
+      pasteTerminalClipboard({
+        readText: async () => '',
+        readImagePng: async () => new Uint8Array([1]),
+        uploadImage: async () => {
+          throw failure;
+        },
+        pasteText: vi.fn(),
+      }),
+    ).rejects.toBe(failure);
+  });
+
+  it('creates a collision-resistant PNG path in the remote temp directory', () => {
+    expect(remoteClipboardImagePath(1234, 'fixed-id')).toBe(
+      '/tmp/muxus-paste-1234-fixed-id.png',
+    );
+  });
+});

--- a/tests/unit/server/sftp-upload.test.ts
+++ b/tests/unit/server/sftp-upload.test.ts
@@ -7,13 +7,16 @@ type RouteHandler = (request: unknown, reply: unknown) => Promise<unknown>;
 
 interface FakeSftp {
   lstat(path: string, callback: (error: Error | null, attrs?: unknown) => void): void;
-  createWriteStream(path: string, options: { flags: string }): Writable;
+  createWriteStream(path: string, options: { flags: string; mode?: number }): Writable;
   rename?(from: string, to: string, callback: (error?: Error | null) => void): void;
   ext_openssh_rename?(from: string, to: string, callback: (error?: Error | null) => void): void;
   unlink?(path: string, callback: (error?: Error | null) => void): void;
 }
 
-function captureUploadHandler(sftp: FakeSftp): RouteHandler {
+function captureUploadHandler(
+  sftp: FakeSftp,
+  route = '/api/sftp/:connId/upload',
+): RouteHandler {
   const posts = new Map<string, RouteHandler>();
   const app = {
     get: vi.fn(),
@@ -30,7 +33,7 @@ function captureUploadHandler(sftp: FakeSftp): RouteHandler {
     },
   };
   registerSftpRoutes(app as never, ctx as never);
-  return posts.get('/api/sftp/:connId/upload')!;
+  return posts.get(route)!;
 }
 
 function captureDownloadHandler(stream: PassThrough): {
@@ -166,6 +169,51 @@ describe('SFTP upload overwrite policy', () => {
     expect(rename).toHaveBeenCalledWith(
       expect.stringMatching(/^\/remote\/report\.txt\.muxus-[a-f0-9]+\.upload$/),
       '/remote/report.txt',
+      expect.any(Function),
+    );
+  });
+
+  it('creates clipboard images with owner-only permissions', async () => {
+    const createWriteStream = vi.fn(
+      (_path: string, _options: { flags: string; mode?: number }) =>
+        new Writable({ write: (_chunk, _encoding, callback) => callback() }),
+    );
+    const rename = vi.fn(
+      (_from: string, _to: string, callback: (error?: Error | null) => void) =>
+        callback(null),
+    );
+    const handler = captureUploadHandler(
+      {
+        lstat: (_path, callback) =>
+          callback(Object.assign(new Error('not found'), { code: 2 })),
+        createWriteStream,
+        rename,
+        unlink: vi.fn(),
+      },
+      '/api/sftp/:connId/clipboard-image',
+    );
+
+    const response = await invoke(handler, {});
+
+    expect(response.result).toEqual({
+      path: expect.stringMatching(/^\/tmp\/muxus-paste-\d+-[a-f0-9]+\.png$/),
+    });
+    if (
+      !response.result ||
+      typeof response.result !== 'object' ||
+      !('path' in response.result) ||
+      typeof response.result.path !== 'string'
+    ) {
+      throw new Error('clipboard image route did not return a path');
+    }
+    const remotePath = response.result.path;
+    expect(createWriteStream.mock.calls[0]?.[0]).toMatch(
+      new RegExp(`^${remotePath.replaceAll('.', '\\.')}\\.muxus-[a-f0-9]+\\.upload$`),
+    );
+    expect(createWriteStream.mock.calls[0]?.[1]).toEqual({ flags: 'wx', mode: 0o600 });
+    expect(rename).toHaveBeenCalledWith(
+      expect.stringMatching(/\.muxus-[a-f0-9]+\.upload$/),
+      remotePath,
       expect.any(Function),
     );
   });


### PR DESCRIPTION
## What changed

- capture clipboard text or PNG data through one trusted Electron main-process snapshot
- upload image-only clipboard content to an owner-only (`0600`) remote temporary file over the active SFTP connection
- paste the generated remote path through the existing terminal paste flow
- route keyboard, command, context-menu, and native paste entry points through an ordered, bounded, cancellable queue
- prevent generated image paths from being mirrored to unrelated multi-exec targets
- cancel pending capture/upload work when the terminal unmounts and revalidate the SSH input target after upload

## Why

CLI agents running on an SSH host cannot access a local clipboard image or a local temporary path. Persisting the PNG on that SSH host and pasting its remote path lets agents that accept image paths consume screenshots without exposing the file to other users on shared hosts.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm check:bundle`
- Linux x64, macOS universal, Windows x64, and Windows ARM64 package-smoke jobs

No visible UI elements changed, so there is no screenshot or recording.