### PR TITLE
Focus Trust Host by default for new keys

### DIFF
--- a/client/src/components/HostKeyDialog.tsx
+++ b/client/src/components/HostKeyDialog.tsx
@@ -60,9 +60,16 @@ export function HostKeyDialog({ request, onAnswer }: { request: HostKeyRequest |
       </DialogContent>
       <DialogActions>
         <Button onClick={() => onAnswer(false)}>Cancel</Button>
-        <Button variant="contained" color={mismatch ? 'error' : 'primary'} onClick={() => onAnswer(true)}>
+        {/* oxlint-disable jsx-a11y/no-autofocus -- New host confirmation is intentionally keyboard-defaulted. */}
+        <Button
+          variant="contained"
+          color={mismatch ? 'error' : 'primary'}
+          autoFocus={!mismatch}
+          onClick={() => onAnswer(true)}
+        >
           {mismatch ? 'Accept new key' : 'Trust host'}
         </Button>
+        {/* oxlint-enable jsx-a11y/no-autofocus */}
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

- focus the Trust Host action when confirming a new server host key
- keep changed-key warnings without an automatically focused acceptance action
- allow Enter/Return to confirm first-time host trust

## Validation

- `pnpm --filter @muxus/client build`
- `pnpm exec oxlint client/src/components/HostKeyDialog.tsx --deny-warnings`
- `pnpm --filter @muxus/tests test` (951 passed, 3 skipped)

Closes #143