### PR TITLE
Add new host action to folder context menu

### DIFF
--- a/client/src/components/HostEditorDialog.tsx
+++ b/client/src/components/HostEditorDialog.tsx
@@ -142,7 +142,9 @@ function editorKind(state: OpenState): 'ssh' | 'telnet' | 'serial' {
 }
 
 function stateIdentity(state: OpenState): string {
-  if (state.mode === 'new') return `new:${state.prefillTarget ?? ''}`;
+  if (state.mode === 'new') {
+    return `new:${state.prefillTarget ?? ''}:${state.group ?? ''}`;
+  }
   if (state.mode === 'edit-profile' || state.mode === 'duplicate-profile') {
     return `${state.mode}:${state.entry.id}`;
   }
@@ -150,7 +152,7 @@ function stateIdentity(state: OpenState): string {
 }
 
 function initialSshDraft(state: OpenState): HostDraft {
-  if (state.mode === 'new') return blankDraft(state.prefillTarget);
+  if (state.mode === 'new') return blankDraft(state.prefillTarget, state.group);
   if (state.mode === 'edit' || state.mode === 'duplicate') {
     return draftFromEntry(state.entry, state.mode === 'duplicate');
   }
@@ -176,7 +178,10 @@ function initialNativeDraft(state: OpenState): NativeHostDraft {
       state.mode === 'duplicate-profile',
     );
   }
-  return blankNativeDraft(state.mode === 'new' ? state.prefillTarget : undefined);
+  return blankNativeDraft(
+    state.mode === 'new' ? state.prefillTarget : undefined,
+    state.mode === 'new' ? state.group : undefined,
+  );
 }
 
 /**
@@ -419,7 +424,7 @@ function SshHostEditorContent({
       typeKind={state.mode === 'new' ? 'ssh' : undefined}
       onTypeChange={
         state.mode === 'new'
-          ? (kind) => setState({ mode: 'new', kind, prefillTarget: state.prefillTarget })
+          ? (kind) => setState({ ...state, kind })
           : undefined
       }
       sections={sections}

--- a/client/src/components/NativeHostEditorContent.tsx
+++ b/client/src/components/NativeHostEditorContent.tsx
@@ -173,7 +173,7 @@ export function NativeHostEditorContent({
       typeKind={state.mode === 'new' ? kind : undefined}
       onTypeChange={
         state.mode === 'new'
-          ? (next) => setState({ mode: 'new', kind: next, prefillTarget: state.prefillTarget })
+          ? (next) => setState({ ...state, kind: next })
           : undefined
       }
       sections={sections}

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -679,6 +679,7 @@ export function SessionSidebar() {
             folder={{
               menu: folderMenu,
               onClose: () => setFolderMenu(null),
+              onNewHost: (node) => setHostEditor({ mode: 'new', group: node.path }),
               onNewChild: (node) => setFolderDialog({ mode: 'new', parentPath: node.path }),
               onEdit: (node) => setFolderDialog({ mode: 'edit', path: node.path }),
               onLaunch: launchNode,

--- a/client/src/components/host-editor/draft.ts
+++ b/client/src/components/host-editor/draft.ts
@@ -62,7 +62,7 @@ export interface HostDraft {
   sessionLogging: HostSessionLoggingDraft;
 }
 
-export function blankDraft(prefillTarget = ''): HostDraft {
+export function blankDraft(prefillTarget = '', group = ''): HostDraft {
   // A quick-connect target already carries the fields the form asks for; a bare
   // name the sidebar could not find is just the alias.
   const target = prefillTarget.trim();
@@ -72,7 +72,7 @@ export function blankDraft(prefillTarget = ''): HostDraft {
     aliasText: parsed?.host ?? target,
     description: '',
     displayName: '',
-    group: '',
+    group,
     color: undefined,
     terminalScheme: undefined,
     terminalFontColor: undefined,

--- a/client/src/components/host-editor/native-draft.ts
+++ b/client/src/components/host-editor/native-draft.ts
@@ -36,11 +36,11 @@ export interface NativeHostDraft {
   sessionLogging: HostSessionLoggingDraft;
 }
 
-export function blankNativeDraft(prefillTarget = ''): NativeHostDraft {
+export function blankNativeDraft(prefillTarget = '', group = ''): NativeHostDraft {
   const { host, port } = parseHostTarget(prefillTarget);
   return {
     name: '',
-    group: '',
+    group,
     color: undefined,
     terminalScheme: undefined,
     terminalFontColor: undefined,

--- a/client/src/components/sidebar/FolderContextMenu.tsx
+++ b/client/src/components/sidebar/FolderContextMenu.tsx
@@ -4,13 +4,14 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import CreateNewFolderOutlinedIcon from '@mui/icons-material/CreateNewFolderOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import type { FolderNode } from '../../host-tree.js';
-import { loadFolderDialog } from '../../lazy-features.js';
+import { loadFolderDialog, loadHostEditorDialog } from '../../lazy-features.js';
 
 export interface FolderMenuState {
   anchor: HTMLElement;
@@ -21,6 +22,7 @@ export interface FolderMenuState {
 export function FolderContextMenu({
   menu,
   onClose,
+  onNewHost,
   onNewChild,
   onEdit,
   onLaunch,
@@ -32,6 +34,7 @@ export function FolderContextMenu({
 }: {
   menu: FolderMenuState | null;
   onClose: () => void;
+  onNewHost: (node: FolderNode) => void;
   onNewChild: (node: FolderNode) => void;
   onEdit: (node: FolderNode) => void;
   onLaunch: (node: FolderNode) => void;
@@ -75,6 +78,16 @@ export function FolderContextMenu({
         Move down
       </MenuItem>
       <Divider />
+      <MenuItem
+        onMouseEnter={() => void loadHostEditorDialog()}
+        onFocus={() => void loadHostEditorDialog()}
+        onClick={run(onNewHost)}
+      >
+        <ListItemIcon>
+          <DnsOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        New host…
+      </MenuItem>
       <MenuItem
         onMouseEnter={() => void loadFolderDialog()}
         onFocus={() => void loadFolderDialog()}

--- a/client/src/state/ui.ts
+++ b/client/src/state/ui.ts
@@ -4,7 +4,12 @@ import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
 /** Unified editor state for OpenSSH entries and Muxus-owned Telnet/serial hosts. */
 export type HostEditorState =
   | false
-  | { mode: 'new'; prefillTarget?: string; kind?: 'ssh' | 'telnet' | 'serial' }
+  | {
+      mode: 'new';
+      prefillTarget?: string;
+      group?: string;
+      kind?: 'ssh' | 'telnet' | 'serial';
+    }
   | { mode: 'duplicate'; entry: SshHostEntry }
   | { mode: 'edit'; entry: SshHostEntry }
   | { mode: 'duplicate-profile'; entry: SavedHostProfile }

--- a/tests/unit/client/host-editor-draft.test.ts
+++ b/tests/unit/client/host-editor-draft.test.ts
@@ -229,4 +229,10 @@ describe('SSH host editor draft', () => {
       port: '',
     });
   });
+
+  it('prefills the selected folder for a new host', () => {
+    expect(blankDraft('', 'Production/Edge')).toMatchObject({
+      group: 'Production/Edge',
+    });
+  });
 });

--- a/tests/unit/client/native-host-draft.test.ts
+++ b/tests/unit/client/native-host-draft.test.ts
@@ -66,6 +66,12 @@ describe('blankNativeDraft', () => {
       port: '23',
     });
   });
+
+  it('prefills the selected folder for Telnet and serial hosts', () => {
+    expect(blankNativeDraft('', 'Lab/Consoles')).toMatchObject({
+      group: 'Lab/Consoles',
+    });
+  });
 });
 
 describe('nativeDraftFromProfile', () => {


### PR DESCRIPTION
## Summary

- add a “New host…” item to folder context menus
- prefill the selected folder in new SSH, Telnet, and serial host drafts
- preserve the folder when switching connection types

Closes #142

## Validation

- 951 tests passed, 3 skipped
- client and test typechecks passed
- lint passed
- production build and bundle budgets passed