### PR TITLE
Add alphabetical host sorting

### DIFF
--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -102,8 +102,8 @@ const fixedRowSx = [treeRowSx(0, undefined), { gap: 0.75 }] as const;
 
 /** Saved Telnet/serial profiles and live OpenSSH hosts in one host manager. */
 export function SessionSidebar() {
-  const { data: config } = useSshConfig();
-  const { data: savedData } = useSavedHostProfiles();
+  const { data: config, isSuccess: sshConfigReady } = useSshConfig();
+  const { data: savedData, isSuccess: savedProfilesReady } = useSavedHostProfiles();
   const setHostEditor = useUiStore((s) => s.setHostEditor);
   const setFolderDialog = useUiStore((s) => s.setFolderDialog);
   const sidebarWidth = usePrefsStore((state) => state.sidebarWidth);
@@ -178,13 +178,16 @@ export function SessionSidebar() {
     updateProfileMetadata.isPending ||
     applyFolderMoves.isPending;
   const filtering = !!needle;
-  const reorderEnabled = !filtering && !mutating;
+  // Both catalogs must be complete before an order can be persisted: writing
+  // a partial list would leave the omitted source carrying conflicting ranks.
+  const hostCatalogsReady = sshConfigReady && savedProfilesReady;
+  const reorderEnabled = hostCatalogsReady && !filtering && !mutating;
   useEffect(() => {
     setSearchCollapsed(EMPTY_KEYS);
   }, [needle]);
   // Folder edits rewrite paths across hosts the filter may be hiding, so they
   // are only offered against the full list.
-  const folderEditsEnabled = !filtering && !mutating;
+  const folderEditsEnabled = hostCatalogsReady && !filtering && !mutating;
 
   const commitOrder = useCallback(
     (keys: readonly string[]) =>

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -48,6 +48,7 @@ import {
   type VisibleNode,
 } from '../host-tree.js';
 import {
+  alphabetizeManagedHosts,
   bestManagedHostMatch,
   groupManagedHosts,
   managedHostDisplayName,
@@ -194,6 +195,14 @@ export function SessionSidebar() {
         }),
       ),
     [reorder, hostByKey],
+  );
+
+  const alphabetizeHosts = useCallback(
+    (items: readonly ManagedHost[]) => {
+      if (!reorderEnabled || items.length < 2) return;
+      commitOrder(alphabetizeManagedHosts(items).map(managedHostKey));
+    },
+    [commitOrder, reorderEnabled],
   );
 
   /** Reorder a host among its siblings — folders are always alphabetical. */
@@ -445,6 +454,9 @@ export function SessionSidebar() {
       ? { index: siblings.keys.indexOf(folderMenu!.node.key), total: siblings.keys.length }
       : { index: -1, total: 0 };
   }, [folderMenu, tree]);
+  const folderMenuHostCount = folderMenu
+    ? siblingHostKeys(folderMenu.node).length
+    : 0;
 
   const empty = hosts.length === 0 && profiles.length === 0;
 
@@ -686,18 +698,27 @@ export function SessionSidebar() {
               onCollapseAll: collapseSubtree,
               onDelete: deleteFolder,
               onMove: (node, delta) => moveFolderByKey(node.key, delta),
+              onSortHosts: (node) =>
+                alphabetizeHosts(
+                  node.children.flatMap((child) =>
+                    child.kind === 'host' ? [child.host] : [],
+                  ),
+                ),
               canMoveUp: reorderEnabled && folderMenuPosition.index > 0,
               canMoveDown:
                 reorderEnabled &&
                 folderMenuPosition.index >= 0 &&
                 folderMenuPosition.index < folderMenuPosition.total - 1,
+              canSortHosts: reorderEnabled && folderMenuHostCount > 1,
             }}
             panel={{
               position: panelMenu,
               onClose: () => setPanelMenu(null),
               onNewHost: () => setHostEditor({ mode: 'new' }),
               onNewFolder: () => setFolderDialog({ mode: 'new' }),
+              onSortHosts: () => alphabetizeHosts(allHosts),
               folderEditsEnabled,
+              canSortHosts: reorderEnabled && allHosts.length > 1,
             }}
             launch={{ target: launchTarget, onClose: () => setLaunchTarget(null) }}
           />

--- a/client/src/components/sidebar/FolderContextMenu.tsx
+++ b/client/src/components/sidebar/FolderContextMenu.tsx
@@ -9,6 +9,7 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
+import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import type { FolderNode } from '../../host-tree.js';
 import { loadFolderDialog, loadHostEditorDialog } from '../../lazy-features.js';
@@ -29,8 +30,10 @@ export function FolderContextMenu({
   onCollapseAll,
   onDelete,
   onMove,
+  onSortHosts,
   canMoveUp,
   canMoveDown,
+  canSortHosts,
 }: {
   menu: FolderMenuState | null;
   onClose: () => void;
@@ -41,8 +44,10 @@ export function FolderContextMenu({
   onCollapseAll: (node: FolderNode) => void;
   onDelete: (node: FolderNode) => void;
   onMove: (node: FolderNode, delta: -1 | 1) => void;
+  onSortHosts: (node: FolderNode) => void;
   canMoveUp: boolean;
   canMoveDown: boolean;
+  canSortHosts: boolean;
 }) {
   const run = (action: (node: FolderNode) => void) => () => {
     if (menu) action(menu.node);
@@ -76,6 +81,12 @@ export function FolderContextMenu({
           <KeyboardArrowDownIcon fontSize="small" />
         </ListItemIcon>
         Move down
+      </MenuItem>
+      <MenuItem disabled={!canSortHosts} onClick={run(onSortHosts)}>
+        <ListItemIcon>
+          <SortByAlphaIcon fontSize="small" />
+        </ListItemIcon>
+        Sort hosts alphabetically
       </MenuItem>
       <Divider />
       <MenuItem

--- a/client/src/components/sidebar/PanelContextMenu.tsx
+++ b/client/src/components/sidebar/PanelContextMenu.tsx
@@ -1,8 +1,10 @@
+import Divider from '@mui/material/Divider';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import CreateNewFolderOutlinedIcon from '@mui/icons-material/CreateNewFolderOutlined';
 import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
+import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
 import { loadFolderDialog, loadHostEditorDialog } from '../../lazy-features.js';
 
 /**
@@ -15,14 +17,19 @@ export function PanelContextMenu({
   onClose,
   onNewHost,
   onNewFolder,
+  onSortHosts,
   folderEditsEnabled,
+  canSortHosts,
 }: {
   position: { top: number; left: number } | null;
   onClose: () => void;
   onNewHost: () => void;
   onNewFolder: () => void;
+  onSortHosts: () => void;
   /** Folder paths are rewritten across the full list, never a filtered one. */
   folderEditsEnabled: boolean;
+  /** Sorting is only safe against the complete, settled host list. */
+  canSortHosts: boolean;
 }) {
   const run = (action: () => void) => () => {
     action();
@@ -56,6 +63,13 @@ export function PanelContextMenu({
           <CreateNewFolderOutlinedIcon fontSize="small" />
         </ListItemIcon>
         New folder…
+      </MenuItem>
+      <Divider />
+      <MenuItem disabled={!canSortHosts} onClick={run(onSortHosts)}>
+        <ListItemIcon>
+          <SortByAlphaIcon fontSize="small" />
+        </ListItemIcon>
+        Sort all hosts alphabetically
       </MenuItem>
     </Menu>
   );

--- a/client/src/managed-hosts.ts
+++ b/client/src/managed-hosts.ts
@@ -180,6 +180,13 @@ export function managedHostDisplayName(host: ManagedHost): string {
     : savedHostDisplayName(host.entry);
 }
 
+/** Alphabetize a mixed host list by the name shown in the sidebar. */
+export function alphabetizeManagedHosts(hosts: readonly ManagedHost[]): ManagedHost[] {
+  return hosts.toSorted((left, right) =>
+    managedHostDisplayName(left).localeCompare(managedHostDisplayName(right)),
+  );
+}
+
 export function managedHostAddress(host: ManagedHost): string {
   return host.kind === 'ssh' ? hostAddress(host.entry) : savedHostAddress(host.entry);
 }

--- a/tests/unit/client/managed-hosts.test.ts
+++ b/tests/unit/client/managed-hosts.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { SavedHostProfile, SshHostEntry } from '@muxus/shared';
 import {
+  alphabetizeManagedHosts,
   editableManagedHostForProfile,
   groupManagedHosts,
   managedHostCopyCommand,
+  managedHostDisplayName,
   managedHostKey,
   managedHostRef,
 } from '../../../client/src/managed-hosts.js';
@@ -288,5 +290,26 @@ describe('managed host identity and clipboard actions', () => {
     ).toBe(false);
     expect(managedHostSupportsSftp(telnet)).toBe(false);
     expect(managedHostSupportsSftp(serial)).toBe(false);
+  });
+});
+
+describe('managed host alphabetization', () => {
+  it('sorts mixed host kinds by their sidebar display name without changing the input', () => {
+    const router = { kind: 'ssh' as const, entry: sshHost('router') };
+    const console = { kind: 'profile' as const, entry: telnetHost('Console') };
+    const database = { kind: 'ssh' as const, entry: sshHost('db-primary') };
+    database.entry.metadata = {
+      profileId: 'ssh-db-primary',
+      displayName: 'Primary database',
+      connectCount: 0,
+    };
+    const hosts = [router, database, console];
+
+    expect(alphabetizeManagedHosts(hosts).map(managedHostDisplayName)).toEqual([
+      'Console',
+      'Primary database',
+      'router',
+    ]);
+    expect(hosts).toEqual([router, database, console]);
   });
 });


### PR DESCRIPTION
## Summary

- add a panel context-menu action to sort all hosts alphabetically
- add a folder context-menu action to sort its direct hosts alphabetically
- sort mixed host types by their displayed sidebar names and persist the result through the existing ordering API
- disable sorting for partial or unsettled host lists
- add regression coverage for mixed-host alphabetization

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm --filter @muxus/client check:bundle`

Closes #155