### PR TITLE
Add command-line launch targets

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -104,6 +104,7 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
   const logViewerOpen = useUiStore((s) => s.logViewerOpen);
   const quickLauncherOpen = useUiStore((s) => s.quickLauncherOpen);
   const workspacesOpen = useUiStore((s) => s.workspacesOpen);
+  const commandLineLaunch = window.muxusDesktop?.commandLineLaunch;
   const dialogOpen = useDialogStore((s) => s.queue.length > 0);
   const toastOpen = useToastStore((s) => !!s.toast);
   const standaloneLaunch = launch?.kind === 'session' || launch?.kind === 'tab-transfer';
@@ -127,7 +128,11 @@ export default function App({ launch }: { launch?: AppWindowLaunch }) {
         ? launch.workspaceId
           ? { kind: 'open', id: launch.workspaceId }
           : { kind: 'new', id: newWorkspaceId!, name: launch.title }
-        : undefined;
+        : commandLineLaunch?.kind === 'workspace'
+          ? { kind: 'open-name', name: commandLineLaunch.name }
+          : commandLineLaunch
+            ? { kind: 'blank' }
+            : undefined;
   useLayoutEffect(() => {
     // Keep the desktop app's native window controls in sync with the theme.
     setTitleBarMode(effectiveMode);

--- a/client/src/command-line-launch.ts
+++ b/client/src/command-line-launch.ts
@@ -1,0 +1,146 @@
+import type {
+  SavedHostProfile,
+  SshHostEntry,
+  WorkspaceSummary,
+} from '@muxus/shared';
+import { buildHostTree, type ContainerNode } from './host-tree.js';
+import {
+  groupManagedHosts,
+  managedHostKey,
+  type ManagedHost,
+} from './managed-hosts.js';
+
+export type TargetResolution<T> =
+  | { status: 'found'; value: T }
+  | { status: 'not-found' }
+  | { status: 'ambiguous'; count: number };
+
+export interface ResolvedHostFolder {
+  label: string;
+  hosts: ManagedHost[];
+}
+
+const normalized = (value: string) => value.trim().toLocaleLowerCase();
+
+function resultFor<T>(matches: readonly T[]): TargetResolution<T> {
+  if (matches.length === 0) return { status: 'not-found' };
+  if (matches.length > 1) return { status: 'ambiguous', count: matches.length };
+  return { status: 'found', value: matches[0]! };
+}
+
+function uniqueHosts(hosts: readonly ManagedHost[]): ManagedHost[] {
+  return [...new Map(hosts.map((host) => [managedHostKey(host), host])).values()];
+}
+
+/** Prefer stable aliases/names over user-editable display names. */
+export function resolveCommandLineHost(
+  name: string,
+  sshHosts: readonly SshHostEntry[],
+  savedProfiles: readonly SavedHostProfile[],
+): TargetResolution<ManagedHost> {
+  const target = normalized(name);
+  const hosts: ManagedHost[] = [
+    ...sshHosts.map((entry) => ({ kind: 'ssh' as const, entry })),
+    ...savedProfiles.map((entry) => ({ kind: 'profile' as const, entry })),
+  ];
+  const identityMatches = uniqueHosts(
+    hosts.filter((host) =>
+      host.kind === 'ssh'
+        ? host.entry.aliases.some((alias) => normalized(alias) === target)
+        : normalized(host.entry.name) === target || normalized(host.entry.id) === target,
+    ),
+  );
+  if (identityMatches.length > 0) return resultFor(identityMatches);
+
+  return resultFor(
+    uniqueHosts(
+      hosts.filter((host) =>
+        normalized(
+          host.kind === 'ssh'
+            ? (host.entry.metadata?.displayName ?? '')
+            : (host.entry.metadata.displayName ?? ''),
+        ) === target,
+      ),
+    ),
+  );
+}
+
+function collectHosts(node: ContainerNode): ManagedHost[] {
+  const hosts: ManagedHost[] = [];
+  const walk = (container: ContainerNode) => {
+    for (const child of container.children) {
+      if (child.kind === 'host') hosts.push(child.host);
+      else if (child.kind === 'folder') walk(child);
+    }
+  };
+  walk(node);
+  return hosts;
+}
+
+function resolvedFolder(node: ContainerNode): ResolvedHostFolder {
+  return {
+    label: node.kind === 'folder' ? node.path : node.label,
+    hosts: collectHosts(node),
+  };
+}
+
+/** Resolve a full folder path, unique leaf label, or ssh_config file-group label. */
+export function resolveCommandLineFolder(
+  name: string,
+  sshHosts: readonly SshHostEntry[],
+  savedProfiles: readonly SavedHostProfile[],
+  files: readonly string[],
+  rootFile: string | undefined,
+): TargetResolution<ResolvedHostFolder> {
+  const target = normalized(name);
+  const tree = buildHostTree(
+    groupManagedHosts(sshHosts, savedProfiles, files, rootFile),
+  );
+  const folders = [...tree.foldersByKey.values()];
+
+  const pathMatches = folders.filter((folder) => normalized(folder.path) === target);
+  if (pathMatches.length > 0) {
+    const resolution = resultFor(pathMatches);
+    return resolution.status === 'found'
+      ? { status: 'found', value: resolvedFolder(resolution.value) }
+      : resolution;
+  }
+
+  const fileMatches = tree.roots.filter(
+    (node) => {
+      if (node.kind !== 'file') return false;
+      const filename = node.tooltip
+        ?.split(/[\\/]/)
+        .at(-1)
+        ?.replace(/\.(conf|config)$/i, '');
+      return (
+        normalized(node.label) === target ||
+        (!!filename && normalized(filename) === target)
+      );
+    },
+  );
+  if (fileMatches.length > 0) {
+    const resolution = resultFor(fileMatches);
+    return resolution.status === 'found'
+      ? { status: 'found', value: resolvedFolder(resolution.value) }
+      : resolution;
+  }
+
+  const labelResolution = resultFor(
+    folders.filter((folder) => normalized(folder.label) === target),
+  );
+  return labelResolution.status === 'found'
+    ? { status: 'found', value: resolvedFolder(labelResolution.value) }
+    : labelResolution;
+}
+
+export function resolveCommandLineWorkspace(
+  name: string,
+  workspaces: readonly WorkspaceSummary[],
+): TargetResolution<WorkspaceSummary> {
+  const target = normalized(name);
+  const idMatches = workspaces.filter((workspace) => normalized(workspace.id) === target);
+  return idMatches.length > 0
+    ? resultFor(idMatches)
+    : resultFor(workspaces.filter((workspace) => normalized(workspace.name) === target));
+}

--- a/client/src/components/CommandLineLaunchHandler.tsx
+++ b/client/src/components/CommandLineLaunchHandler.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CommandLineLaunch } from '@muxus/shared';
+import { useSavedHostProfiles, useSshConfig } from '../api/queries.js';
+import {
+  resolveCommandLineFolder,
+  resolveCommandLineHost,
+  resolveCommandLineWorkspace,
+  type TargetResolution,
+} from '../command-line-launch.js';
+import { managedHostDisplayName } from '../managed-hosts.js';
+import {
+  connectManagedHost,
+  launchManagedHostGroup,
+} from '../session-actions.js';
+import { showToast } from '../state/toast.js';
+import { useWorkspacesStore } from '../state/workspaces.js';
+import {
+  focusOpenWorkspace,
+  openWorkspace,
+} from '../workspace-persistence.js';
+
+interface QueuedLaunch {
+  id: number;
+  request: CommandLineLaunch;
+}
+
+function resolutionError(
+  kind: CommandLineLaunch['kind'],
+  name: string,
+  resolution: Exclude<TargetResolution<unknown>, { status: 'found' }>,
+): string {
+  const label = kind === 'folder' ? 'folder' : kind;
+  return resolution.status === 'not-found'
+    ? `No ${label} named “${name}” was found.`
+    : `More than one ${label} matches “${name}”. Use its exact ${
+        kind === 'folder' ? 'path' : 'name or ID'
+      }.`;
+}
+
+/** Execute desktop CLI requests once the normal application catalogs are ready. */
+export function CommandLineLaunchHandler() {
+  const initialRequest = window.muxusDesktop?.commandLineLaunch;
+  const nextId = useRef(1);
+  const processing = useRef(new Set<number>());
+  const [queue, setQueue] = useState<QueuedLaunch[]>(() =>
+    initialRequest ? [{ id: 0, request: initialRequest }] : [],
+  );
+  const active = queue[0];
+  const needsHostCatalog =
+    active?.request.kind === 'host' || active?.request.kind === 'folder';
+  const sshQuery = useSshConfig(needsHostCatalog);
+  const profilesQuery = useSavedHostProfiles(needsHostCatalog);
+  const hostCatalogReady = !!sshQuery.data && !!profilesQuery.data;
+  const hostCatalogError =
+    (!sshQuery.data && sshQuery.isError) ||
+    (!profilesQuery.data && profilesQuery.isError);
+  const workspaces = useWorkspacesStore((state) => state.workspaces);
+  const activeWorkspaceId = useWorkspacesStore((state) => state.activeId);
+  const workspacesReady = useWorkspacesStore((state) => state.ready);
+
+  const enqueue = useCallback((request: CommandLineLaunch) => {
+    const id = nextId.current++;
+    setQueue((current) => [...current, { id, request }]);
+  }, []);
+
+  useEffect(() => window.muxusDesktop?.onCommandLineLaunch(enqueue), [enqueue]);
+
+  useEffect(() => {
+    if (!active || !workspacesReady || processing.current.has(active.id)) return;
+    if (needsHostCatalog && !hostCatalogReady && !hostCatalogError) return;
+
+    processing.current.add(active.id);
+    const { request } = active;
+    const finish = () => {
+      setQueue((current) => current.filter((entry) => entry.id !== active.id));
+    };
+
+    void (async () => {
+      if (needsHostCatalog && hostCatalogError) {
+        showToast('error', 'Could not load the host catalog for the command-line request.');
+        return;
+      }
+
+      const ssh = sshQuery.data;
+      const profiles = profilesQuery.data;
+      if (request.kind === 'host') {
+        const resolution = resolveCommandLineHost(
+          request.name,
+          ssh?.hosts ?? [],
+          profiles?.profiles ?? [],
+        );
+        if (resolution.status !== 'found') {
+          showToast('error', resolutionError(request.kind, request.name, resolution));
+          return;
+        }
+        connectManagedHost(resolution.value);
+        showToast('info', `Connecting to “${managedHostDisplayName(resolution.value)}”.`);
+        return;
+      }
+
+      if (request.kind === 'folder') {
+        const resolution = resolveCommandLineFolder(
+          request.name,
+          ssh?.hosts ?? [],
+          profiles?.profiles ?? [],
+          ssh?.files ?? [],
+          ssh?.path,
+        );
+        if (resolution.status !== 'found') {
+          showToast('error', resolutionError(request.kind, request.name, resolution));
+          return;
+        }
+        const ids = await launchManagedHostGroup(resolution.value.hosts, 'tabs');
+        if (ids.length > 0) {
+          showToast(
+            'success',
+            `Launching ${ids.length} session${ids.length === 1 ? '' : 's'} from “${resolution.value.label}”.`,
+          );
+        }
+        return;
+      }
+
+      const resolution = resolveCommandLineWorkspace(request.name, workspaces);
+      if (resolution.status !== 'found') {
+        showToast('error', resolutionError(request.kind, request.name, resolution));
+        return;
+      }
+      if (resolution.value.id === activeWorkspaceId) {
+        showToast('info', `Workspace “${resolution.value.name}” is already open.`);
+      } else if (focusOpenWorkspace(resolution.value.id)) {
+        showToast('info', `Switched to the window showing “${resolution.value.name}”.`);
+      } else {
+        await openWorkspace(resolution.value.id);
+        showToast('success', `Opened workspace “${resolution.value.name}”.`);
+      }
+    })()
+      .catch((error: unknown) => {
+        showToast(
+          'error',
+          error instanceof Error ? error.message : 'The command-line launch failed.',
+        );
+      })
+      .finally(finish);
+  }, [
+    active,
+    activeWorkspaceId,
+    hostCatalogError,
+    hostCatalogReady,
+    needsHostCatalog,
+    profilesQuery.data,
+    sshQuery.data,
+    workspaces,
+    workspacesReady,
+  ]);
+
+  return null;
+}

--- a/client/src/components/CommandLineLaunchHandler.tsx
+++ b/client/src/components/CommandLineLaunchHandler.tsx
@@ -14,10 +14,8 @@ import {
 } from '../session-actions.js';
 import { showToast } from '../state/toast.js';
 import { useWorkspacesStore } from '../state/workspaces.js';
-import {
-  focusOpenWorkspace,
-  openWorkspace,
-} from '../workspace-persistence.js';
+import { focusOpenWorkspace } from '../workspace-persistence.js';
+import { openAppWindow } from '../window-management.js';
 
 interface QueuedLaunch {
   id: number;
@@ -130,8 +128,12 @@ export function CommandLineLaunchHandler() {
       } else if (focusOpenWorkspace(resolution.value.id)) {
         showToast('info', `Switched to the window showing “${resolution.value.name}”.`);
       } else {
-        await openWorkspace(resolution.value.id);
-        showToast('success', `Opened workspace “${resolution.value.name}”.`);
+        openAppWindow({
+          kind: 'workspace',
+          workspaceId: resolution.value.id,
+          title: resolution.value.name,
+        });
+        showToast('info', `Opening workspace “${resolution.value.name}” in a new window.`);
       }
     })()
       .catch((error: unknown) => {

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -1,6 +1,7 @@
 import type {
   AppInfo,
   AppWindowLaunch,
+  CommandLineLaunch,
   MobaXtermSessionSource,
   UpdateCheckResult,
 } from '@muxus/shared';
@@ -15,6 +16,8 @@ declare global {
       authToken: string;
       /** One-shot payload describing the content of a secondary app window. */
       windowLaunch?: AppWindowLaunch;
+      /** One-shot host, folder, or workspace target supplied to the executable. */
+      commandLineLaunch?: CommandLineLaunch;
       stateStorage: {
         getItem(name: string): string | null;
         setItem(name: string, value: string): void;
@@ -33,6 +36,8 @@ declare global {
       listLocalFontFamilies(): Promise<string[] | undefined>;
       /** Open a secondary native application window. */
       openWindow(launch: AppWindowLaunch): void;
+      /** Subscribe to launch targets forwarded by later executable invocations. */
+      onCommandLineLaunch(callback: (launch: CommandLineLaunch) => void): () => void;
       /** Open a tab-transfer window when the native cursor is outside every app window. */
       detachTab(
         launch: Extract<AppWindowLaunch, { kind: 'tab-transfer' }>,

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -32,6 +32,7 @@ import {
   type WorkspaceInitialSelection,
 } from '../workspace-persistence.js';
 import { ErrorBoundary } from '../components/ErrorBoundary.js';
+import { CommandLineLaunchHandler } from '../components/CommandLineLaunchHandler.js';
 import { ActionBar } from '../components/ActionBar.js';
 import { EmptyPane } from '../components/EmptyPane.js';
 import { SessionSidebar } from '../components/SessionSidebar.js';
@@ -79,6 +80,7 @@ export function AppShell({
       data-focus-mode={focusMode ? 'true' : 'false'}
       sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
     >
+      <CommandLineLaunchHandler />
       <TopBar />
       {focusMode ? null : <ActionBar />}
       <Box sx={{ flex: 1, display: 'flex', minHeight: 0 }}>

--- a/client/src/workspace-persistence.ts
+++ b/client/src/workspace-persistence.ts
@@ -31,7 +31,8 @@ interface WorkspaceSnapshot {
 export type WorkspaceInitialSelection =
   | { kind: 'blank' }
   | { kind: 'new'; id: string; name: string }
-  | { kind: 'open'; id: string };
+  | { kind: 'open'; id: string }
+  | { kind: 'open-name'; name: string };
 
 function currentSnapshot(): WorkspaceSnapshot {
   const { root, tabs, activePaneId } = useTabsStore.getState();
@@ -127,6 +128,24 @@ export class WorkspaceRuntime {
             `/api/workspaces/${encodeURIComponent(this.initialSelection.id)}`,
           ),
         ]);
+      } else if (this.initialSelection?.kind === 'open-name') {
+        catalog = await catalogRequest;
+        const target = this.initialSelection.name.trim().toLocaleLowerCase();
+        const idMatches = catalog.workspaces.filter(
+          (candidate) => candidate.id.toLocaleLowerCase() === target,
+        );
+        const matches =
+          idMatches.length > 0
+            ? idMatches
+            : catalog.workspaces.filter(
+                (candidate) => candidate.name.trim().toLocaleLowerCase() === target,
+              );
+        workspace =
+          matches.length === 1
+            ? await apiFetch<WorkspaceRecord>(
+                `/api/workspaces/${encodeURIComponent(matches[0]!.id)}`,
+              )
+            : null;
       } else if (this.initialSelection?.kind === 'blank') {
         catalog = await catalogRequest;
         workspace = null;
@@ -675,8 +694,13 @@ export function useWorkspacePersistence(
   initialSelection?: WorkspaceInitialSelection,
 ): void {
   const initialKind = initialSelection?.kind;
-  const initialId = initialSelection?.kind === 'blank' ? undefined : initialSelection?.id;
+  const initialId =
+    initialSelection?.kind === 'open' || initialSelection?.kind === 'new'
+      ? initialSelection.id
+      : undefined;
   const initialName = initialSelection?.kind === 'new' ? initialSelection.name : undefined;
+  const initialLookupName =
+    initialSelection?.kind === 'open-name' ? initialSelection.name : undefined;
   useEffect(() => {
     if (!enabled) return;
     const selection: WorkspaceInitialSelection | undefined = initialKind
@@ -684,6 +708,8 @@ export function useWorkspacePersistence(
         ? { kind: 'open', id: initialId! }
         : initialKind === 'new'
           ? { kind: 'new', id: initialId!, name: initialName! }
+          : initialKind === 'open-name'
+            ? { kind: 'open-name', name: initialLookupName! }
           : { kind: 'blank' }
       : undefined;
     const runtime = new WorkspaceRuntime(selection);
@@ -698,5 +724,5 @@ export function useWorkspacePersistence(
       runtime.stop();
       if (activeRuntime === runtime) activeRuntime = undefined;
     };
-  }, [enabled, initialId, initialKind, initialName]);
+  }, [enabled, initialId, initialKind, initialLookupName, initialName]);
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,9 +21,10 @@ the current pane layout, matching the sidebar's default **Launch hosts** action.
 accepts its name or ID.
 
 Only one launch target may be supplied at a time. If Muxus is already running, the new
-invocation is forwarded to its existing window. Windows installations are not added to
-`PATH`; AutoHotkey, Stream Deck, PowerShell, and shortcuts can invoke `muxus.exe` by its full
-installation path.
+invocation is forwarded to its existing process. A workspace that is not already open uses
+a new window, preserving live sessions in the current one. Windows installations are not
+added to `PATH`; AutoHotkey, Stream Deck, PowerShell, and shortcuts can invoke `muxus.exe`
+by its full installation path.
 
 Flags accept both `--host edge-router` and `--host=edge-router`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,6 +4,31 @@ icon: lucide/terminal-square
 
 # Command-line flags
 
+## Desktop launch targets
+
+The desktop executable can open a saved host, a folder of hosts, or a workspace directly:
+
+```bash
+muxus --host edge-router
+muxus --folder "Production/EU"
+muxus --workspace "Night shift"
+```
+
+Names are matched case-insensitively. A host accepts an OpenSSH alias, a saved-host name or
+ID, or an unambiguous display name. A folder accepts its full path, an unambiguous leaf
+name, or an `ssh_config` file-group label or filename. Folder launches use tabs and replace
+the current pane layout, matching the sidebar's default **Launch hosts** action. A workspace
+accepts its name or ID.
+
+Only one launch target may be supplied at a time. If Muxus is already running, the new
+invocation is forwarded to its existing window. Windows installations are not added to
+`PATH`; AutoHotkey, Stream Deck, PowerShell, and shortcuts can invoke `muxus.exe` by its full
+installation path.
+
+Flags accept both `--host edge-router` and `--host=edge-router`.
+
+## Server flags
+
 The server is `server/dist/index.js`, started by `pnpm start` or embedded in the desktop
 app. It always binds `127.0.0.1`.
 

--- a/electron/src/command-line.ts
+++ b/electron/src/command-line.ts
@@ -1,0 +1,38 @@
+import type { CommandLineLaunch } from '@muxus/shared';
+
+const TARGET_FLAGS = {
+  '--host': 'host',
+  '--folder': 'folder',
+  '--workspace': 'workspace',
+} as const satisfies Record<string, CommandLineLaunch['kind']>;
+
+const MAX_TARGET_LENGTH = 500;
+
+/** Parse exactly one desktop launch target from Electron's full argv array. */
+export function parseCommandLineLaunch(
+  argv: readonly string[],
+): CommandLineLaunch | undefined {
+  let launch: CommandLineLaunch | undefined;
+
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index]!;
+    const separator = argument.indexOf('=');
+    const flag = separator < 0 ? argument : argument.slice(0, separator);
+    const kind = TARGET_FLAGS[flag as keyof typeof TARGET_FLAGS];
+    if (!kind) continue;
+
+    const rawName = separator < 0 ? argv[++index] : argument.slice(separator + 1);
+    const name = rawName?.trim();
+    if (
+      launch ||
+      !name ||
+      name.startsWith('--') ||
+      name.length > MAX_TARGET_LENGTH
+    ) {
+      return undefined;
+    }
+    launch = { kind, name };
+  }
+
+  return launch;
+}

--- a/electron/src/command-line.ts
+++ b/electron/src/command-line.ts
@@ -1,4 +1,4 @@
-import type { CommandLineLaunch } from '@muxus/shared';
+import type { AppWindowLaunch, CommandLineLaunch } from '@muxus/shared';
 
 const TARGET_FLAGS = {
   '--host': 'host',
@@ -35,4 +35,31 @@ export function parseCommandLineLaunch(
   }
 
   return launch;
+}
+
+/** Validate the structured payload forwarded through Electron's single-instance lock. */
+export function parseCommandLineLaunchData(
+  value: unknown,
+): CommandLineLaunch | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.kind !== 'host' &&
+    candidate.kind !== 'folder' &&
+    candidate.kind !== 'workspace'
+  ) {
+    return undefined;
+  }
+  if (typeof candidate.name !== 'string') return undefined;
+  const name = candidate.name.trim();
+  return name && name.length <= MAX_TARGET_LENGTH
+    ? { kind: candidate.kind, name }
+    : undefined;
+}
+
+/** SFTP-only windows do not mount the client-side command request handler. */
+export function canHandleCommandLineLaunch(
+  windowLaunch: AppWindowLaunch | undefined,
+): boolean {
+  return windowLaunch?.kind !== 'sftp';
 }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -26,7 +26,11 @@ import type {
   MobaXtermSessionSource,
   UpdateCheckResult,
 } from '@muxus/shared';
-import { parseCommandLineLaunch } from './command-line.js';
+import {
+  canHandleCommandLineLaunch,
+  parseCommandLineLaunch,
+  parseCommandLineLaunchData,
+} from './command-line.js';
 import {
   developmentUserDataPath,
   seedDevelopmentDatabase,
@@ -727,12 +731,24 @@ function validProfileId(value: unknown): boolean {
 
 const initialCommandLineLaunch = parseCommandLineLaunch(process.argv);
 
-if (!app.requestSingleInstanceLock()) {
+function commandLineLaunchWindow(): BrowserWindow | undefined {
+  return [...managedWindows].find((candidate) =>
+    canHandleCommandLineLaunch(windowLaunches.get(candidate.webContents.id)),
+  );
+}
+
+// Electron may reorder split-form custom switches in second-instance argv.
+// Preserve the launch parsed by the invoking process as structured data.
+if (!app.requestSingleInstanceLock(initialCommandLineLaunch ?? {})) {
   app.quit();
 } else {
-  app.on('second-instance', (_event, commandLine) => {
-    const win = primaryWindow ?? [...managedWindows][0];
-    const launch = parseCommandLineLaunch(commandLine);
+  app.on('second-instance', (_event, commandLine, _workingDirectory, additionalData) => {
+    const launch =
+      parseCommandLineLaunchData(additionalData) ??
+      parseCommandLineLaunch(commandLine);
+    const win = launch
+      ? (commandLineLaunchWindow() ?? (appUrl ? createWindow(appUrl) : undefined))
+      : (primaryWindow ?? [...managedWindows][0]);
     if (!win) {
       if (launch) deferredCommandLineLaunches.push(launch);
       return;

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -22,9 +22,11 @@ import {
 import { isNewerVersion } from '@muxus/shared';
 import type {
   AppWindowLaunch,
+  CommandLineLaunch,
   MobaXtermSessionSource,
   UpdateCheckResult,
 } from '@muxus/shared';
+import { parseCommandLineLaunch } from './command-line.js';
 import {
   developmentUserDataPath,
   seedDevelopmentDatabase,
@@ -75,6 +77,8 @@ let primaryWindow: BrowserWindow | undefined;
 let appUrl: string | undefined;
 const managedWindows = new Set<BrowserWindow>();
 const windowLaunches = new Map<number, AppWindowLaunch>();
+const commandLineLaunches = new Map<number, CommandLineLaunch>();
+const deferredCommandLineLaunches: CommandLineLaunch[] = [];
 const activeWorkspaceByWebContents = new Map<number, string>();
 let server: RunningServer | undefined;
 let closing: Promise<void> | undefined;
@@ -275,7 +279,11 @@ async function checkForUpdate(force = false): Promise<UpdateCheckResult> {
   }
 }
 
-function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
+function createWindow(
+  url: string,
+  launch?: AppWindowLaunch,
+  commandLineLaunch?: CommandLineLaunch,
+): BrowserWindow {
   const state = loadWindowState();
   const appOrigin = new URL(url).origin;
   const isPrimary = !primaryWindow;
@@ -312,6 +320,7 @@ function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
   managedWindows.add(win);
   const webContentsId = win.webContents.id;
   if (launch) windowLaunches.set(webContentsId, launch);
+  if (commandLineLaunch) commandLineLaunches.set(webContentsId, commandLineLaunch);
   if (isPrimary) primaryWindow = win;
   if (state.maximized && isPrimary) win.maximize();
   // The menu stays installed so its accelerators (zoom, reload, devtools,
@@ -323,6 +332,7 @@ function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
   win.on('closed', () => {
     managedWindows.delete(win);
     windowLaunches.delete(webContentsId);
+    commandLineLaunches.delete(webContentsId);
     activeWorkspaceByWebContents.delete(webContentsId);
     if (primaryWindow === win) primaryWindow = undefined;
   });
@@ -456,6 +466,15 @@ ipcMain.on('muxus:window-launch', (event) => {
   event.returnValue = isManagedWindowSender(event)
     ? windowLaunches.get(event.sender.id)
     : undefined;
+});
+
+ipcMain.on('muxus:command-line-launch', (event) => {
+  if (!isManagedWindowSender(event)) {
+    event.returnValue = undefined;
+    return;
+  }
+  event.returnValue = commandLineLaunches.get(event.sender.id);
+  commandLineLaunches.delete(event.sender.id);
 });
 
 ipcMain.on('muxus:open-window', (event, value: unknown) => {
@@ -706,14 +725,32 @@ function validProfileId(value: unknown): boolean {
   );
 }
 
+const initialCommandLineLaunch = parseCommandLineLaunch(process.argv);
+
 if (!app.requestSingleInstanceLock()) {
   app.quit();
 } else {
-  app.on('second-instance', () => {
+  app.on('second-instance', (_event, commandLine) => {
     const win = primaryWindow ?? [...managedWindows][0];
-    if (win) {
-      if (win.isMinimized()) win.restore();
-      win.focus();
+    const launch = parseCommandLineLaunch(commandLine);
+    if (!win) {
+      if (launch) deferredCommandLineLaunches.push(launch);
+      return;
+    }
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+    if (launch) {
+      const send = () => {
+        if (!win.isDestroyed()) {
+          win.webContents.send('muxus:command-line-launch-requested', launch);
+        }
+      };
+      if (win.webContents.isLoadingMainFrame()) {
+        win.webContents.once('did-finish-load', send);
+      } else {
+        send();
+      }
     }
   });
 
@@ -766,7 +803,16 @@ if (!app.requestSingleInstanceLock()) {
     buildMenu();
     const url = server.url;
     appUrl = url;
-    createWindow(url);
+    const win = createWindow(url, undefined, initialCommandLineLaunch);
+    if (deferredCommandLineLaunches.length > 0) {
+      const launches = deferredCommandLineLaunches.splice(0);
+      win.webContents.once('did-finish-load', () => {
+        if (win.isDestroyed()) return;
+        for (const launch of launches) {
+          win.webContents.send('muxus:command-line-launch-requested', launch);
+        }
+      });
+    }
   });
 
   // The server (and its SSH connections) is tied to the window, so quit

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -1,5 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { AppWindowLaunch, MobaXtermSessionSource } from '@muxus/shared';
+import type {
+  AppWindowLaunch,
+  CommandLineLaunch,
+  MobaXtermSessionSource,
+} from '@muxus/shared';
 
 // Client state is mirrored here and persisted with fire-and-forget messages.
 // sendSync is deliberately avoided for the steady-state path: it parks the
@@ -32,6 +36,30 @@ const windowLaunch: AppWindowLaunch | undefined = (() => {
     return undefined;
   }
 })();
+
+const commandLineLaunch: CommandLineLaunch | undefined = (() => {
+  try {
+    const value: unknown = ipcRenderer.sendSync('muxus:command-line-launch');
+    return value && typeof value === 'object' ? (value as CommandLineLaunch) : undefined;
+  } catch {
+    return undefined;
+  }
+})();
+
+const commandLineLaunchListeners = new Set<(launch: CommandLineLaunch) => void>();
+const queuedCommandLineLaunches: CommandLineLaunch[] = [];
+
+// Register in preload so a second executable invocation cannot race React's
+// subscription while the first window is still loading.
+ipcRenderer.on('muxus:command-line-launch-requested', (_event, value: unknown) => {
+  if (!value || typeof value !== 'object') return;
+  const launch = value as CommandLineLaunch;
+  if (commandLineLaunchListeners.size === 0) {
+    queuedCommandLineLaunches.push(launch);
+    return;
+  }
+  for (const listener of commandLineLaunchListeners) listener(launch);
+});
 
 interface LocalFontData {
   family?: unknown;
@@ -86,6 +114,7 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   platform: process.platform,
   authToken,
   windowLaunch,
+  commandLineLaunch,
   stateStorage: {
     getItem(name: string): string | null {
       return stateSnapshot[name] ?? null;
@@ -123,6 +152,11 @@ contextBridge.exposeInMainWorld('muxusDesktop', {
   listLocalFontFamilies,
   openWindow(launch: AppWindowLaunch): void {
     ipcRenderer.send('muxus:open-window', launch);
+  },
+  onCommandLineLaunch(callback: (launch: CommandLineLaunch) => void): () => void {
+    commandLineLaunchListeners.add(callback);
+    for (const launch of queuedCommandLineLaunches.splice(0)) callback(launch);
+    return () => commandLineLaunchListeners.delete(callback);
   },
   /** Detach a tab only when the native cursor is outside every Muxus window. */
   detachTab(launch: Extract<AppWindowLaunch, { kind: 'tab-transfer' }>): Promise<boolean> {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -301,6 +301,16 @@ export interface HostOrderRequest {
 }
 
 /**
+ * One target supplied when the desktop executable is launched from a command
+ * line. Names stay unresolved until the renderer has loaded the same host and
+ * workspace catalogs used by the rest of the UI.
+ */
+export type CommandLineLaunch =
+  | { kind: 'host'; name: string }
+  | { kind: 'folder'; name: string }
+  | { kind: 'workspace'; name: string };
+
+/**
  * One extra application window requested by the renderer. Workspace windows
  * either create a named workspace or open an existing one; session windows
  * start a fresh shell; SFTP windows stay attached to an existing SSH

--- a/tests/unit/client/command-line-launch.test.ts
+++ b/tests/unit/client/command-line-launch.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  SavedHostProfile,
+  SshHostEntry,
+  WorkspaceSummary,
+} from '@muxus/shared';
+import {
+  resolveCommandLineFolder,
+  resolveCommandLineHost,
+  resolveCommandLineWorkspace,
+} from '../../../client/src/command-line-launch.js';
+import { managedHostKey } from '../../../client/src/managed-hosts.js';
+
+const ROOT = '/home/test/.ssh/config';
+const LAB_FILE = '/home/test/.ssh/lab.conf';
+
+function sshHost(
+  alias: string,
+  group?: string,
+  file = ROOT,
+  displayName?: string,
+): SshHostEntry {
+  return {
+    alias,
+    aliases: [alias, `${alias}.example.test`],
+    file,
+    options: {},
+    resolved: {
+      hostname: `${alias}.example.test`,
+      port: 22,
+      identityFiles: [],
+      certificateFiles: [],
+      identitiesOnly: false,
+      forwardAgent: false,
+      proxyJump: [],
+      forwards: [],
+      passwordOnly: false,
+    },
+    metadata:
+      group || displayName
+        ? { profileId: `ssh-${alias}`, group, displayName, connectCount: 0 }
+        : undefined,
+  };
+}
+
+function savedHost(name: string, group?: string, displayName?: string): SavedHostProfile {
+  return {
+    id: `saved-${name.toLocaleLowerCase().replaceAll(' ', '-')}`,
+    kind: 'telnet',
+    name,
+    profile: {
+      kind: 'telnet',
+      profileId: `saved-${name}`,
+      host: `${name.toLocaleLowerCase()}.example.test`,
+      port: 23,
+    },
+    metadata: {
+      profileId: `saved-${name}`,
+      group,
+      displayName,
+      connectCount: 0,
+    },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+function workspace(id: string, name: string): WorkspaceSummary {
+  return {
+    id,
+    name,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    isLocked: false,
+    isStartup: false,
+  };
+}
+
+describe('command-line host resolution', () => {
+  it('matches SSH aliases and saved-host names case-insensitively', () => {
+    const ssh = sshHost('edge-1');
+    const saved = savedHost('Console One');
+
+    const sshResolution = resolveCommandLineHost('EDGE-1.EXAMPLE.TEST', [ssh], [saved]);
+    const savedResolution = resolveCommandLineHost('console one', [ssh], [saved]);
+
+    expect(sshResolution.status).toBe('found');
+    expect(savedResolution.status).toBe('found');
+    if (sshResolution.status === 'found') {
+      expect(managedHostKey(sshResolution.value)).toBe('ssh:edge-1');
+    }
+    if (savedResolution.status === 'found') {
+      expect(managedHostKey(savedResolution.value)).toBe('profile:saved-console-one');
+    }
+  });
+
+  it('uses display names only after stable names and reports collisions', () => {
+    const stable = sshHost('core', undefined, ROOT, 'Shared');
+    const duplicateDisplay = savedHost('Console', undefined, 'Shared');
+
+    expect(resolveCommandLineHost('core', [stable], [duplicateDisplay])).toMatchObject({
+      status: 'found',
+      value: { kind: 'ssh' },
+    });
+    expect(resolveCommandLineHost('shared', [stable], [duplicateDisplay])).toEqual({
+      status: 'ambiguous',
+      count: 2,
+    });
+  });
+});
+
+describe('command-line folder resolution', () => {
+  const hosts = [
+    sshHost('edge-eu', 'Production/EU/Edge'),
+    sshHost('core-eu', 'Production/EU/Core'),
+    sshHost('edge-us', 'Production/US/Edge'),
+    sshHost('lab-router', undefined, LAB_FILE),
+  ];
+  const saved = [savedHost('EU console', 'Production/EU')];
+
+  it('launches every descendant of an exact folder path', () => {
+    const resolution = resolveCommandLineFolder(
+      'production/eu',
+      hosts,
+      saved,
+      [ROOT, LAB_FILE],
+      ROOT,
+    );
+
+    expect(resolution.status).toBe('found');
+    if (resolution.status === 'found') {
+      expect(resolution.value.label).toBe('Production/EU');
+      expect(resolution.value.hosts.map(managedHostKey).sort()).toEqual([
+        'profile:saved-eu-console',
+        'ssh:core-eu',
+        'ssh:edge-eu',
+      ]);
+    }
+  });
+
+  it('accepts ssh_config file-group labels and rejects ambiguous leaf labels', () => {
+    const fileResolution = resolveCommandLineFolder(
+      'lab',
+      hosts,
+      saved,
+      [ROOT, LAB_FILE],
+      ROOT,
+    );
+    const ambiguous = resolveCommandLineFolder(
+      'Edge',
+      hosts,
+      saved,
+      [ROOT, LAB_FILE],
+      ROOT,
+    );
+
+    expect(fileResolution.status).toBe('found');
+    if (fileResolution.status === 'found') {
+      expect(fileResolution.value.hosts.map(managedHostKey)).toEqual(['ssh:lab-router']);
+    }
+    expect(ambiguous).toEqual({ status: 'ambiguous', count: 2 });
+  });
+});
+
+describe('command-line workspace resolution', () => {
+  const workspaces = [
+    workspace('production-id', 'Production'),
+    workspace('duplicate-a', 'Lab'),
+    workspace('duplicate-b', 'lab'),
+  ];
+
+  it('matches IDs before names and detects duplicate names', () => {
+    expect(resolveCommandLineWorkspace('PRODUCTION-ID', workspaces)).toMatchObject({
+      status: 'found',
+      value: { id: 'production-id' },
+    });
+    expect(resolveCommandLineWorkspace('production', workspaces)).toMatchObject({
+      status: 'found',
+      value: { id: 'production-id' },
+    });
+    expect(resolveCommandLineWorkspace('lab', workspaces)).toEqual({
+      status: 'ambiguous',
+      count: 2,
+    });
+    expect(resolveCommandLineWorkspace('missing', workspaces)).toEqual({
+      status: 'not-found',
+    });
+  });
+});

--- a/tests/unit/client/workspace-persistence.test.ts
+++ b/tests/unit/client/workspace-persistence.test.ts
@@ -240,6 +240,69 @@ describe('workspace persistence', () => {
     runtime.stop();
   });
 
+  it('resolves a command-line workspace name before loading startup defaults', async () => {
+    const persisted: WorkspaceRecord = {
+      id: 'night-shift-id',
+      name: 'Night shift',
+      layout: {
+        version: 1,
+        root: {
+          id: 'pane-night',
+          type: 'pane',
+          activeTabId: 'night-shell',
+          tabs: [
+            {
+              id: 'night-shell',
+              kind: 'terminal',
+              title: 'Night shell',
+              profile: { kind: 'local' },
+              offerReconnect: true,
+            },
+          ],
+        },
+        activePaneId: 'pane-night',
+      },
+      multiExecGroups: [],
+      isLocked: false,
+      isStartup: false,
+      createdAt: '2026-08-05T20:00:00Z',
+      updatedAt: '2026-08-05T20:00:00Z',
+    };
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const path =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      if (path === '/api/workspaces' && method === 'GET') {
+        return json({ workspaces: [summaryOf(persisted)] });
+      }
+      if (path === `/api/workspaces/${persisted.id}` && method === 'GET') {
+        return json(persisted);
+      }
+      if (path === `/api/workspaces/${persisted.id}/open` && method === 'POST') {
+        return json(persisted);
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const runtime = new WorkspaceRuntime({ kind: 'open-name', name: 'NIGHT SHIFT' });
+    await runtime.start();
+
+    expect(useWorkspacesStore.getState()).toMatchObject({
+      activeId: persisted.id,
+      activeName: persisted.name,
+      ready: true,
+    });
+    expect(useTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({ id: 'night-shell', title: 'Night shell' }),
+    ]);
+    expect(fetchMock.mock.calls.map(([path]) => path)).not.toContain(
+      '/api/workspaces/startup',
+    );
+
+    runtime.stop();
+  });
+
   it('restores a locked workspace after one of its sessions was closed', async () => {
     const persisted: WorkspaceRecord = {
       id: 'locked-operations',

--- a/tests/unit/electron/command-line.test.ts
+++ b/tests/unit/electron/command-line.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { parseCommandLineLaunch } from '../../../electron/src/command-line.js';
+
+describe('desktop command-line launch parsing', () => {
+  it('accepts split and equals forms among unrelated Electron arguments', () => {
+    expect(parseCommandLineLaunch(['muxus', '--host', 'edge-1'])).toEqual({
+      kind: 'host',
+      name: 'edge-1',
+    });
+    expect(
+      parseCommandLineLaunch(['electron', '.', '--inspect=9229', '--folder=Production/EU']),
+    ).toEqual({ kind: 'folder', name: 'Production/EU' });
+    expect(parseCommandLineLaunch(['muxus', '--workspace', 'Night shift'])).toEqual({
+      kind: 'workspace',
+      name: 'Night shift',
+    });
+  });
+
+  it('ignores invocations without a desktop launch target', () => {
+    expect(parseCommandLineLaunch(['muxus'])).toBeUndefined();
+    expect(parseCommandLineLaunch(['muxus', '--no-sandbox'])).toBeUndefined();
+  });
+
+  it('rejects missing, empty, oversized, and competing targets', () => {
+    expect(parseCommandLineLaunch(['muxus', '--host'])).toBeUndefined();
+    expect(parseCommandLineLaunch(['muxus', '--host='])).toBeUndefined();
+    expect(parseCommandLineLaunch(['muxus', '--host', '--workspace', 'Lab'])).toBeUndefined();
+    expect(
+      parseCommandLineLaunch(['muxus', '--host', 'edge', '--folder', 'Lab']),
+    ).toBeUndefined();
+    expect(parseCommandLineLaunch(['muxus', `--host=${'x'.repeat(501)}`])).toBeUndefined();
+  });
+});

--- a/tests/unit/electron/command-line.test.ts
+++ b/tests/unit/electron/command-line.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseCommandLineLaunch } from '../../../electron/src/command-line.js';
+import {
+  canHandleCommandLineLaunch,
+  parseCommandLineLaunch,
+  parseCommandLineLaunchData,
+} from '../../../electron/src/command-line.js';
 
 describe('desktop command-line launch parsing', () => {
   it('accepts split and equals forms among unrelated Electron arguments', () => {
@@ -29,5 +33,41 @@ describe('desktop command-line launch parsing', () => {
       parseCommandLineLaunch(['muxus', '--host', 'edge', '--folder', 'Lab']),
     ).toBeUndefined();
     expect(parseCommandLineLaunch(['muxus', `--host=${'x'.repeat(501)}`])).toBeUndefined();
+  });
+
+  it('validates structured second-instance launch data', () => {
+    expect(parseCommandLineLaunchData({ kind: 'workspace', name: ' Night shift ' })).toEqual({
+      kind: 'workspace',
+      name: 'Night shift',
+    });
+    expect(parseCommandLineLaunchData({ kind: 'host', name: 'edge-1' })).toEqual({
+      kind: 'host',
+      name: 'edge-1',
+    });
+    expect(parseCommandLineLaunchData({ kind: 'unknown', name: 'edge-1' })).toBeUndefined();
+    expect(parseCommandLineLaunchData({ kind: 'folder', name: '' })).toBeUndefined();
+  });
+});
+
+describe('desktop command-line window routing', () => {
+  it('excludes SFTP-only windows from launch request delivery', () => {
+    expect(canHandleCommandLineLaunch(undefined)).toBe(true);
+    expect(
+      canHandleCommandLineLaunch({
+        kind: 'workspace',
+        workspaceId: 'operations',
+        title: 'Operations',
+      }),
+    ).toBe(true);
+    expect(
+      canHandleCommandLineLaunch({
+        kind: 'session',
+        profile: { kind: 'local' },
+        title: 'Local',
+      }),
+    ).toBe(true);
+    expect(
+      canHandleCommandLineLaunch({ kind: 'sftp', connId: 'ssh-1', title: 'Files' }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- add `--host`, `--folder`, and `--workspace` desktop launch flags
- forward later invocations to the running Muxus window, including requests received during startup
- resolve exact catalog names and IDs without guessing ambiguous targets
- keep cold host and folder launches separate from the configured startup workspace
- document desktop command-line usage

## Testing

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm check:bundle`
- `pnpm build-docs`

Closes #145