### PR TITLE
Fix moving SSH hosts back to the root config

### DIFF
--- a/client/src/components/host-editor/GeneralSection.tsx
+++ b/client/src/components/host-editor/GeneralSection.tsx
@@ -126,7 +126,7 @@ export function GeneralSection({
             onChange={(e) => {
               const v = e.target.value;
               if (v === NEW_FILE) applyNewFile(newFileName || 'group');
-              else set({ file: v === rootPath ? '' : v });
+              else set({ file: v });
             }}
             fullWidth
           >

--- a/tests/unit/server/ssh-config-edit.test.ts
+++ b/tests/unit/server/ssh-config-edit.test.ts
@@ -136,6 +136,18 @@ describe('upsertHost', () => {
     expect(hosts.find((h) => h.alias === 'web')!.file).toBe(groupFile);
   });
 
+  it('moves a host from an include file back to the root config', () => {
+    const root = seed(['Host web', '  HostName web.example.com', ''].join('\n'));
+    const groupFile = path.join(path.dirname(root), 'config.d', 'work');
+    upsertHost(req({ previousAlias: 'web', file: groupFile }), root);
+
+    upsertHost(req({ previousAlias: 'web', file: root }), root);
+
+    expect(readFileSync(root, 'utf8')).toContain('HostName web.example.com');
+    expect(readFileSync(groupFile, 'utf8')).not.toContain('Host web');
+    expect(listHosts(loadConfigDocument(root))[0]!.file).toBe(root);
+  });
+
   it('refuses config files outside the root config directory', () => {
     const root = seed('');
     expect(() => upsertHost(req({ file: '/etc/passwd' }), root)).toThrowError(/must live under/);


### PR DESCRIPTION
## Summary

- preserve the concrete root SSH config path when selected in the host editor
- allow hosts in included group files to move back to the default config
- add regression coverage for moving an included host to the root config

Fixes #144

## Validation

- pnpm test
- pnpm typecheck
- pnpm lint