### PR TITLE
feat: SSH keepalive fallback and force reconnect

### DIFF
--- a/client/src/api/dial.ts
+++ b/client/src/api/dial.ts
@@ -4,6 +4,7 @@ import type {
   AuthPromptResult,
 } from '../components/AuthPromptDialog.js';
 import type { HostKeyRequest } from '../components/HostKeyDialog.js';
+import { sshKeepalivePrefField } from '../state/prefs.js';
 import { closeTerminalWebSocket, wsProtocols, wsUrl } from './http.js';
 
 /** Interactive hooks a shell-less dial needs from the UI. */
@@ -53,6 +54,7 @@ export function dialConnection(
             kind: 'ssh',
             target,
             ...(sshOptions === undefined ? {} : { useConfig: false, ...sshOptions }),
+            ...sshKeepalivePrefField(),
           },
         }),
       );

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -66,6 +66,7 @@ import {
 import { useChordLabel } from '../keymap/hints.js';
 import { IS_MAC } from '../platform.js';
 import {
+  DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS,
   MAX_INACTIVE_PANE_DIM_STRENGTH,
   MIN_INACTIVE_PANE_DIM_STRENGTH,
   clampInactivePaneDimStrength,
@@ -644,6 +645,8 @@ function TerminalSection() {
   );
 }
 
+const SSH_KEEPALIVE_CHOICES = [0, 15, DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS, 60, 120];
+
 function BehaviorSection() {
   const prefs = usePrefsStore();
 
@@ -672,6 +675,31 @@ function BehaviorSection() {
       <Box>
         <SectionTitle>Restore & reconnect</SectionTitle>
         <Stack spacing={1.5}>
+          <TextField
+            select
+            label="SSH keepalive interval"
+            value={prefs.sshKeepaliveIntervalSeconds}
+            onChange={(event) =>
+              prefs.set({ sshKeepaliveIntervalSeconds: Number(event.target.value) })
+            }
+            helperText="Keeps idle SSH connections active. A host's ServerAliveInterval setting takes precedence; changes apply on reconnect."
+            sx={{ width: 280 }}
+          >
+            <MenuItem value={0}>SSH configuration only</MenuItem>
+            <MenuItem value={15}>Every 15 seconds</MenuItem>
+            <MenuItem value={DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS}>
+              Every 30 seconds (recommended)
+            </MenuItem>
+            <MenuItem value={60}>Every minute</MenuItem>
+            <MenuItem value={120}>Every 2 minutes</MenuItem>
+            {SSH_KEEPALIVE_CHOICES.includes(prefs.sshKeepaliveIntervalSeconds) ? null : (
+              // A hand-edited or newer-version value must stay visible and
+              // active instead of rendering the select blank.
+              <MenuItem value={prefs.sshKeepaliveIntervalSeconds}>
+                Every {prefs.sshKeepaliveIntervalSeconds} seconds (custom)
+              </MenuItem>
+            )}
+          </TextField>
           <FormControlLabel
             control={
               <Switch

--- a/client/src/components/TabStrip.tsx
+++ b/client/src/components/TabStrip.tsx
@@ -44,6 +44,7 @@ import OpenInFullOutlinedIcon from '@mui/icons-material/OpenInFullOutlined';
 import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutlineOutlined';
 import ReplayOutlinedIcon from '@mui/icons-material/ReplayOutlined';
+import RestartAltOutlinedIcon from '@mui/icons-material/RestartAltOutlined';
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import VerticalSplitOutlinedIcon from '@mui/icons-material/VerticalSplitOutlined';
@@ -58,10 +59,12 @@ import {
   openTabInNewWindow,
   requestClosePane,
   requestCloseTabs,
+  requestForceReconnect,
   splitActivePane,
 } from '../session-actions.js';
 import {
   closableTabIdsToRight,
+  isRemoteSessionTab,
   useTabsStore,
   type PaneDirection,
   type TabStatus,
@@ -343,6 +346,14 @@ export function TabStrip({
   const canSplitMenuTab = !!menuTab && allTabs.some(
     (tab) => tab.paneId === menuTab.paneId && tab.id !== menuTab.id,
   );
+  // Offered only where it differs from plain Reconnect: a live session has no
+  // other way to replace its connection, and a closed SSH tab would otherwise
+  // multiplex back onto the possibly dead shared transport.
+  const canForceReconnectMenuTab =
+    !!menuTab &&
+    isRemoteSessionTab(menuTab) &&
+    (menuTab.status !== 'closed' || menuTab.profile.kind === 'ssh');
+  const menuTabReconnectable = !!menuTab?.profile && menuTab.status === 'closed';
 
   const commitRename = () => {
     if (renaming && renameValue.trim()) update(renaming.id, { title: renameValue.trim() });
@@ -1202,9 +1213,9 @@ export function TabStrip({
           </ListItemIcon>
           <ListItemText>Move tab to split down</ListItemText>
         </MenuItem>
+        {menuTabReconnectable || canForceReconnectMenuTab ? <Divider /> : null}
         {menuTab?.profile && menuTab.status === 'closed' ? (
           <>
-            <Divider />
             <MenuItem
               onClick={() => {
                 reconnect([menuTab.id]);
@@ -1243,6 +1254,19 @@ export function TabStrip({
               </>
             ) : null}
           </>
+        ) : null}
+        {canForceReconnectMenuTab ? (
+          <MenuItem
+            onClick={() => {
+              if (menuTab) void requestForceReconnect(menuTab.id);
+              setMenu(null);
+            }}
+          >
+            <ListItemIcon>
+              <RestartAltOutlinedIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Force reconnect (new connection)</ListItemText>
+          </MenuItem>
         ) : null}
         <Divider />
         <Box sx={{ px: 2, py: 0.5 }}>

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -47,6 +47,7 @@ import { showToast } from '../state/toast.js';
 import { broadcastTerminalInput } from '../state/multi-exec.js';
 import {
   TERMINAL_SYMBOL_FONT,
+  sshKeepalivePrefField,
   terminalFontStack,
   terminalSchemeIdForMode,
   usePrefsStore,
@@ -850,6 +851,12 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
         // it was not when the terminal mounted. Measure now so the remote PTY
         // starts at the size on screen instead of being resized a beat later.
         if (!fitted) fitted = fitTerminal();
+        // Read the preference at send time, the way dialConnection does, so a
+        // change made while this socket was opening still applies.
+        const profile =
+          tab.profile.kind === 'ssh'
+            ? { ...tab.profile, ...sshKeepalivePrefField() }
+            : tab.profile;
         socket.send(JSON.stringify(
           attachTerminalId
             ? {
@@ -860,7 +867,8 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               }
             : {
                 op: 'connect',
-                profile: tab.profile,
+                profile,
+                freshTransport: tab.freshTransport,
                 title: tab.title,
                 cols: term.cols,
                 rows: term.rows,
@@ -1001,6 +1009,9 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               sftpAvailable,
               ...(sftpAvailable === false ? { sftpOpen: false } : {}),
               transferId: undefined,
+              // The replacement connection is live; retries from here on may
+              // multiplex normally again.
+              freshTransport: undefined,
             });
             if (pendingTransferId) {
               completeTabTransfer(pendingTransferId);

--- a/client/src/components/TerminalViewImpl.tsx
+++ b/client/src/components/TerminalViewImpl.tsx
@@ -996,6 +996,13 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               : shouldWaitForTerminalOutput(tab.profile.kind, receivedTerminalOutput);
             const sftpAvailable =
               tab.profile.kind === 'ssh' ? ctl.sftpAvailable !== false : undefined;
+            // Clear only the token this connect carried: a ready outracing the
+            // effect teardown must not erase a newer gesture's token.
+            const tokenUnchanged =
+              useTabsStore
+                .getState()
+                .tabs.find((candidate) => candidate.id === tab.id)
+                ?.freshTransport === tab.freshTransport;
             updateTab(tab.id, {
               status: transportSuspect
                 ? 'interrupted'
@@ -1011,7 +1018,7 @@ export default function TerminalViewImpl({ tab, active }: { tab: SessionTab; act
               transferId: undefined,
               // The replacement connection is live; retries from here on may
               // multiplex normally again.
-              freshTransport: undefined,
+              ...(tokenUnchanged ? { freshTransport: undefined } : {}),
             });
             if (pendingTransferId) {
               completeTabTransfer(pendingTransferId);

--- a/client/src/components/WorkspaceDialog.tsx
+++ b/client/src/components/WorkspaceDialog.tsx
@@ -31,6 +31,7 @@ import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
+import ReplayOutlinedIcon from '@mui/icons-material/ReplayOutlined';
 import RestoreOutlinedIcon from '@mui/icons-material/RestoreOutlined';
 import SaveAsOutlinedIcon from '@mui/icons-material/SaveAsOutlined';
 import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
@@ -51,13 +52,14 @@ import {
   setStartupWorkspace,
   setWorkspaceLocked,
 } from '../workspace-persistence.js';
+import { requestForceReconnectAll } from '../session-actions.js';
 import {
   selectWorkspaces,
   type WorkspaceSort,
 } from '../workspace-list.js';
 import { confirmDiscardRemoteEditors } from '../editor/remote-editor-registry.js';
 import { confirmAction } from '../state/dialogs.js';
-import { useTabsStore } from '../state/tabs.js';
+import { isRemoteSessionTab, useTabsStore } from '../state/tabs.js';
 import { showErrorToast, showToast } from '../state/toast.js';
 import { useUiStore } from '../state/ui.js';
 import { useWorkspacesStore } from '../state/workspaces.js';
@@ -109,6 +111,9 @@ export function WorkspaceDialog() {
   const reconnectable = useMemo(
     () => tabs.filter((tab) => tab.profile && tab.status === 'closed'),
     [tabs],
+  );
+  const hasLiveRemote = tabs.some(
+    (tab) => isRemoteSessionTab(tab) && tab.status !== 'closed',
   );
   const liveCount = tabs.filter(
     (tab) => tab.profile && (tab.status === 'connected' || tab.status === 'connecting'),
@@ -882,6 +887,19 @@ export function WorkspaceDialog() {
             }}
           >
             {selectedIds.length ? 'Reconnect selected' : 'Reconnect all'}
+          </Button>
+        ) : null}
+        {hasLiveRemote ? (
+          <Button
+            color="warning"
+            startIcon={<ReplayOutlinedIcon />}
+            onClick={() =>
+              void requestForceReconnectAll().then((reconnected) => {
+                if (reconnected) setSelectedIds([]);
+              })
+            }
+          >
+            Force reconnect all
           </Button>
         ) : null}
         <Box sx={{ flex: 1 }} />

--- a/client/src/keymap/commands.ts
+++ b/client/src/keymap/commands.ts
@@ -6,11 +6,12 @@ import {
   openEmptyTab,
   requestCloseActivePane,
   requestCloseTabs,
+  requestForceReconnectAll,
   splitActivePane,
   toggleMultiExec,
 } from '../session-actions.js';
 import { usePrefsStore } from '../state/prefs.js';
-import { PANE_RESIZE_STEP, useTabsStore } from '../state/tabs.js';
+import { PANE_RESIZE_STEP, isRemoteSessionTab, useTabsStore } from '../state/tabs.js';
 import { useUiStore } from '../state/ui.js';
 import { terminalHandle } from '../terminal/terminal-registry.js';
 import type { PaneDirection } from '../state/workspace-layout.js';
@@ -353,6 +354,18 @@ export const KEY_COMMANDS: readonly KeyCommand[] = [
     defaultChords: ['Mod+Shift+M'],
     keywords: ['multi-exec', 'mirror', 'broadcast', 'sync input', 'all sessions'],
     run: () => toggleMultiExec(),
+  },
+  {
+    id: 'terminal.force-reconnect-all',
+    title: 'Force reconnect all remote sessions',
+    category: 'terminal',
+    defaultChords: [],
+    keywords: ['ssh', 'telnet', 'serial', 'restart', 'replace', 'stuck', 'hung'],
+    run: () => {
+      if (!tabs().tabs.some(isRemoteSessionTab)) return false;
+      void requestForceReconnectAll();
+      return true;
+    },
   },
   {
     id: 'terminal.zoom-in',

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -12,7 +12,7 @@ import {
   type LocalShellProfileConfig,
 } from './state/prefs.js';
 import { useMultiExecStore } from './state/multi-exec.js';
-import { useTabsStore } from './state/tabs.js';
+import { isRemoteSessionTab, useTabsStore } from './state/tabs.js';
 import type { PaneDirection, SessionSetLayout } from './state/tabs.js';
 import { confirmAction } from './state/dialogs.js';
 import { showToast } from './state/toast.js';
@@ -197,6 +197,34 @@ export function toggleMultiExec(): boolean {
     connected.length < 2
       ? 'Connect at least two sessions to mirror input.'
       : 'Pick the terminals to mirror input into from the multi-exec control.',
+  );
+  return true;
+}
+
+/** Replace every remote connection in this window after warning about live shells. */
+export async function requestForceReconnectAll(): Promise<boolean> {
+  const state = useTabsStore.getState();
+  const remoteSessions = state.tabs.filter(isRemoteSessionTab);
+  if (!remoteSessions.length) return false;
+  const liveCount = remoteSessions.filter((tab) => tab.status !== 'closed').length;
+  const confirmed = await confirmAction({
+    title: `Force reconnect ${remoteSessions.length} remote session${remoteSessions.length === 1 ? '' : 's'}?`,
+    description: liveCount
+      ? `This ends ${liveCount} live or connecting session${liveCount === 1 ? '' : 's'} and starts fresh connections in the same tabs. Remote programs survive only when they run in tmux or screen.`
+      : 'This starts fresh connections for every remote tab.',
+    confirmLabel: 'Force reconnect all',
+    destructive: liveCount > 0,
+  });
+  if (
+    !confirmed ||
+    !(await confirmDiscardRemoteEditors(remoteSessions.map((tab) => tab.id)))
+  ) {
+    return false;
+  }
+  useTabsStore.getState().forceReconnectAll();
+  showToast(
+    'info',
+    `Reconnecting ${remoteSessions.length} remote session${remoteSessions.length === 1 ? '' : 's'}…`,
   );
   return true;
 }

--- a/client/src/session-actions.ts
+++ b/client/src/session-actions.ts
@@ -229,6 +229,25 @@ export async function requestForceReconnectAll(): Promise<boolean> {
   return true;
 }
 
+/** Replace one remote session's connection, warning first when it is live. */
+export async function requestForceReconnect(tabId: string): Promise<boolean> {
+  const tab = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
+  if (!tab || !isRemoteSessionTab(tab)) return false;
+  if (tab.status !== 'closed') {
+    const confirmed = await confirmAction({
+      title: `Force reconnect ${tab.title}?`,
+      description:
+        'This ends the current session and starts a fresh connection in the same tab. Remote programs survive only when they run in tmux or screen.',
+      confirmLabel: 'Force reconnect',
+      destructive: true,
+    });
+    if (!confirmed) return false;
+  }
+  if (!(await confirmDiscardRemoteEditors([tabId]))) return false;
+  useTabsStore.getState().forceReconnect(tabId);
+  return true;
+}
+
 /** Duplicate an open tab (same profile, fresh session). */
 export function duplicateTab(tabId: string): boolean {
   const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId);

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SFTP_PANEL_WIDTH } from '../sftp-panel-width.js';
 import { muxusStateStorage } from './persist-storage.js';
 import { isKeywordHighlightProfileArray } from '../highlight-profiles.js';
 import type { KeywordHighlightProfile, KeywordHighlightRule } from '@muxus/shared';
+import { MAX_SSH_KEEPALIVE_INTERVAL_SECONDS } from '@muxus/shared/ws-protocol';
 
 export type ThemeMode = 'light' | 'dark' | 'os';
 export type EffectiveThemeMode = Exclude<ThemeMode, 'os'>;
@@ -15,6 +16,17 @@ export type TabNumberVisibility = 'shortcut' | 'always';
 export const DEFAULT_INACTIVE_PANE_DIM_STRENGTH = 0.15;
 export const MIN_INACTIVE_PANE_DIM_STRENGTH = 0.1;
 export const MAX_INACTIVE_PANE_DIM_STRENGTH = 0.6;
+export const DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS = 30;
+
+/**
+ * SSH keepalive fallback as wire fields for a connect or dial message, read
+ * at send time so the current preference applies. Empty when the preference
+ * says the OpenSSH configuration alone decides.
+ */
+export function sshKeepalivePrefField(): { keepaliveIntervalSeconds?: number } {
+  const interval = usePrefsStore.getState().sshKeepaliveIntervalSeconds;
+  return interval > 0 ? { keepaliveIntervalSeconds: interval } : {};
+}
 
 /** Keep hand-edited or older persisted values from making a pane illegible. */
 export function clampInactivePaneDimStrength(value: number): number {
@@ -114,6 +126,8 @@ export interface PrefsState {
   confirmCloseConnected: boolean;
   /** Dial remote sessions on workspace restore and retry dropped connections. */
   autoReconnectRemote: boolean;
+  /** SSH keepalive fallback in seconds; zero relies entirely on ssh_config. */
+  sshKeepaliveIntervalSeconds: number;
   /** Show a notification at startup when a newer release is available. */
   notifyOnNewVersion: boolean;
   /** Persist recent terminal output and replay it on restore and reconnect. */
@@ -200,6 +214,14 @@ export function migratePrefsState(persisted: unknown, version: number): unknown 
   if (!isTabNumberVisibility(state.tabNumberVisibility)) delete state.tabNumberVisibility;
   if (!isTerminalFileLinkActivation(state.terminalFileLinkActivation)) {
     delete state.terminalFileLinkActivation;
+  }
+  if (
+    typeof state.sshKeepaliveIntervalSeconds !== 'number' ||
+    !Number.isInteger(state.sshKeepaliveIntervalSeconds) ||
+    state.sshKeepaliveIntervalSeconds < 0 ||
+    state.sshKeepaliveIntervalSeconds > MAX_SSH_KEEPALIVE_INTERVAL_SECONDS
+  ) {
+    delete state.sshKeepaliveIntervalSeconds;
   }
   if (typeof state.activePaneBorder !== 'boolean') delete state.activePaneBorder;
   if (typeof state.dimInactivePanes !== 'boolean') delete state.dimInactivePanes;
@@ -342,6 +364,7 @@ export const usePrefsStore = create<PrefsState>()(
       pasteWarnMultiline: true,
       confirmCloseConnected: true,
       autoReconnectRemote: true,
+      sshKeepaliveIntervalSeconds: DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS,
       notifyOnNewVersion: true,
       restoreScrollback: true,
       interfaceZoom: 1,
@@ -367,7 +390,7 @@ export const usePrefsStore = create<PrefsState>()(
     }),
     {
       name: 'muxus-prefs',
-      version: 13,
+      version: 14,
       migrate: migratePrefsState,
       storage: createJSONStorage(() => muxusStateStorage),
     },

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -25,7 +25,9 @@ export const DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS = 30;
  */
 export function sshKeepalivePrefField(): { keepaliveIntervalSeconds?: number } {
   const interval = usePrefsStore.getState().sshKeepaliveIntervalSeconds;
-  return interval > 0 ? { keepaliveIntervalSeconds: interval } : {};
+  // Explicit undefined (dropped by JSON serialization) so a stale field on a
+  // persisted profile can never outvote a disabled preference.
+  return { keepaliveIntervalSeconds: interval > 0 ? interval : undefined };
 }
 
 /** Keep hand-edited or older persisted values from making a pane illegible. */

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -186,6 +186,8 @@ interface TabsState {
   reconnectAll: (options?: ReconnectOptions) => void;
   /** Replace every remote session in the current workspace, including live ones. */
   forceReconnectAll: () => void;
+  /** Replace one remote session's connection, even while it is live. */
+  forceReconnect: (id: string) => void;
   /** Record terminal output, notifying only while the tab is hidden. */
   notifyOutput: (id: string) => void;
   update: (id: string, patch: TabUpdate) => void;
@@ -905,6 +907,24 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     set((state) => ({
       tabs: state.tabs.map((tab) =>
         isRemoteSessionTab(tab)
+          ? {
+              ...tab,
+              ...reconnectPatch(tab, {
+                freshTransport:
+                  tab.profile.kind === 'ssh' ? freshTransport : undefined,
+              }),
+            }
+          : tab,
+      ),
+    }));
+  },
+  forceReconnect: (id) => {
+    // A token of its own: this tab dials a replacement transport while its
+    // siblings keep the connection they are on.
+    const freshTransport = newId('fresh');
+    set((state) => ({
+      tabs: state.tabs.map((tab) =>
+        tab.id === id && isRemoteSessionTab(tab)
           ? {
               ...tab,
               ...reconnectPatch(tab, {

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -59,6 +59,13 @@ interface TabBase {
   reconnectRequest: number;
   /** Optional multiplexer to attach after the replacement SSH shell is ready. */
   reconnectMode?: ReattachMode;
+  /**
+   * Replacement-group token: the next SSH connection must not multiplex onto
+   * an established transport, but connects sharing the token (one force
+   * reconnect gesture) share one replacement connection. Kept across failed
+   * retries; cleared when a connection succeeds.
+   */
+  freshTransport?: string;
   /** Most recent connection/end reason, shown without requiring terminal scrollback. */
   failureReason?: string;
   disconnectReason?: 'completed' | 'failed' | 'disconnected';
@@ -100,6 +107,7 @@ type TabUpdate = Partial<{
   captureInput: boolean;
   failureReason: string | undefined;
   disconnectReason: 'completed' | 'failed' | 'disconnected' | undefined;
+  freshTransport: string | undefined;
 }>;
 
 export interface ReconnectOptions {
@@ -176,6 +184,8 @@ interface TabsState {
   reconnect: (tabIds: readonly string[], options?: ReconnectOptions) => void;
   /** Reconnect every ended/restored session in the current workspace. */
   reconnectAll: (options?: ReconnectOptions) => void;
+  /** Replace every remote session in the current workspace, including live ones. */
+  forceReconnectAll: () => void;
   /** Record terminal output, notifying only while the tab is hidden. */
   notifyOutput: (id: string) => void;
   update: (id: string, patch: TabUpdate) => void;
@@ -183,6 +193,35 @@ interface TabsState {
 
 let nextId = 1;
 const newId = (prefix: string) => `${prefix}-${Date.now().toString(36)}-${nextId++}`;
+
+/** Session tabs that dial a transport — everything but local shells. */
+export function isRemoteSessionTab(tab: TerminalTab): tab is SessionTab {
+  return !!tab.profile && tab.profile.kind !== 'local';
+}
+
+/**
+ * Shared patch for dialing a replacement session into an existing tab. An
+ * unfulfilled fresh-transport request survives retries — the ready handler
+ * clears it on success — so a failed forced dial never falls back silently
+ * onto the very transport it was meant to replace.
+ */
+function reconnectPatch(
+  tab: SessionTab,
+  options?: { reattach?: ReattachMode; freshTransport?: string },
+) {
+  return {
+    status: 'connecting' as const,
+    connectOnMount: true,
+    connId: undefined,
+    terminalId: undefined,
+    transferId: undefined,
+    reconnectRequest: tab.reconnectRequest + 1,
+    reconnectMode: tab.profile.kind === 'ssh' ? options?.reattach : undefined,
+    freshTransport: options?.freshTransport ?? tab.freshTransport,
+    failureReason: undefined,
+    disconnectReason: undefined,
+  };
+}
 const initialPane = (): PaneLeaf => ({ id: newId('pane'), type: 'pane', activeTabId: null });
 const initial = initialPane();
 
@@ -846,18 +885,7 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     set((state) => ({
       tabs: state.tabs.map((tab) =>
         tab.profile && tab.status === 'closed' && requested.has(tab.id)
-          ? {
-              ...tab,
-              status: 'connecting' as const,
-              connectOnMount: true,
-              terminalId: undefined,
-              transferId: undefined,
-              reconnectRequest: tab.reconnectRequest + 1,
-              reconnectMode:
-                tab.profile.kind === 'ssh' ? options?.reattach : undefined,
-              failureReason: undefined,
-              disconnectReason: undefined,
-            }
+          ? { ...tab, ...reconnectPatch(tab, options) }
           : tab,
       ),
     }));
@@ -866,21 +894,28 @@ export const useTabsStore = create<TabsState>()((set, get) => ({
     set((state) => ({
       tabs: state.tabs.map((tab) =>
         tab.profile && tab.status === 'closed'
-          ? {
-              ...tab,
-              status: 'connecting' as const,
-              connectOnMount: true,
-              terminalId: undefined,
-              transferId: undefined,
-              reconnectRequest: tab.reconnectRequest + 1,
-              reconnectMode:
-                tab.profile.kind === 'ssh' ? options?.reattach : undefined,
-              failureReason: undefined,
-              disconnectReason: undefined,
-            }
+          ? { ...tab, ...reconnectPatch(tab, options) }
           : tab,
       ),
     })),
+  forceReconnectAll: () => {
+    // One token for the whole gesture: every SSH tab skips established
+    // transports, while the window still shares one replacement per host.
+    const freshTransport = newId('fresh');
+    set((state) => ({
+      tabs: state.tabs.map((tab) =>
+        isRemoteSessionTab(tab)
+          ? {
+              ...tab,
+              ...reconnectPatch(tab, {
+                freshTransport:
+                  tab.profile.kind === 'ssh' ? freshTransport : undefined,
+              }),
+            }
+          : tab,
+      ),
+    }));
+  },
   notifyOutput: (id) =>
     set((state) => {
       const tab = state.tabs.find((candidate) => candidate.id === id);

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -120,17 +120,22 @@ Each consumer holds its own lease on the transport:
 
 ## Connection loss
 
-Muxus adds no probe traffic of its own. It observes the keepalives the configuration
-already requests:
+Muxus sends an SSH keepalive after 30 idle seconds by default. Settings → Behavior changes
+that fallback interval, while an explicit `ServerAliveInterval` in the matching OpenSSH
+configuration takes precedence:
 
 | Tab icon | Meaning |
 | --- | --- |
 | :material-circle:{ style="color:#e7b341" } amber | Existing keepalives are unanswered |
 | :material-circle:{ style="color:#f87171" } red | SSH declared the transport lost; the reason is printed in the terminal |
 
-Reconnection is never automatic. Press any key in the tab, or use **Reconnect** from the
-tab menu. SSH tabs additionally offer **Reconnect + tmux** and **Reconnect + screen**, which
+With **Automatically reconnect remote sessions** enabled, a dropped connection is retried
+a few times before waiting for a key press. You can also use **Reconnect** from the tab
+menu. SSH tabs additionally offer **Reconnect + tmux** and **Reconnect + screen**, which
 dial a fresh transport and then reattach the existing multiplexer session.
 
-A restored [workspace](workspaces.md) reconnects selected sessions, or all of them, from
-its dialog.
+The [workspace](workspaces.md) dialog reconnects selected ended sessions, all ended
+sessions, or force-reconnects every remote tab. Force reconnect ends live shells; use tmux
+or screen when remote programs must survive. Saved tunnels keep their existing
+connections: the replaced transport carries them until they stop, while new sessions and
+new tunnels use the replacement.

--- a/docs/guide/connecting.md
+++ b/docs/guide/connecting.md
@@ -134,6 +134,12 @@ a few times before waiting for a key press. You can also use **Reconnect** from 
 menu. SSH tabs additionally offer **Reconnect + tmux** and **Reconnect + screen**, which
 dial a fresh transport and then reattach the existing multiplexer session.
 
+**Force reconnect (new connection)** in the tab menu replaces one tab's connection, even
+while the session is live. It never multiplexes onto an established transport, so it also
+recovers an ended SSH tab whose shared connection went dead while other tabs still hold
+it. Once the replacement is up, new sessions to that host use it instead of the old
+transport.
+
 The [workspace](workspaces.md) dialog reconnects selected ended sessions, all ended
 sessions, or force-reconnects every remote tab. Force reconnect ends live shells; use tmux
 or screen when remote programs must survive. Saved tunnels keep their existing

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -4,9 +4,10 @@ icon: lucide/settings
 
 # Settings
 
-Settings are opened with ++ctrl+comma++ or the gear control in the top bar. Changes apply
-immediately to open terminals. Session logging is the exception and saves explicitly,
-because storage policy should not change under a running recorder.
+Settings are opened with ++ctrl+comma++ or the gear control in the top bar. Most changes
+apply immediately to open terminals. SSH keepalive changes apply on the next connection;
+session logging saves explicitly because storage policy should not change under a running
+recorder.
 
 <figure markdown="span">
   ![The settings dialog](../assets/screenshots/settings.png#only-light){ .shadow }
@@ -98,6 +99,13 @@ include the global set.
 
 **Confirm before closing a live session** is on by default because closing a connected tab
 ends its shell.
+
+**SSH keepalive interval** defaults to 30 seconds. It sends a protocol-level probe while an
+SSH connection is idle so firewalls, NATs and VPNs do not silently discard it. An explicit
+`ServerAliveInterval` in the host's OpenSSH configuration takes precedence; choose **SSH
+configuration only** to disable the Muxus fallback. A changed interval applies when a
+connection is dialed fresh; tabs that share an existing transport keep its keepalive until
+it is replaced, for example by **Force reconnect all** in the workspace dialog.
 
 The two restore switches are also on by default. **Automatically reconnect remote
 sessions** dials remote tabs when restoring a workspace and retries a dropped connection a

--- a/docs/guide/workspaces.md
+++ b/docs/guide/workspaces.md
@@ -55,6 +55,11 @@ Both behaviours have switches in Settings → Behavior. Turning **Automatically 
 remote sessions** off restores remote tabs without dialling them, so a large layout does
 not trigger a set of simultaneous logins and 2FA prompts. Reconnect them individually from
 the tab menu, or use the workspace dialog to reconnect selected sessions or all of them.
+**Force reconnect all** replaces every SSH, Telnet and serial terminal session in the
+current workspace, including sessions that still appear connected. It ends their live
+shells, so use tmux or screen for remote work that must survive the replacement. Saved
+tunnels keep their existing connections and are not restarted. The action is also
+searchable by name in the quick launcher.
 Turning **Restore terminal history** off keeps scrollback out of local storage and restores
 every tab empty.
 

--- a/docs/reference/ssh-config.md
+++ b/docs/reference/ssh-config.md
@@ -67,7 +67,7 @@ but the dialler still applies them the way `ssh` would:
 | `Ciphers`, `KexAlgorithms`, `HostKeyAlgorithms`, `MACs` | Algorithm negotiation, including the `+`/`^`/`-` list syntax and `*` patterns. Entries the SSH engine does not implement are skipped with a notice, so a config shared with OpenSSH keeps working. The editor flags them while you type. |
 | `Compression` | `yes` prefers zlib like `ssh -C` |
 | `ConnectTimeout` | Dial timeout; defaults to 20 seconds |
-| `ServerAliveInterval`, `ServerAliveCountMax` | Keepalives; default 15 seconds / 3 missed replies |
+| `ServerAliveInterval`, `ServerAliveCountMax` | Keepalives; OpenSSH defaults to disabled / 3 missed replies. Muxus supplies the interval selected in Settings (30 seconds by default) when the config leaves it unset. |
 | `PasswordAuthentication no`, `KbdInteractiveAuthentication no` | Removes that rung from the auth ladder (the legacy `ChallengeResponseAuthentication` spelling works too) |
 | `UserKnownHostsFile`, `GlobalKnownHostsFile` | Host keys verify against these files instead; new keys are recorded into the first user file, `none` disables, and user-file path tokens such as `%h`, `%n`, and `%p` expand per connection |
 | `SetEnv`, `SendEnv` | Session environment, with `-pattern` removals and SetEnv overriding |

--- a/server/src/routes/profiles.ts
+++ b/server/src/routes/profiles.ts
@@ -19,7 +19,9 @@ const savedProfileSchema = z.object({
   id: z.string().min(1).max(200).optional(),
   name: z.string().trim().min(1).max(200),
   profile: z.discriminatedUnion('kind', [
-    sshProfileSchema,
+    // The keepalive fallback is an application preference each connect sends
+    // for itself — never a stored connection field that could outvote it.
+    sshProfileSchema.omit({ keepaliveIntervalSeconds: true }),
     telnetProfileSchema,
     serialProfileSchema,
   ]),

--- a/server/src/serial/serial-transport.ts
+++ b/server/src/serial/serial-transport.ts
@@ -19,6 +19,15 @@ export function serialOpenOptions(profile: SerialProfile): ConstructorParameters
   };
 }
 
+const BUSY_RETRY_TOTAL_MS = 2500;
+const BUSY_RETRY_DELAY_MS = 150;
+
+function isSerialBusyError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EBUSY' || /cannot lock port|resource busy|access is denied/i.test(error.message);
+}
+
 export class SerialTransport extends EventEmitter implements TerminalTransport {
   private ended = false;
   private closed = false;
@@ -41,12 +50,29 @@ export class SerialTransport extends EventEmitter implements TerminalTransport {
     });
   }
 
-  static connect(profile: SerialProfile): Promise<SerialTransport> {
+  static async connect(profile: SerialProfile): Promise<SerialTransport> {
+    // Replacing a live session reopens the device while the previous fd is
+    // still releasing its exclusive lock (close and open race on separate
+    // connections), so a busy port gets a short grace period before failing.
+    const deadline = Date.now() + BUSY_RETRY_TOTAL_MS;
+    for (;;) {
+      try {
+        return await SerialTransport.open(profile);
+      } catch (error) {
+        if (!isSerialBusyError(error) || Date.now() >= deadline) {
+          throw friendlySerialError(error as Error, profile.path);
+        }
+        await new Promise((resolve) => setTimeout(resolve, BUSY_RETRY_DELAY_MS));
+      }
+    }
+  }
+
+  private static open(profile: SerialProfile): Promise<SerialTransport> {
     return new Promise((resolve, reject) => {
       const port = new SerialPort(serialOpenOptions(profile));
       port.open((error) => {
         if (error) {
-          reject(friendlySerialError(error, profile.path));
+          reject(error);
           return;
         }
         resolve(new SerialTransport(port));

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -269,10 +269,15 @@ export class SshConnectionManager {
   private readonly connections = new ConnectionLeaseRegistry<ManagedConnection>();
   private readonly closeReasons = new WeakMap<Client, string>();
   private readonly postAuth = new WeakMap<Client, Promise<void>>();
-  /** In-flight dials by mux key, so simultaneous sessions share one TCP connection and one auth round-trip. */
+  /**
+   * In-flight dials by mux key, so simultaneous sessions share one TCP
+   * connection and one auth round-trip. A list, not a single slot: overlapping
+   * force-reconnect gestures each keep their own dial joinable until it
+   * settles, so a straggler always finds the dial of its own gesture.
+   */
   private readonly pendingDials = new Map<
     string,
-    { promise: Promise<ManagedConnection>; freshToken?: string }
+    Array<{ promise: Promise<ManagedConnection>; freshToken?: string }>
   >();
   /** Dial plans whose optional integration setup killed the remote transport; reset on app restart. */
   private readonly automaticPlainShellKeys = new Set<string>();
@@ -429,12 +434,16 @@ export class SshConnectionManager {
         io.status(`Reusing the SSH connection to ${label} (multiplexed).`, { transient: true });
         return shared;
       }
-      const pending = this.pendingDials.get(key);
+      const pendingList = this.pendingDials.get(key) ?? [];
       // A failed dial fails every session waiting on it — auth prompts and
       // errors surface on the session that started the dial. A fresh request
       // never waits on the dial it is trying to escape: it joins an in-flight
       // dial only when that dial belongs to its own force-reconnect group.
-      if (pending && (!freshToken || pending.freshToken === freshToken)) {
+      // Regular requests join the newest dial.
+      const pending = freshToken
+        ? pendingList.find((entry) => entry.freshToken === freshToken)
+        : pendingList.at(-1);
+      if (pending) {
         io.status(`Waiting for the SSH connection to ${label} …`, { transient: true });
         const conn = await pending.promise;
         const lease = this.connections.acquire(conn.id, owner);
@@ -467,13 +476,20 @@ export class SshConnectionManager {
     const tracked = dial.then((lease) => lease.connection);
     tracked.catch(() => undefined); // waiters observe the rejection through their own await
     if (!opts.dedicatedTransport) {
-      this.pendingDials.set(key, { promise: tracked, freshToken });
+      const list = this.pendingDials.get(key);
+      if (list) list.push({ promise: tracked, freshToken });
+      else this.pendingDials.set(key, [{ promise: tracked, freshToken }]);
     }
     try {
       const lease = await dial;
       return { ...lease, reused: false, target };
     } finally {
-      if (this.pendingDials.get(key)?.promise === tracked) this.pendingDials.delete(key);
+      const list = this.pendingDials.get(key);
+      if (list) {
+        const index = list.findIndex((entry) => entry.promise === tracked);
+        if (index >= 0) list.splice(index, 1);
+        if (list.length === 0) this.pendingDials.delete(key);
+      }
     }
   }
 

--- a/server/src/ssh/connection-manager.ts
+++ b/server/src/ssh/connection-manager.ts
@@ -133,6 +133,12 @@ export interface ManagedConnection {
   sftpAvailable: boolean;
   /** *Forward lines resolved from ssh config — auto-started once the session is up. */
   configForwards: ConfigForward[];
+  /** Force-reconnect group that dialed this transport, so sibling requests
+   *  from the same gesture share the one replacement connection. */
+  replacementToken?: string;
+  /** Replaced by a forced fresh transport: never handed out for sharing again;
+   *  existing leases (tunnels, transfers) keep it alive until they release. */
+  superseded?: boolean;
   /** Current passive keepalive health of the transport. */
   health(): SshTransportHealth;
   /** Session defaults come from the dialed target when none are passed. */
@@ -264,7 +270,10 @@ export class SshConnectionManager {
   private readonly closeReasons = new WeakMap<Client, string>();
   private readonly postAuth = new WeakMap<Client, Promise<void>>();
   /** In-flight dials by mux key, so simultaneous sessions share one TCP connection and one auth round-trip. */
-  private readonly pendingDials = new Map<string, Promise<ManagedConnection>>();
+  private readonly pendingDials = new Map<
+    string,
+    { promise: Promise<ManagedConnection>; freshToken?: string }
+  >();
   /** Dial plans whose optional integration setup killed the remote transport; reset on app restart. */
   private readonly automaticPlainShellKeys = new Set<string>();
   private readonly loadConfig: () => ConfigDocument;
@@ -334,7 +343,12 @@ export class SshConnectionManager {
 
   /** Live transports (forwarding panel, connection reuse when starting tunnels). */
   list(): ConnectionInfo[] {
-    return this.connections.list().map((conn) => ({
+    // A superseded transport still carries its existing tunnels, but new
+    // consumers must land on the replacement, not the corpse-to-be.
+    return this.connections
+      .list()
+      .filter((conn) => !conn.superseded)
+      .map((conn) => ({
       id: conn.id,
       target: conn.profile.target,
       host: conn.host,
@@ -358,7 +372,15 @@ export class SshConnectionManager {
     profile: SshProfile,
     io: ConnectIo,
     owner: ConnectionLeaseOwner = 'terminal',
-    opts: { freshTransport?: boolean; forcePlainShell?: boolean } = {},
+    opts: {
+      /** Force-reconnect group token: skip transports established before this
+       *  request; requests sharing a token share one replacement connection. */
+      freshTransport?: string;
+      /** Internal fallbacks (MaxSessions overflow, plain-console retry): dial
+       *  an own transport without joining or retiring anyone else's. */
+      dedicatedTransport?: boolean;
+      forcePlainShell?: boolean;
+    } = {},
   ): Promise<MuxedConnectionLease> {
     profile = this.resolveProfile(profile);
     const doc = this.loadConfig();
@@ -393,8 +415,11 @@ export class SshConnectionManager {
       'ssh connect requested',
     );
 
-    if (!opts.freshTransport) {
-      const shared = this.acquireShared(key, owner, target);
+    const freshToken = opts.dedicatedTransport ? undefined : opts.freshTransport;
+    if (!opts.dedicatedTransport) {
+      // A force-reconnect request skips every pre-existing transport but may
+      // still share the replacement its own gesture already established.
+      const shared = this.acquireShared(key, owner, target, freshToken);
       if (shared) {
         shared.connection.configForwards = mergeConfigForwards(
           shared.connection.configForwards,
@@ -405,11 +430,13 @@ export class SshConnectionManager {
         return shared;
       }
       const pending = this.pendingDials.get(key);
-      if (pending) {
+      // A failed dial fails every session waiting on it — auth prompts and
+      // errors surface on the session that started the dial. A fresh request
+      // never waits on the dial it is trying to escape: it joins an in-flight
+      // dial only when that dial belongs to its own force-reconnect group.
+      if (pending && (!freshToken || pending.freshToken === freshToken)) {
         io.status(`Waiting for the SSH connection to ${label} …`, { transient: true });
-        // A failed dial fails every session waiting on it — auth prompts and
-        // errors surface on the session that started the dial.
-        const conn = await pending;
+        const conn = await pending.promise;
         const lease = this.connections.acquire(conn.id, owner);
         if (lease) {
           conn.configForwards = mergeConfigForwards(conn.configForwards, configForwards);
@@ -428,15 +455,25 @@ export class SshConnectionManager {
       metadataAlias,
       disableSftp,
       consoleCompatibility,
-    );
+    ).then((lease) => {
+      if (freshToken) {
+        // Tag before waiters observe the connection, and retire the replaced
+        // transports so no later session multiplexes onto them.
+        lease.connection.replacementToken = freshToken;
+        this.retireReplacedTransports(key, lease.connection.id);
+      }
+      return lease;
+    });
     const tracked = dial.then((lease) => lease.connection);
     tracked.catch(() => undefined); // waiters observe the rejection through their own await
-    this.pendingDials.set(key, tracked);
+    if (!opts.dedicatedTransport) {
+      this.pendingDials.set(key, { promise: tracked, freshToken });
+    }
     try {
       const lease = await dial;
       return { ...lease, reused: false, target };
     } finally {
-      if (this.pendingDials.get(key) === tracked) this.pendingDials.delete(key);
+      if (this.pendingDials.get(key)?.promise === tracked) this.pendingDials.delete(key);
     }
   }
 
@@ -451,24 +488,54 @@ export class SshConnectionManager {
     if (!saved || saved.profileId !== profile.profileId || saved.useConfig !== false) {
       throw new Error(`saved SSH profile "${profile.profileId}" was not found`);
     }
-    return saved;
+    // Connection fields come from the database. The keepalive fallback is an
+    // application preference supplied by the current renderer, so the wire
+    // value always wins — including its absence (preference set to
+    // configuration-only), which must clear anything a client stored.
+    return { ...saved, keepaliveIntervalSeconds: profile.keepaliveIntervalSeconds };
   }
 
-  /** Least-busy live, healthy transport with the same dial plan, if any. */
+  /**
+   * Least-busy live, healthy transport with the same dial plan, if any.
+   * A superseded transport is never handed out again; a force-reconnect
+   * request reuses only the replacement its own gesture established.
+   */
   private acquireShared(
     key: string,
     owner: ConnectionLeaseOwner,
     target: ChainHop,
+    freshToken?: string,
   ): MuxedConnectionLease | undefined {
     const candidates = this.connections
       .list()
-      .filter((conn) => conn.muxKey === key && conn.health() === 'healthy')
+      .filter(
+        (conn) =>
+          conn.muxKey === key &&
+          conn.health() === 'healthy' &&
+          (freshToken ? conn.replacementToken === freshToken : !conn.superseded),
+      )
       .sort((a, b) => this.connections.leaseCount(a.id) - this.connections.leaseCount(b.id));
     for (const conn of candidates) {
       const lease = this.connections.acquire(conn.id, owner);
       if (lease) return { ...lease, reused: true, target };
     }
     return undefined;
+  }
+
+  /**
+   * A live replacement makes every older same-plan transport ineligible for
+   * new consumers. Their existing leases (tunnels, transfers) stay valid, and
+   * the transport still closes only after the last of them releases.
+   */
+  private retireReplacedTransports(key: string, replacementId: string): void {
+    for (const conn of this.connections.list()) {
+      if (conn.id === replacementId || conn.muxKey !== key || conn.superseded) continue;
+      conn.superseded = true;
+      this.log.info(
+        { connId: conn.id, host: conn.host },
+        'ssh transport superseded by a forced replacement',
+      );
+    }
   }
 
   /**
@@ -484,8 +551,9 @@ export class SshConnectionManager {
     cols: number,
     rows: number,
     term: string,
+    opts: { freshTransport?: string } = {},
   ): Promise<TerminalShell> {
-    const lease = await this.connect(profile, io);
+    const lease = await this.connect(profile, io, 'terminal', opts);
     try {
       const stream = await lease.connection.shell(cols, rows, term, sessionSettings(lease.target.resolved));
       return { lease, stream, transport: lease.reused ? 'shared' : 'new' };
@@ -500,7 +568,7 @@ export class SshConnectionManager {
         'shared ssh transport refused a session; dialing a dedicated connection',
       );
       io.status('The shared SSH connection refused another session — opening a dedicated one …', { transient: true });
-      const dedicated = await this.connect(profile, io, 'terminal', { freshTransport: true });
+      const dedicated = await this.connect(profile, io, 'terminal', { dedicatedTransport: true });
       try {
         const stream = await dedicated.connection.shell(cols, rows, term, sessionSettings(dedicated.target.resolved));
         return { lease: dedicated, stream, transport: 'overflow' };
@@ -546,7 +614,7 @@ export class SshConnectionManager {
       { transient: true },
     );
     const compatible = await this.connect(profile, io, 'terminal', {
-      freshTransport: true,
+      dedicatedTransport: true,
       forcePlainShell: true,
     });
     try {
@@ -1002,9 +1070,10 @@ export class SshConnectionManager {
 /**
  * Identity of a dial plan for connection sharing: the resolved hop sequence
  * (user@hostname:port and agent-forwarding policy for each hop) plus the
- * expanded ProxyCommand transport when one applies. Other auth settings are
- * deliberately absent — they matter while establishing a transport, not for
- * attaching to an established one.
+ * expanded ProxyCommand transport when one applies. Settings that matter only
+ * while establishing a transport — auth and keepalive policy alike — are
+ * deliberately absent: a keepalive preference change must not fork sharing
+ * (and demand a second login) while the established transport still works.
  */
 export function muxKey(
   chain: ChainHop[],
@@ -1070,11 +1139,19 @@ export function buildChain(
       : final && profile.profileId
         ? profileFolderAuthFor?.(profile.profileId)
         : undefined;
-    const base = fromConfig
+    const configuredBase = fromConfig
       ? resolveHost(doc, spec.host, folder?.optionLines)
       : folder
         ? resolveHost(EMPTY_CONFIG_DOCUMENT, spec.host, folder.optionLines)
         : directSettings(spec.host);
+    // The application preference is a fallback, not an override: aliases with
+    // an explicit ServerAliveInterval (including 0) keep their own policy.
+    // Apply it to jump hops as well so every TCP leg stays alive while idle.
+    const base = {
+      ...configuredBase,
+      serverAliveInterval:
+        configuredBase.serverAliveInterval ?? profile.keepaliveIntervalSeconds,
+    };
     const user = (final ? profile.user : undefined) ?? spec.user ?? base.user ?? os.userInfo().username;
     const resolved: ResolvedTarget = final
       ? {

--- a/server/src/ws/terminal-socket.ts
+++ b/server/src/ws/terminal-socket.ts
@@ -576,7 +576,14 @@ async function handleSession(socket: WebSocket, ctx: AppContext, app: FastifyIns
   }
 
   // --- SSH ---
-  const { lease: terminalLease, stream, transport } = await ctx.connections.connectShell(profile, io, cols, rows, DEFAULT_TERM);
+  const { lease: terminalLease, stream, transport } = await ctx.connections.connectShell(
+    profile,
+    io,
+    cols,
+    rows,
+    DEFAULT_TERM,
+    { freshTransport: connectMsg.freshTransport },
+  );
   const conn = terminalLease.connection;
   // Session forwards belong to the terminal sessions using this transport;
   // stop them when the last terminal/dial lease leaves. Saved/manual tunnels

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -7,6 +7,9 @@ export const TERMINAL_WS_AUTH_PREFIX = 'muxus.auth.';
 /** Clean-close reason that explicitly ends the backend terminal lifecycle. */
 export const TERMINAL_SESSION_CLOSE_REASON = 'terminal session closed';
 
+/** Upper bound for the Muxus-wide ServerAliveInterval fallback, in seconds. */
+export const MAX_SSH_KEEPALIVE_INTERVAL_SECONDS = 3600;
+
 /** Protocols offered by browser WebSocket clients during the HTTP upgrade. */
 export function terminalWebSocketProtocols(token: string): string[] {
   return [TERMINAL_WS_PROTOCOL, `${TERMINAL_WS_AUTH_PREFIX}${token}`];
@@ -45,6 +48,16 @@ export const sshProfileSchema = z.object({
   target: z.string().min(1),
   /** False for a self-contained saved host or tunnel; jump aliases may still resolve from config. */
   useConfig: z.boolean().optional(),
+  /**
+   * Muxus-wide fallback for ServerAliveInterval, in seconds. An explicit
+   * ssh_config value still wins for the host or jump hop.
+   */
+  keepaliveIntervalSeconds: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_SSH_KEEPALIVE_INTERVAL_SECONDS)
+    .optional(),
   /** Quick-connect overrides on top of config resolution. */
   user: z.string().optional(),
   port: z.number().int().min(1).max(65535).optional(),
@@ -142,6 +155,12 @@ export const terminalClientMessageSchema = z.discriminatedUnion('op', [
   z.object({
     op: z.literal('connect'),
     profile: sessionProfileSchema,
+    /**
+     * Replacement-group token: skip SSH transports established before this
+     * request and dial a replacement. Connects carrying the same token share
+     * one replacement connection (one login for a force-reconnected window).
+     */
+    freshTransport: z.string().min(1).max(100).optional(),
     /** User-facing tab title retained in session history. */
     title: z.string().trim().min(1).max(500).optional(),
     cols: z.number().int().positive(),

--- a/tests/unit/client/prefs.test.ts
+++ b/tests/unit/client/prefs.test.ts
@@ -9,6 +9,7 @@ import {
 import { DEFAULT_SIDEBAR_WIDTH } from '../../../client/src/sidebar-width.js';
 import {
   DEFAULT_INACTIVE_PANE_DIM_STRENGTH,
+  DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS,
   MONO_FONT_FALLBACK,
   clampInactivePaneDimStrength,
   isLocalShellProfileArray,
@@ -27,6 +28,23 @@ const ubuntuProfile = {
   cwd: 'C:\\work',
   startupCommand: 'cd project',
 };
+
+describe('SSH keepalive preference', () => {
+  it('defaults to a 30-second fallback', () => {
+    expect(usePrefsStore.getInitialState().sshKeepaliveIntervalSeconds).toBe(
+      DEFAULT_SSH_KEEPALIVE_INTERVAL_SECONDS,
+    );
+  });
+
+  it('keeps valid values and drops malformed persisted values', () => {
+    expect(migratePrefsState({ sshKeepaliveIntervalSeconds: 60 }, 13)).toEqual({
+      sshKeepaliveIntervalSeconds: 60,
+    });
+    expect(
+      migratePrefsState({ sshKeepaliveIntervalSeconds: -1, monoFontSize: 16 }, 13),
+    ).toEqual({ monoFontSize: 16 });
+  });
+});
 
 describe('appearance preference', () => {
   it('defaults new installations to the system appearance', () => {

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  requestForceReconnectAll,
   requestClosePane,
   splitActivePane,
 } from '../../../client/src/session-actions.js';
@@ -409,6 +410,107 @@ describe('workspace restoration', () => {
         reconnectMode: undefined,
       }),
     ]);
+  });
+
+  it('force reconnects every remote session without replacing local shells', () => {
+    const localId = useTabsStore.getState().open({ kind: 'local' }, 'Local');
+    const sshId = useTabsStore.getState().open(
+      { kind: 'ssh', target: 'router' },
+      'Router',
+    );
+    const telnetId = useTabsStore.getState().open(
+      { kind: 'telnet', host: 'console', port: 23 },
+      'Console',
+    );
+    useTabsStore.getState().update(sshId, {
+      status: 'connected',
+      connId: 'old-transport',
+    });
+    useTabsStore.getState().update(telnetId, {
+      status: 'interrupted',
+      failureReason: 'not responding',
+      disconnectReason: 'disconnected',
+    });
+
+    useTabsStore.getState().forceReconnectAll();
+
+    expect(useTabsStore.getState().tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: localId,
+          status: 'connecting',
+          reconnectRequest: 0,
+        }),
+        expect.objectContaining({
+          id: sshId,
+          status: 'connecting',
+          connId: undefined,
+          reconnectRequest: 1,
+          freshTransport: expect.any(String),
+          failureReason: undefined,
+        }),
+        expect.objectContaining({
+          id: telnetId,
+          status: 'connecting',
+          reconnectRequest: 1,
+          freshTransport: undefined,
+          failureReason: undefined,
+          disconnectReason: undefined,
+        }),
+      ]),
+    );
+  });
+
+  it('confirms before force reconnecting live remote sessions', async () => {
+    const sshId = useTabsStore.getState().open(
+      { kind: 'ssh', target: 'router' },
+      'Router',
+    );
+    useTabsStore.getState().update(sshId, { status: 'connected' });
+
+    const pending = requestForceReconnectAll();
+    await settle();
+
+    expect(useDialogStore.getState().queue[0]).toMatchObject({
+      kind: 'confirm',
+      title: 'Force reconnect 1 remote session?',
+      destructive: true,
+    });
+    await answerDialog(true);
+
+    expect(await pending).toBe(true);
+    expect(useTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({
+        id: sshId,
+        status: 'connecting',
+        reconnectRequest: 1,
+        freshTransport: expect.any(String),
+      }),
+    ]);
+  });
+
+  it('keeps an unfulfilled fresh-transport request across retries until success', () => {
+    const sshId = useTabsStore.getState().open(
+      { kind: 'ssh', target: 'router' },
+      'Router',
+    );
+    useTabsStore.getState().update(sshId, { status: 'connected' });
+    useTabsStore.getState().forceReconnectAll();
+    const token = useTabsStore.getState().tabs[0]!.freshTransport;
+    expect(token).toEqual(expect.any(String));
+
+    // A failed forced dial retries through reconnect() and must stay fresh —
+    // never silently multiplex onto the transport it was meant to replace.
+    useTabsStore.getState().update(sshId, { status: 'closed' });
+    useTabsStore.getState().reconnect([sshId]);
+    expect(useTabsStore.getState().tabs[0]!.freshTransport).toBe(token);
+
+    // Success clears it, the way the terminal ready handler does.
+    useTabsStore.getState().update(sshId, {
+      status: 'connected',
+      freshTransport: undefined,
+    });
+    expect(useTabsStore.getState().tabs[0]!.freshTransport).toBeUndefined();
   });
 
   it('clears stale failure details when manually reconnecting', () => {

--- a/tests/unit/client/tabs.test.ts
+++ b/tests/unit/client/tabs.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  requestForceReconnect,
   requestForceReconnectAll,
   requestClosePane,
   splitActivePane,
@@ -487,6 +488,80 @@ describe('workspace restoration', () => {
         freshTransport: expect.any(String),
       }),
     ]);
+  });
+
+  it('force reconnects one session while its siblings keep their transport', () => {
+    const sshId = useTabsStore.getState().open(
+      { kind: 'ssh', target: 'router' },
+      'Router',
+    );
+    const siblingId = useTabsStore.getState().open(
+      { kind: 'ssh', target: 'router' },
+      'Router 2',
+    );
+    useTabsStore.getState().update(sshId, { status: 'connected', connId: 'shared' });
+    useTabsStore.getState().update(siblingId, { status: 'connected', connId: 'shared' });
+
+    useTabsStore.getState().forceReconnect(sshId);
+
+    expect(useTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({
+        id: sshId,
+        status: 'connecting',
+        connId: undefined,
+        reconnectRequest: 1,
+        freshTransport: expect.any(String),
+      }),
+      expect.objectContaining({
+        id: siblingId,
+        status: 'connected',
+        connId: 'shared',
+        reconnectRequest: 0,
+      }),
+    ]);
+    expect(useTabsStore.getState().tabs[1]!.freshTransport).toBeUndefined();
+  });
+
+  it('confirms before force reconnecting one live session', async () => {
+    const sshId = useTabsStore.getState().open(
+      { kind: 'ssh', target: 'router' },
+      'Router',
+    );
+    useTabsStore.getState().update(sshId, { status: 'connected' });
+
+    const pending = requestForceReconnect(sshId);
+    await settle();
+
+    expect(useDialogStore.getState().queue[0]).toMatchObject({
+      kind: 'confirm',
+      title: 'Force reconnect Router?',
+      destructive: true,
+    });
+    await answerDialog(true);
+
+    expect(await pending).toBe(true);
+    expect(useTabsStore.getState().tabs[0]).toMatchObject({
+      status: 'connecting',
+      reconnectRequest: 1,
+      freshTransport: expect.any(String),
+    });
+  });
+
+  it('force reconnects an ended session without a confirmation', async () => {
+    const sshId = useTabsStore.getState().open(
+      { kind: 'ssh', target: 'router' },
+      'Router',
+    );
+    useTabsStore.getState().update(sshId, { status: 'closed' });
+
+    expect(await requestForceReconnect(sshId)).toBe(true);
+
+    expect(useDialogStore.getState().queue).toEqual([]);
+    expect(useTabsStore.getState().tabs[0]).toMatchObject({
+      status: 'connecting',
+      reconnectRequest: 1,
+      freshTransport: expect.any(String),
+    });
   });
 
   it('keeps an unfulfilled fresh-transport request across retries until success', () => {

--- a/tests/unit/server/chain.test.ts
+++ b/tests/unit/server/chain.test.ts
@@ -56,6 +56,28 @@ describe('buildChain', () => {
     expect(chain[1]!.hopLabel).toBeUndefined();
   });
 
+  it('uses the Muxus keepalive fallback without overriding SSH configuration', () => {
+    const doc = docOf(
+      [
+        'Host app',
+        '  ProxyJump bastion',
+        '  ServerAliveInterval 90',
+        '',
+        'Host bastion',
+        '  HostName bastion.example.com',
+      ].join('\n'),
+    );
+
+    const chain = buildChain(doc, {
+      target: 'app',
+      keepaliveIntervalSeconds: 30,
+    });
+
+    expect(chain).toHaveLength(2);
+    expect(chain[0]!.resolved.serverAliveInterval).toBe(30);
+    expect(chain[1]!.resolved.serverAliveInterval).toBe(90);
+  });
+
   it('expands nested and comma-listed jumps in dial order', () => {
     const doc = docOf(
       ['Host app', '  ProxyJump j1,ops@j2:2202', '', 'Host j1', '  HostName j1.example.com', '  ProxyJump j0', '', 'Host j0', '  HostName j0.example.com'].join(
@@ -174,6 +196,8 @@ describe('saved SSH profile resolution', () => {
               target: 'current.example.test',
               useConfig: false,
               user: 'current-user',
+              // Not writable from the app; simulates an API-written profile.
+              keepaliveIntervalSeconds: 120,
             }
           : undefined,
     });
@@ -185,11 +209,23 @@ describe('saved SSH profile resolution', () => {
         target: 'stale.example.test',
         useConfig: false,
         user: 'stale-user',
+        keepaliveIntervalSeconds: 30,
       }),
     ).toMatchObject({
       target: 'current.example.test',
       user: 'current-user',
+      keepaliveIntervalSeconds: 30,
     });
+    // The keepalive preference travels with each connect; a stored value must
+    // not resurface when the renderer's preference says configuration-only.
+    expect(
+      manager.resolveProfile({
+        kind: 'ssh',
+        profileId: 'saved-1',
+        target: 'stale.example.test',
+        useConfig: false,
+      }).keepaliveIntervalSeconds,
+    ).toBeUndefined();
     expect(() =>
       manager.resolveProfile({
         kind: 'ssh',
@@ -291,6 +327,19 @@ describe('passive SSH transport health', () => {
 });
 
 describe('muxKey', () => {
+  it('shares transports across keepalive policies', () => {
+    // Keepalive matters while establishing a transport, not for attaching to
+    // an established one — a preference change must not fork sharing (and
+    // demand a second login) while the existing transport still works.
+    const doc = docOf('');
+    const withoutKeepalive = muxKey(buildChain(doc, { target: 'web' }));
+    const withKeepalive = muxKey(
+      buildChain(doc, { target: 'web', keepaliveIntervalSeconds: 30 }),
+    );
+
+    expect(withKeepalive).toBe(withoutKeepalive);
+  });
+
   it('matches when different targets resolve to the same dial plan', () => {
     const doc = docOf(
       [

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -171,6 +171,25 @@ function profile(port: number): SshProfile {
   return { kind: 'ssh', target: '127.0.0.1', user: 'tester', port, passwordOnly: true, useConfig: false };
 }
 
+/** ConnectIo that parks its dial at the auth prompt until released. */
+function hangingIo(): { io: ConnectIo; prompted: Promise<void>; release: () => void } {
+  let release: (() => void) | undefined;
+  let shown!: () => void;
+  const prompted = new Promise<void>((resolve) => {
+    shown = resolve;
+  });
+  const io: ConnectIo = {
+    status: () => undefined,
+    prompt: () =>
+      new Promise((resolve) => {
+        release = () => resolve({ answers: [PASSWORD] });
+        shown();
+      }),
+    hostKey: () => Promise.resolve(true),
+  };
+  return { io, prompted, release: () => release?.() };
+}
+
 describe('SSH connection multiplexing', () => {
   let manager: SshConnectionManager | undefined;
   let server: Server | undefined;
@@ -356,23 +375,10 @@ describe('SSH connection multiplexing', () => {
 
     // A dial stuck at an unanswered auth prompt used to capture the forced
     // reconnect, which then inherited the hang it was meant to escape.
-    let releasePrompt: (() => void) | undefined;
-    let promptShown!: () => void;
-    const prompted = new Promise<void>((resolve) => {
-      promptShown = resolve;
-    });
-    const hungIo: ConnectIo = {
-      status: () => undefined,
-      prompt: () =>
-        new Promise((resolve) => {
-          releasePrompt = () => resolve({ answers: [PASSWORD] });
-          promptShown();
-        }),
-      hostKey: () => Promise.resolve(true),
-    };
-    const hung = manager.connect(profile(started.port), hungIo);
+    const stuck = hangingIo();
+    const hung = manager.connect(profile(started.port), stuck.io);
     hung.catch(() => undefined);
-    await prompted;
+    await stuck.prompted;
 
     const fresh = await manager.connect(profile(started.port), makeIo().io, 'terminal', {
       freshTransport: 'wave-c',
@@ -381,8 +387,42 @@ describe('SSH connection multiplexing', () => {
     expect(started.stats.connections).toBe(2);
 
     // Unblock the abandoned dial so teardown can close its transport cleanly.
-    releasePrompt?.();
+    stuck.release();
     (await hung).release();
+  }, 15_000);
+
+  it('keeps overlapping force-reconnect gestures joinable side by side', async () => {
+    const started = await startServer();
+    server = started.server;
+    manager = makeManager();
+
+    // Two gestures with in-flight dials: a straggler from the first gesture
+    // must join its own gesture's dial, not the newer one's, and never start
+    // a third transport.
+    const slowA = hangingIo();
+    const dialA = manager.connect(profile(started.port), slowA.io, 'terminal', {
+      freshTransport: 'wave-a',
+    });
+    dialA.catch(() => undefined);
+    await slowA.prompted;
+    const slowB = hangingIo();
+    const dialB = manager.connect(profile(started.port), slowB.io, 'terminal', {
+      freshTransport: 'wave-b',
+    });
+    dialB.catch(() => undefined);
+    await slowB.prompted;
+
+    const straggler = manager.connect(profile(started.port), makeIo().io, 'terminal', {
+      freshTransport: 'wave-a',
+    });
+    slowA.release();
+    slowB.release();
+    const [a, b, joined] = await Promise.all([dialA, dialB, straggler]);
+
+    expect(joined.reused).toBe(true);
+    expect(joined.connection.id).toBe(a.connection.id);
+    expect(b.connection.id).not.toBe(a.connection.id);
+    expect(started.stats.connections).toBe(2);
   }, 15_000);
 
   it('gives concurrent overflow fallbacks their own dedicated transports', async () => {

--- a/tests/unit/server/connection-mux.test.ts
+++ b/tests/unit/server/connection-mux.test.ts
@@ -296,7 +296,7 @@ describe('SSH connection multiplexing', () => {
     expect(started.stats.connections).toBe(3);
   }, 15_000);
 
-  it('honors the freshTransport escape hatch', async () => {
+  it('honors the freshTransport escape hatch and retires the replaced transport', async () => {
     const started = await startServer();
     server = started.server;
     manager = makeManager();
@@ -304,12 +304,106 @@ describe('SSH connection multiplexing', () => {
     const first = makeIo();
     const a = await manager.connect(profile(started.port), first.io);
     const second = makeIo();
-    const b = await manager.connect(profile(started.port), second.io, 'terminal', { freshTransport: true });
+    const b = await manager.connect(profile(started.port), second.io, 'terminal', {
+      freshTransport: 'wave-a',
+    });
 
     expect(a.reused).toBe(false);
     expect(b.reused).toBe(false);
     expect(b.connection.id).not.toBe(a.connection.id);
     expect(started.stats.connections).toBe(2);
+
+    // Later sessions multiplex onto the replacement, never the replaced one.
+    const third = await manager.connect(profile(started.port), makeIo().io);
+    expect(third.reused).toBe(true);
+    expect(third.connection.id).toBe(b.connection.id);
+    expect(started.stats.connections).toBe(2);
+  }, 15_000);
+
+  it('deduplicates same-gesture fresh transports without reusing the old one', async () => {
+    const started = await startServer();
+    server = started.server;
+    manager = makeManager();
+
+    const old = await manager.connect(profile(started.port), makeIo().io);
+    const [first, second] = await Promise.all([
+      manager.connect(profile(started.port), makeIo().io, 'terminal', {
+        freshTransport: 'wave-b',
+      }),
+      manager.connect(profile(started.port), makeIo().io, 'terminal', {
+        freshTransport: 'wave-b',
+      }),
+    ]);
+
+    expect(first.connection.id).not.toBe(old.connection.id);
+    expect(second.connection.id).toBe(first.connection.id);
+    expect(started.stats.connections).toBe(2);
+
+    // A straggler from the same gesture reuses the established replacement
+    // instead of dialing yet another transport.
+    const straggler = await manager.connect(profile(started.port), makeIo().io, 'terminal', {
+      freshTransport: 'wave-b',
+    });
+    expect(straggler.reused).toBe(true);
+    expect(straggler.connection.id).toBe(first.connection.id);
+    expect(started.stats.connections).toBe(2);
+  }, 15_000);
+
+  it('never joins an in-flight dial from before the force reconnect', async () => {
+    const started = await startServer();
+    server = started.server;
+    manager = makeManager();
+
+    // A dial stuck at an unanswered auth prompt used to capture the forced
+    // reconnect, which then inherited the hang it was meant to escape.
+    let releasePrompt: (() => void) | undefined;
+    let promptShown!: () => void;
+    const prompted = new Promise<void>((resolve) => {
+      promptShown = resolve;
+    });
+    const hungIo: ConnectIo = {
+      status: () => undefined,
+      prompt: () =>
+        new Promise((resolve) => {
+          releasePrompt = () => resolve({ answers: [PASSWORD] });
+          promptShown();
+        }),
+      hostKey: () => Promise.resolve(true),
+    };
+    const hung = manager.connect(profile(started.port), hungIo);
+    hung.catch(() => undefined);
+    await prompted;
+
+    const fresh = await manager.connect(profile(started.port), makeIo().io, 'terminal', {
+      freshTransport: 'wave-c',
+    });
+    expect(fresh.reused).toBe(false);
+    expect(started.stats.connections).toBe(2);
+
+    // Unblock the abandoned dial so teardown can close its transport cleanly.
+    releasePrompt?.();
+    (await hung).release();
+  }, 15_000);
+
+  it('gives concurrent overflow fallbacks their own dedicated transports', async () => {
+    const started = await startServer({ maxShellsPerConnection: 1 });
+    server = started.server;
+    manager = makeManager();
+
+    const a = await manager.connectShell(profile(started.port), makeIo().io, 80, 24, 'xterm-256color');
+    // Two panes overflowing at once must not share one fallback dial — on a
+    // MaxSessions=1 host the second shell would be refused with no retry.
+    const [b, c] = await Promise.all([
+      manager.connectShell(profile(started.port), makeIo().io, 80, 24, 'xterm-256color'),
+      manager.connectShell(profile(started.port), makeIo().io, 80, 24, 'xterm-256color'),
+    ]);
+
+    expect(a.transport).toBe('new');
+    expect([b.transport, c.transport]).toEqual(['overflow', 'overflow']);
+    expect(
+      new Set([a.lease.connection.id, b.lease.connection.id, c.lease.connection.id]).size,
+    ).toBe(3);
+    expect(started.stats).toMatchObject({ connections: 3, shells: 3 });
   }, 15_000);
 
   it('opens a plain shell in console mode when the host rejects pty-req', async () => {

--- a/tests/unit/shared/ws-protocol.test.ts
+++ b/tests/unit/shared/ws-protocol.test.ts
@@ -57,11 +57,36 @@ describe('sessionProfileSchema', () => {
       port: 2222,
       user: 'alice',
       useConfig: false,
+      keepaliveIntervalSeconds: 30,
       identityFiles: ['~/.ssh/work_ed25519'],
       identitiesOnly: true,
       proxyJump: ['bastion', 'ops@relay:2200'],
     });
     expect(parsed.success).toBe(true);
+  });
+
+  it('bounds the Muxus SSH keepalive fallback', () => {
+    expect(
+      sessionProfileSchema.safeParse({
+        kind: 'ssh',
+        target: 'web',
+        keepaliveIntervalSeconds: 30,
+      }).success,
+    ).toBe(true);
+    expect(
+      sessionProfileSchema.safeParse({
+        kind: 'ssh',
+        target: 'web',
+        keepaliveIntervalSeconds: 0,
+      }).success,
+    ).toBe(false);
+    expect(
+      sessionProfileSchema.safeParse({
+        kind: 'ssh',
+        target: 'web',
+        keepaliveIntervalSeconds: 3601,
+      }).success,
+    ).toBe(false);
   });
 
   it('accepts Telnet profiles and supplies the standard port', () => {
@@ -152,6 +177,7 @@ describe('terminalClientMessageSchema', () => {
     const parsed = terminalClientMessageSchema.safeParse({
       op: 'connect',
       profile: { kind: 'ssh', target: 'example.com' },
+      freshTransport: 'fresh-1a2b',
       title: 'Production',
       cols: 80,
       rows: 24,


### PR DESCRIPTION
## SSH keepalive fallback

Muxus now sends a protocol-level SSH keepalive after 30 idle seconds by default, so firewalls, NATs and VPNs no longer silently discard idle connections. Details:

- New **SSH keepalive interval** select in Settings → Behavior (`SSH configuration only`, 15 s, 30 s, 1 min, 2 min). A value persisted outside that list renders as an explicit "custom" entry instead of a blank field.
- The preference is a fallback, not an override: an explicit `ServerAliveInterval` (including `0`) keeps its own policy, per host and per jump hop.
- It travels with each connect/dial message and is never stored — saved-host writes strip the field, and profile resolution always takes the wire value, so a stored value can't outvote the current preference.
- Keepalive stays **out of the mux key**: it matters while establishing a transport, like auth settings, so changing the preference never forks connection sharing or demands a second login/2FA. It applies when a transport is dialed fresh.

## Force reconnect all

New action in the workspace dialog and the quick launcher: replace every SSH, Telnet and serial terminal session in the window, including sessions that still look connected (with a destructive-styled confirmation; tmux/screen survive as usual).

The interesting part is transport handling. Each gesture generates a replacement-group token that all its SSH connects carry:

- A tokened connect skips every established transport **and every in-flight dial from before the gesture** — a hung dial can't capture the reconnect that is trying to escape it.
- Connects sharing a token share one replacement connection per host: the first dials, siblings join the pending dial, and stragglers multiplex onto the established replacement. One login/2FA per host per gesture.
- Once the replacement is live, older same-plan transports are retired from sharing (and from `/api/connections`, so new tunnels land on the replacement). Existing tunnels keep their transport alive until they stop.
- An unfulfilled replacement request survives failed retries and is cleared only when a connection succeeds, so a failed forced dial never falls back silently onto the transport it was meant to replace.
- The internal MaxSessions-overflow and plain-console fallbacks use a separate dedicated-dial path, so concurrent overflow panes keep getting their own transports.
- Serial: reopening the same port races the old descriptor's exclusive-lock release, so a busy port gets a short retry grace period before failing.

## Docs & tests

Docs updated (connecting, workspaces, settings, ssh-config reference), including the explicit note that saved tunnels keep their existing connections. New unit coverage: keepalive fallback resolution and bounds, mux-key sharing across keepalive policies, hung-dial escape, same-gesture dedup + straggler reuse, replaced-transport retirement, concurrent overflow fallbacks, and fresh-token lifecycle in the tab store.