### PR TITLE
docs: add 0.7 release notes

### DIFF
--- a/docs/release-notes/0.7.md
+++ b/docs/release-notes/0.7.md
@@ -1,0 +1,48 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.7
+
+:material-calendar: 2 September 2026 · [Full changelog](https://github.com/FloSch62/muxus/compare/v0.6.3...v0.7.0)
+
+Release 0.7 keeps idle SSH connections alive by default and adds deliberate recovery tools
+for sessions that need a fresh transport. Desktop launch targets open hosts, folders and
+workspaces from scripts or shortcuts, and an optional GPU renderer makes heavy terminal
+output smoother on supported systems.
+
+## Keep connections alive and recover them cleanly
+
+Muxus now sends an SSH keepalive after 30 idle seconds unless the host's OpenSSH configuration
+sets its own `ServerAliveInterval`. The fallback interval can be changed or disabled in
+Settings, and applies to jump hosts as well as the final destination.
+
+**Force reconnect (new connection)** replaces an individual remote tab's connection without
+reusing its existing SSH transport. The workspace dialog and quick launcher can force-reconnect
+every remote tab at once. Existing tunnels continue on the connection they already use, while
+new sessions and tunnels move to the replacement.
+
+## Launch straight into your work
+
+The desktop executable accepts `--host`, `--folder` and `--workspace` targets, so shortcuts,
+scripts and tools such as Stream Deck can open the exact sessions they need. Launch requests
+are forwarded to an already-running Muxus instance, and a requested workspace opens in its
+existing window or a new one without replacing live work elsewhere.
+
+Names are matched case-insensitively and can use saved IDs, host aliases and unambiguous folder
+or display names where applicable.
+
+## Optional GPU terminal rendering
+
+Settings → Terminal includes a GPU renderer switch for smoother painting under heavy output.
+It can be turned on or off without reopening sessions, stays off by default and falls back to
+the standard renderer when WebGL is unavailable or loses its graphics context.
+
+## Host setup refinements
+
+Folder menus can create a new host directly in that folder. New host-key prompts focus the
+safe trust action for keyboard use, while changed-key warnings continue to require an explicit
+choice. Moving an OpenSSH-backed host to the root configuration also preserves the intended
+destination correctly.
+
+[View release 0.7 on GitHub](https://github.com/FloSch62/muxus/releases/tag/v0.7.0)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,8 +5,8 @@ hide:
   - toc
 ---
 
-<meta http-equiv="refresh" content="0; url=0.6/">
+<meta http-equiv="refresh" content="0; url=0.7/">
 
 # Latest release
 
-[Continue to release 0.6](0.6.md)
+[Continue to release 0.7](0.7.md)

--- a/zensical.toml
+++ b/zensical.toml
@@ -57,6 +57,7 @@ nav = [
     { "Security model" = "reference/security.md" },
   ] },
   { "Release notes" = [
+    { "0.7" = "release-notes/0.7.md" },
     { "0.6" = "release-notes/0.6.md" },
     { "0.5" = "release-notes/0.5.md" },
     { "0.4" = "release-notes/0.4.md" },


### PR DESCRIPTION
## Summary

- add release 0.7 notes covering connection recovery, launch targets, GPU rendering, and host setup refinements
- point the latest-release page to 0.7
- add release 0.7 to the documentation navigation

## Validation

- git diff --check