### PR TITLE
Add an About page to Settings and the docs

### DIFF
--- a/client/src/components/AboutSection.tsx
+++ b/client/src/components/AboutSection.tsx
@@ -1,0 +1,236 @@
+import { Fragment, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
+import CoffeeOutlinedIcon from '@mui/icons-material/CoffeeOutlined';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
+import type { UpdateCheckResult } from '@muxus/shared';
+import { checkForUpdate } from '../api/app.js';
+import { useAppInfo } from '../api/queries.js';
+import { usePrefsStore } from '../state/prefs.js';
+
+const LINKS = {
+  docs: 'https://flosch62.github.io/muxus/',
+  source: 'https://github.com/FloSch62/muxus',
+  releases: 'https://github.com/FloSch62/muxus/releases',
+  author: 'https://flosch.me/',
+  authorGithub: 'https://github.com/FloSch62',
+  authorLinkedIn: 'https://www.linkedin.com/in/florian-schwarz-812a34145/',
+  coffee: 'https://www.buymeacoffee.com/FloSch62',
+} as const;
+
+/**
+ * The About page of Settings: what this build is, who makes it, how to support
+ * the work, and whether a newer build exists. Every link opens in the system
+ * browser (the desktop shell denies new windows and hands the URL to the OS).
+ */
+export function AboutSection() {
+  const { data: info } = useAppInfo();
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <SectionTitle>About</SectionTitle>
+        <Stack spacing={1.25}>
+          <Typography variant="body2">
+            {[`Muxus ${info?.version ?? ''}`.trim(), platformLabel(info?.platform), 'MIT license']
+              .filter(Boolean)
+              .join(' · ')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            A free, open-source SSH, Telnet and serial client. Split panes, saved workspaces, SFTP,
+            a remote editor, saved tunnels and images in the terminal.
+          </Typography>
+          <LinkRow
+            links={[
+              ['Documentation', LINKS.docs],
+              ['Source', LINKS.source],
+              ['Releases', LINKS.releases],
+            ]}
+          />
+        </Stack>
+      </Box>
+
+      <Box>
+        <SectionTitle>Made by</SectionTitle>
+        <Stack spacing={1.25}>
+          <Typography variant="body2" color="text.secondary">
+            Muxus is built by me (FloSch), in the open and in my spare time. Bug reports, ideas
+            and pull requests are always welcome.
+          </Typography>
+          <LinkRow
+            links={[
+              ['flosch.me', LINKS.author],
+              ['GitHub', LINKS.authorGithub],
+              ['LinkedIn', LINKS.authorLinkedIn],
+            ]}
+          />
+        </Stack>
+      </Box>
+
+      <Box>
+        <SectionTitle>Support</SectionTitle>
+        <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
+          <Typography variant="body2" color="text.secondary">
+            Muxus is free and stays free. If it saves you time, a coffee keeps the releases coming.
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+            <Button
+              variant="outlined"
+              startIcon={<CoffeeOutlinedIcon />}
+              href={LINKS.coffee}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Buy me a coffee
+            </Button>
+            <Button startIcon={<StarBorderOutlinedIcon />} href={LINKS.source} target="_blank" rel="noreferrer">
+              Star on GitHub
+            </Button>
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Box>
+        <SectionTitle>Updates</SectionTitle>
+        <UpdateControls currentVersion={info?.version} />
+      </Box>
+    </Stack>
+  );
+}
+
+function UpdateControls({ currentVersion }: { currentVersion?: string }) {
+  const prefs = usePrefsStore();
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<UpdateCheckResult | null>(null);
+
+  const checkForUpdates = () => {
+    setChecking(true);
+    setResult(null);
+    void checkForUpdate({ force: true })
+      .then(setResult)
+      .catch(() => setResult({ available: false, currentVersion: currentVersion ?? '', reason: 'network' }))
+      .finally(() => setChecking(false));
+  };
+
+  const updatesAvailable = result?.available === true;
+
+  return (
+    <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            checked={prefs.notifyOnNewVersion}
+            onChange={(e) => prefs.set({ notifyOnNewVersion: e.target.checked })}
+          />
+        }
+        label={
+          <Box>
+            <Typography variant="body2">Notify me when a new version is available</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Off: no notification at startup — checking here still works.
+            </Typography>
+          </Box>
+        }
+      />
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+        <Button
+          variant="contained"
+          startIcon={checking ? <CircularProgress color="inherit" size={16} /> : <CachedOutlinedIcon />}
+          disabled={checking}
+          onClick={checkForUpdates}
+        >
+          Check for updates
+        </Button>
+        {updatesAvailable ? (
+          <Button startIcon={<DownloadOutlinedIcon />} href={result.releaseUrl} target="_blank" rel="noreferrer">
+            Download
+          </Button>
+        ) : null}
+      </Stack>
+      {result?.available === false && result.latestVersion ? (
+        <Alert severity="success" variant="outlined">
+          Muxus is up to date. Latest release: {result.latestVersion}.
+        </Alert>
+      ) : null}
+      {result?.available === false && !result.latestVersion ? (
+        <Alert severity="warning" variant="outlined">
+          {updateReasonLabel(result.reason)}
+        </Alert>
+      ) : null}
+      {updatesAvailable ? (
+        <Alert severity="info" variant="outlined">
+          Muxus {result.latestVersion} is available. You are running {result.currentVersion}.
+        </Alert>
+      ) : null}
+    </Stack>
+  );
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+      {children}
+    </Typography>
+  );
+}
+
+/** A row of plain links, the way the rest of the dialog points elsewhere. */
+function LinkRow({ links }: { links: ReadonlyArray<readonly [label: string, href: string]> }) {
+  return (
+    <Typography variant="body2" sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1 }}>
+      {links.map(([label, href], index) => (
+        <Fragment key={href}>
+          {index > 0 ? (
+            <Box component="span" aria-hidden sx={{ color: 'text.disabled' }}>
+              ·
+            </Box>
+          ) : null}
+          <Link href={href} target="_blank" rel="noreferrer">
+            {label}
+          </Link>
+        </Fragment>
+      ))}
+    </Typography>
+  );
+}
+
+function platformLabel(platform?: string): string {
+  switch (platform) {
+    case 'darwin':
+      return 'macOS';
+    case 'win32':
+      return 'Windows';
+    case 'linux':
+      return 'Linux';
+    default:
+      return platform ?? '';
+  }
+}
+
+function updateReasonLabel(reason?: string): string {
+  switch (reason) {
+    case 'timeout':
+      return 'The update check timed out.';
+    case 'network':
+      return 'The update check could not reach GitHub.';
+    case 'no-release':
+      return 'No published release was found.';
+    case 'missing-version':
+    case 'missing-release-url':
+      return 'The latest release metadata is incomplete.';
+    default:
+      return reason?.startsWith('manifest-')
+        ? `The update manifest returned ${reason.replace('manifest-', '')}.`
+        : 'The update check could not be completed.';
+  }
+}

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -3,7 +3,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import Divider from '@mui/material/Divider';
@@ -14,7 +13,6 @@ import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import Link from '@mui/material/Link';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Slider from '@mui/material/Slider';
@@ -29,7 +27,6 @@ import { useTheme } from '@mui/material/styles';
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
 import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import HighlightOutlinedIcon from '@mui/icons-material/HighlightOutlined';
@@ -40,18 +37,12 @@ import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
 import PasswordOutlinedIcon from '@mui/icons-material/PasswordOutlined';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
-import type { UpdateCheckResult } from '@muxus/shared';
-import { checkForUpdate } from '../api/app.js';
 import { fetchAppLogs, formatLogEntry } from '../api/logs.js';
 import {
   useSaveSessionHistorySettings,
   useSaveSessionLoggingPolicy,
 } from '../api/session-history.js';
-import {
-  useAppInfo,
-  useSessionHistoryStorage,
-  useSessionLoggingPolicy,
-} from '../api/queries.js';
+import { useSessionHistoryStorage, useSessionLoggingPolicy } from '../api/queries.js';
 import {
   FALLBACK_SESSION_LOGGING_POLICY,
   hostSessionLoggingDraft,
@@ -91,6 +82,7 @@ import {
   terminalFontFamilies,
   terminalFontIsAvailable,
 } from '../terminal/font-catalog.js';
+import { AboutSection } from './AboutSection.js';
 import { chordSx } from './chord-style.js';
 import { HighlightProfilesSection } from './HighlightProfilesSection.js';
 import { LocalShellProfilesSection } from './LocalShellProfilesSection.js';
@@ -1127,25 +1119,6 @@ function HistoryStorageSettings({ onDirtyChange }: { onDirtyChange: (dirty: bool
   );
 }
 
-function updateReasonLabel(reason?: string): string {
-  switch (reason) {
-    case 'timeout':
-      return 'The update check timed out.';
-    case 'network':
-      return 'The update check could not reach GitHub.';
-    case 'no-release':
-      return 'No published release was found.';
-    case 'missing-version':
-    case 'missing-release-url':
-      return 'The latest release metadata is incomplete.';
-    default:
-      return reason?.startsWith('manifest-')
-        ? `The update manifest returned ${reason.replace('manifest-', '')}.`
-        : 'The update check could not be completed.';
-  }
-}
-
-/** Diagnostic logging: the verbose-capture toggle plus log viewer and export. */
 function DebugSection() {
   const debugMode = usePrefsStore((s) => s.debugMode);
   const set = usePrefsStore((s) => s.set);
@@ -1216,96 +1189,6 @@ function DebugSection() {
           them. If the app fails to launch entirely, the desktop shell also writes
           logs/main.log in its data directory.
         </Typography>
-      </Box>
-    </Stack>
-  );
-}
-
-function AboutSection() {
-  const { data: info } = useAppInfo();
-  const prefs = usePrefsStore();
-  const [checking, setChecking] = useState(false);
-  const [result, setResult] = useState<UpdateCheckResult | null>(null);
-
-  const checkForUpdates = () => {
-    setChecking(true);
-    setResult(null);
-    void checkForUpdate({ force: true })
-      .then(setResult)
-      .catch(() => setResult({ available: false, currentVersion: info?.version ?? '', reason: 'network' }))
-      .finally(() => setChecking(false));
-  };
-
-  const updatesAvailable = result?.available === true;
-
-  return (
-    <Stack spacing={3}>
-      <Box>
-        <SectionTitle>About</SectionTitle>
-        <Stack spacing={1.25}>
-          <Typography variant="body2">
-            Muxus {info?.version ?? ''} · {String(info?.platform ?? '')}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Free, open-source SSH, Telnet, and serial client — kitty graphics, split-pane
-            workspaces, SFTP and terminal-independent port forwarding.
-          </Typography>
-          <Link href="https://github.com/FloSch62/muxus" target="_blank" rel="noreferrer">
-            github.com/FloSch62/muxus
-          </Link>
-        </Stack>
-      </Box>
-      <Box>
-        <SectionTitle>Updates</SectionTitle>
-        <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
-          <FormControlLabel
-            control={
-              <Switch
-                size="small"
-                checked={prefs.notifyOnNewVersion}
-                onChange={(e) => prefs.set({ notifyOnNewVersion: e.target.checked })}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body2">Notify me when a new version is available</Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Off: no notification at startup — checking here still works.
-                </Typography>
-              </Box>
-            }
-          />
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Button
-              variant="contained"
-              startIcon={checking ? <CircularProgress color="inherit" size={16} /> : <CachedOutlinedIcon />}
-              disabled={checking}
-              onClick={checkForUpdates}
-            >
-              Check for updates
-            </Button>
-            {updatesAvailable ? (
-              <Button startIcon={<DownloadOutlinedIcon />} href={result.releaseUrl} target="_blank" rel="noreferrer">
-                Download
-              </Button>
-            ) : null}
-          </Stack>
-          {result?.available === false && result.latestVersion ? (
-            <Alert severity="success" variant="outlined">
-              Muxus is up to date. Latest release: {result.latestVersion}.
-            </Alert>
-          ) : null}
-          {result?.available === false && !result.latestVersion ? (
-            <Alert severity="warning" variant="outlined">
-              {updateReasonLabel(result.reason)}
-            </Alert>
-          ) : null}
-          {updatesAvailable ? (
-            <Alert severity="info" variant="outlined">
-              Muxus {result.latestVersion} is available. You are running {result.currentVersion}.
-            </Alert>
-          ) : null}
-        </Stack>
       </Box>
     </Stack>
   );

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,50 @@
+---
+icon: lucide/user-round
+hide:
+  - navigation
+---
+
+# About
+
+Muxus is built by me (FloSch), in the open and in my spare time. I build open-source tooling
+for network automation and the desktop apps that go with it, and Muxus is the terminal client I
+wanted for that work: the hosts from `~/.ssh/config`, split panes, SFTP, tunnels and a remote
+editor on one connection, in a window I can save and reopen.
+
+- :material-web: [flosch.me](https://flosch.me/), who I am and what I work on
+- :simple-github: [FloSch62 on GitHub](https://github.com/FloSch62), everything I build, Muxus included
+- :fontawesome-brands-linkedin: [LinkedIn](https://www.linkedin.com/in/florian-schwarz-812a34145/), say hello
+
+## Support Muxus
+
+Muxus is free and stays free. If it saves you time, a coffee keeps the releases coming, and a
+star helps others find it.
+
+[:simple-buymeacoffee: Buy me a coffee](https://www.buymeacoffee.com/FloSch62){ .md-button .md-button--primary }
+[:material-star-outline: Star on GitHub](https://github.com/FloSch62/muxus){ .md-button }
+
+## Other things I build
+
+<div class="grid cards" markdown>
+
+-   :material-kubernetes: **[Kubus](https://github.com/FloSch62/Kubus)**
+
+    ---
+
+    A free, open-source Kubernetes GUI. Every cluster and resource, logs, shells, port forwards,
+    metrics and Helm in one local app.
+
+-   :material-lan: **[containerlab tooling](https://github.com/srl-labs/vscode-containerlab)**
+
+    ---
+
+    The VS Code extension and the desktop app for containerlab, which spins up container-based
+    networking labs from topology files.
+
+</div>
+
+## Get in touch
+
+Bug reports, ideas and pull requests are always welcome on the
+[issue tracker](https://github.com/FloSch62/muxus/issues). For anything else, the links above
+reach me.

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -38,10 +38,21 @@
   font-size: 0.78rem;
 }
 
-/* Buttons follow the app: 8px corners, weight 600 */
+/* Buttons follow the app: 8px corners, weight 600. An icon shortcode inside a button
+   sits on the text baseline with a small gap. */
 .md-typeset .md-button {
   border-radius: 8px;
   font-weight: 600;
+}
+
+.md-typeset .md-button .twemoji {
+  margin-right: 0.35em;
+  vertical-align: -0.2em;
+}
+
+.md-typeset .md-button .twemoji svg {
+  width: 1.1em;
+  height: 1.1em;
 }
 
 /* ---------------------------------------------------------------------------

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -33,3 +33,12 @@ reports and feature ideas are welcome.
 
 - :simple-github: **Source & issues**: [github.com/FloSch62/muxus](https://github.com/FloSch62/muxus)
 - :material-download: **Releases**: [github.com/FloSch62/muxus/releases](https://github.com/FloSch62/muxus/releases)
+- :material-account-outline: **The author**: [About](../about.md), or [flosch.me](https://flosch.me/)
+
+## Support the project
+
+Muxus is built by me (FloSch) in my spare time, and it is free and stays free. If it saves you
+time, a coffee keeps the releases coming, and a star helps others find it.
+
+[:simple-buymeacoffee: Buy me a coffee](https://www.buymeacoffee.com/FloSch62){ .md-button .md-button--primary }
+[:material-star-outline: Star on GitHub](https://github.com/FloSch62/muxus){ .md-button }

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,3 +135,11 @@ use the same local database.
     [:octicons-arrow-right-24: Quickstart](quickstart.md)
 
 </div>
+
+## Made by
+
+Muxus is built by me (FloSch), in the open and in my spare time. It is free and stays free.
+If it saves you time, a coffee keeps the releases coming. [More about me](about.md).
+
+[:simple-buymeacoffee: Buy me a coffee](https://www.buymeacoffee.com/FloSch62){ .md-button .md-button--primary }
+[:material-star-outline: Star on GitHub](https://github.com/FloSch62/muxus){ .md-button }

--- a/zensical.toml
+++ b/zensical.toml
@@ -72,6 +72,7 @@ nav = [
     { "Building from source" = "community/development.md" },
     { "FAQ" = "community/faq.md" },
   ] },
+  { "About" = "about.md" },
 ]
 
 # ----------------------------------------------------------------------------
@@ -129,6 +130,16 @@ code = "JetBrains Mono"
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/FloSch62/muxus"
+
+[[project.extra.social]]
+icon = "simple/buymeacoffee"
+link = "https://www.buymeacoffee.com/FloSch62"
+name = "Buy me a coffee"
+
+[[project.extra.social]]
+icon = "material/web"
+link = "https://flosch.me/"
+name = "flosch.me"
 
 # ----------------------------------------------------------------------------
 # Markdown extensions use the same stack as Material-based sites.


### PR DESCRIPTION
## Summary

Stacked on #158. Muxus gets a proper About page in two places.

**Settings → About** moves into its own component, `client/src/components/AboutSection.tsx`, and keeps the dialog's plain style: section titles, body text, links and buttons, no cards.

- **About.** Build line with version, platform and licence, the one-line description, and Documentation · Source · Releases links.
- **Made by.** "Muxus is built by me (FloSch), in the open and in my spare time…" with flosch.me · GitHub · LinkedIn links.
- **Support.** A short line, an outlined Buy Me a Coffee button and a text "Star on GitHub" button.
- **Updates.** Unchanged.

Every link opens with `target="_blank"`, which the desktop shell already routes to the system browser.

**Docs** get an About tab after Community, with the same content in prose: who makes Muxus, the personal links as an icon list, the support buttons, the other projects, and how to get in touch. The landing page's "Made by" section and the Community page's "Support the project" section use the same icon buttons and link through to it. The footer carries the Buy Me a Coffee and website icons next to GitHub, and a small style rule aligns icon glyphs inside docs buttons.

## Verification

- Lint, typecheck and the client build pass.
- `zensical build --clean --strict` passes.
- Captured Settings → About in the sandboxed app in both themes, plus the docs About page, the landing "Made by" section and the Community page in both themes.
